### PR TITLE
refactor(serverless): better performance for functions results

### DIFF
--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "watch": "esbuild src/index.ts --bundle --external:./node_modules/* --platform=node --outdir=dist --format=esm --watch",
-    "build": "esbuild src/index.ts --bundle --external:./node_modules/* --platform=node --outdir=dist --format=esm",
+    "watch": "esbuild src/index.ts src/clickhouse.ts --bundle --external:./node_modules/* --platform=node --outdir=dist --format=esm --watch",
+    "build": "esbuild src/index.ts src/clickhouse.ts --bundle --external:./node_modules/* --platform=node --outdir=dist --format=esm",
     "dev": "nodemon dist/index.js",
     "start": "node dist/index.js"
   },

--- a/packages/serverless/src/clickhouse.ts
+++ b/packages/serverless/src/clickhouse.ts
@@ -1,0 +1,38 @@
+import { workerData } from 'node:worker_threads';
+import { ClickHouse } from 'clickhouse';
+
+const clickhouse = new ClickHouse({});
+
+workerData.forEach((functionResult, [functionId, deploymentId]) => {
+  clickhouse
+    .query(
+      `INSERT INTO functions_result (date, functionId, deploymentId, cpuTime, memory, sendBytes, receivedBytes, requests) VALUES (now(), '${functionId}', '${deploymentId}', ${
+        functionResult.reduce((acc, current) => {
+          return acc + current.cpuTime;
+        }, BigInt(0)) / BigInt(functionResult.length)
+      }, ${
+        functionResult.reduce((acc, current) => {
+          return acc + current.memory;
+        }, 0) / functionResult.length
+      }, ${
+        functionResult.reduce((acc, current) => {
+          return acc + current.sentBytes;
+        }, 0) / functionResult.length
+      }, ${
+        functionResult.reduce((acc, current) => {
+          return acc + current.receivedBytes;
+        }, 0) / functionResult.length
+      }, ${functionResult.length})`,
+    )
+    .toPromise();
+
+  functionResult.forEach(functionResult => {
+    functionResult.logs.forEach(log => {
+      clickhouse
+        .query(
+          `INSERT INTO logs (date, functionId, deploymentId, level, message) VALUES (now(), '${functionId}', '${deploymentId}', '${log.level}', '${log.content}')`,
+        )
+        .toPromise();
+    });
+  });
+});

--- a/packages/serverless/src/clickhouse.ts
+++ b/packages/serverless/src/clickhouse.ts
@@ -1,38 +1,42 @@
 import { workerData } from 'node:worker_threads';
 import { ClickHouse } from 'clickhouse';
+import { DeploymentResult } from '@lagon/runtime';
 
 const clickhouse = new ClickHouse({});
+const deploymentsResult: Map<[string, string], DeploymentResult[]> = workerData;
 
-workerData.forEach((functionResult, [functionId, deploymentId]) => {
-  clickhouse
-    .query(
-      `INSERT INTO functions_result (date, functionId, deploymentId, cpuTime, memory, sendBytes, receivedBytes, requests) VALUES (now(), '${functionId}', '${deploymentId}', ${
-        functionResult.reduce((acc, current) => {
-          return acc + current.cpuTime;
-        }, BigInt(0)) / BigInt(functionResult.length)
-      }, ${
-        functionResult.reduce((acc, current) => {
-          return acc + current.memory;
-        }, 0) / functionResult.length
-      }, ${
-        functionResult.reduce((acc, current) => {
-          return acc + current.sentBytes;
-        }, 0) / functionResult.length
-      }, ${
-        functionResult.reduce((acc, current) => {
-          return acc + current.receivedBytes;
-        }, 0) / functionResult.length
-      }, ${functionResult.length})`,
-    )
-    .toPromise();
+let functionsResultQuery =
+  'INSERT INTO functions_result (date, functionId, deploymentId, cpuTime, memory, sendBytes, receivedBytes, requests) VALUES';
+let logsQuery = 'INSERT INTO logs (date, functionId, deploymentId, level, message) VALUES';
 
-  functionResult.forEach(functionResult => {
-    functionResult.logs.forEach(log => {
-      clickhouse
-        .query(
-          `INSERT INTO logs (date, functionId, deploymentId, level, message) VALUES (now(), '${functionId}', '${deploymentId}', '${log.level}', '${log.content}')`,
-        )
-        .toPromise();
+async function send() {
+  deploymentsResult.forEach((functionResult, [functionId, deploymentId]) => {
+    functionsResultQuery += ` (now(), '${functionId}', '${deploymentId}', ${
+      functionResult.reduce((acc, current) => {
+        return acc + current.cpuTime;
+      }, BigInt(0)) / BigInt(functionResult.length)
+    }, ${
+      functionResult.reduce((acc, current) => {
+        return acc + current.memory;
+      }, 0) / functionResult.length
+    }, ${
+      functionResult.reduce((acc, current) => {
+        return acc + current.sentBytes;
+      }, 0) / functionResult.length
+    }, ${
+      functionResult.reduce((acc, current) => {
+        return acc + current.receivedBytes;
+      }, 0) / functionResult.length
+    }, ${functionResult.length})`;
+
+    functionResult.forEach(functionResult => {
+      functionResult.logs.forEach(log => {
+        logsQuery += ` (now(), '${functionId}', '${deploymentId}', '${log.level}', '${log.content}')`;
+      });
     });
   });
-});
+
+  await Promise.all([clickhouse.query(functionsResultQuery).toPromise(), clickhouse.query(logsQuery).toPromise()]);
+}
+
+send();

--- a/packages/serverless/src/master.ts
+++ b/packages/serverless/src/master.ts
@@ -1,6 +1,6 @@
 import { GetObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
 import { Deployment, fetch } from '@lagon/runtime';
-import cluster from 'cluster';
+import cluster from 'node:cluster';
 import { cpus } from 'node:os';
 import { Readable } from 'node:stream';
 import { createClient } from 'redis';

--- a/packages/serverless/src/worker.ts
+++ b/packages/serverless/src/worker.ts
@@ -76,6 +76,9 @@ export default function worker() {
   const port = Number(process.env.LAGON_PORT || 4000);
   const host = process.env.LAGON_HOST || '127.0.0.1';
 
+  // Send a message to receive `deployments` message back
+  process.send?.('ok');
+
   process.on('message', message => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore


### PR DESCRIPTION
Move clickhouse queries to a separate worker thread, and batch queries instead of running one per function result.