### PR TITLE
fix(serverless): memory leaks & remove memory from stats

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@lagon/common": "workspace:1.0.0",
-    "@lagon/runtime": "0.0.2",
+    "@lagon/runtime": "0.0.3",
     "@trpc/client": "^9.25.3",
     "chalk": "^5.0.1",
     "commander": "^9.3.0",

--- a/packages/prisma/migrations/20220709142006_remove_memory_from_stats/migration.sql
+++ b/packages/prisma/migrations/20220709142006_remove_memory_from_stats/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `memory` on the `Stat` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `Stat` DROP COLUMN `memory`;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -169,7 +169,6 @@ model Stat {
   deploymentId String
 
   cpuTime Int
-  memory Int
   sendBytes Int
   receivedBytes Int
   requests Int

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagon/runtime",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "JavaScript Serverless Runtime for Lagon",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/runtime/src/deployments/index.ts
+++ b/packages/runtime/src/deployments/index.ts
@@ -6,7 +6,6 @@ export const deploymentsCache = new Map<string, DeploymentCache>();
 export type DeploymentResult = {
   logs: DeploymentLog[];
   cpuTime: bigint;
-  memory: number;
   receivedBytes: number;
   sentBytes: number;
 };

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -15,7 +15,7 @@
     "@aws-sdk/client-s3": "^3.100.0",
     "@lagon/common": "workspace:1.0.0",
     "@lagon/prisma": "workspace:1.0.0",
-    "@lagon/runtime": "workspace:0.0.2",
+    "@lagon/runtime": "workspace:0.0.3",
     "@sentry/node": "^7.1.1",
     "@sentry/tracing": "^7.1.1",
     "dotenv": "^16.0.1",

--- a/packages/serverless/src/__tests__/errors.test.ts
+++ b/packages/serverless/src/__tests__/errors.test.ts
@@ -48,7 +48,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }
@@ -78,7 +77,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }
@@ -107,7 +105,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }
@@ -137,7 +134,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }
@@ -167,7 +163,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }
@@ -198,7 +193,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }
@@ -237,7 +231,6 @@ export function handler(request) {
             "level": "error",
           },
         ],
-        "memory": 0,
         "receivedBytes": 34,
         "sentBytes": 0,
       }

--- a/packages/serverless/src/exporter.ts
+++ b/packages/serverless/src/exporter.ts
@@ -9,7 +9,6 @@ async function send() {
     functionId: string;
     deploymentId: string;
     cpuTime: number;
-    memory: number;
     sendBytes: number;
     receivedBytes: number;
     requests: number;
@@ -29,10 +28,6 @@ async function send() {
       cpuTime:
         functionResults.reduce((acc, current) => {
           return acc + Number(current.cpuTime);
-        }, 0) / functionResults.length,
-      memory:
-        functionResults.reduce((acc, current) => {
-          return acc + current.memory;
         }, 0) / functionResults.length,
       sendBytes:
         functionResults.reduce((acc, current) => {

--- a/packages/serverless/src/master.ts
+++ b/packages/serverless/src/master.ts
@@ -201,5 +201,5 @@ export default async function master() {
     for (const i in cluster.workers) {
       cluster.workers[i]?.send({ msg: 'clean' });
     }
-  }, 1000 * 60);
+  }, 1000 * 10);
 }

--- a/packages/serverless/src/master.ts
+++ b/packages/serverless/src/master.ts
@@ -201,5 +201,5 @@ export default async function master() {
     for (const i in cluster.workers) {
       cluster.workers[i]?.send({ msg: 'clean' });
     }
-  }, 1000 * 10);
+  }, 1000 * 60); // 1min
 }

--- a/packages/serverless/src/server.ts
+++ b/packages/serverless/src/server.ts
@@ -1,5 +1,5 @@
 import { getBytesFromReply, getBytesFromRequest, getDeploymentFromRequest } from 'src/deployments/config';
-import { addDeploymentResult, calculateIsolateResources } from 'src/deployments/result';
+import { addDeploymentResult, getCpuTime } from 'src/deployments/result';
 import Fastify from 'fastify';
 import { DeploymentResult, HandlerRequest, addLog, OnDeploymentLog, DeploymentLog, getIsolate } from '@lagon/runtime';
 import { getAssetContent, getDeploymentCode } from 'src/deployments';
@@ -98,7 +98,6 @@ export default function startServer(port: number, host: string) {
 
     const deploymentResult: DeploymentResult = {
       cpuTime: BigInt(0),
-      memory: 0,
       receivedBytes: getBytesFromRequest(request),
       sentBytes: 0,
       logs: [],
@@ -160,11 +159,9 @@ export default function startServer(port: number, host: string) {
       );
     }
 
-    if (!errored) {
-      calculateIsolateResources({ isolate: isolateCache!, deployment, deploymentResult });
-    }
-
+    deploymentResult.cpuTime = getCpuTime({ isolate: isolateCache!, deployment });
     deploymentResult.logs = logs.get(deployment.deploymentId) || [];
+
     logs.delete(deployment.deploymentId);
 
     addDeploymentResult({ deployment, deploymentResult });

--- a/packages/serverless/src/server.ts
+++ b/packages/serverless/src/server.ts
@@ -159,7 +159,10 @@ export default function startServer(port: number, host: string) {
       );
     }
 
-    deploymentResult.cpuTime = getCpuTime({ isolate: isolateCache!, deployment });
+    if (!errored) {
+      deploymentResult.cpuTime = getCpuTime({ isolate: isolateCache!, deployment });
+    }
+
     deploymentResult.logs = logs.get(deployment.deploymentId) || [];
 
     logs.delete(deployment.deploymentId);

--- a/packages/serverless/src/worker.ts
+++ b/packages/serverless/src/worker.ts
@@ -1,7 +1,8 @@
 import { clearCache, Deployment } from '@lagon/runtime';
 import { deployments } from 'src/deployments/config';
 import startServer from 'src/server';
-import { shouldClearCache } from './deployments/result';
+import { IS_DEV } from './constants';
+import { clearStatsCache, shouldClearCache } from './deployments/result';
 
 function deploy(deployment: Deployment) {
   const { domains, deploymentId } = deployment;
@@ -25,6 +26,7 @@ function deploy(deployment: Deployment) {
   deployments.set(`${deploymentId}.${process.env.LAGON_ROOT_DOMAIN}`, deployment);
 
   clearCache(deployment);
+  clearStatsCache(deployment);
 }
 
 function undeploy(deployment: Deployment) {
@@ -49,6 +51,7 @@ function undeploy(deployment: Deployment) {
   deployments.delete(`${deploymentId}.${process.env.LAGON_ROOT_DOMAIN}`);
 
   clearCache(deployment);
+  clearStatsCache(deployment);
 }
 
 function changeCurrentDeployment(deployment: Deployment & { previousDeploymentId: string }) {
@@ -105,7 +108,12 @@ export default function worker() {
 
         for (const deployment of deployments.values()) {
           if (shouldClearCache(deployment, now)) {
+            if (IS_DEV) {
+              console.log('Clear cache', deployment.deploymentId);
+            }
+
             clearCache(deployment);
+            clearStatsCache(deployment);
           }
         }
         break;

--- a/packages/website/lib/pages/function/FunctionOverview.tsx
+++ b/packages/website/lib/pages/function/FunctionOverview.tsx
@@ -12,10 +12,6 @@ import useFunctionStats from 'lib/hooks/useFunctionStats';
 import { Timeframe, TIMEFRAMES } from 'lib/types';
 import useFunction from 'lib/hooks/useFunction';
 
-function formatBytes(bytes: number): number {
-  return parseFloat((bytes / 1000000).toFixed(2));
-}
-
 function formatKb(bytes: number): number {
   return parseFloat((bytes / 1000).toFixed(2));
 }
@@ -34,7 +30,6 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
   const { data: stats = [] } = useFunctionStats({ functionId: func?.id, timeframe }) as {
     data: {
       createdAt: Date;
-      memory: number;
       requests: number;
       cpuTime: number;
       receivedBytes: number;
@@ -50,7 +45,6 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
       labels: string[];
       values: {
         requests: number;
-        memory: number;
         cpu: number;
         receivedBytes: number;
         sendBytes: number;
@@ -76,7 +70,6 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
 
         result.values.push({
           requests: stat.reduce((acc, current) => acc + current.requests, 0),
-          memory: stat.reduce((acc, current) => acc + current.memory, 0) / stat.length || 0,
           cpu: stat.reduce((acc, current) => acc + current.cpuTime, 0) / stat.length || 0,
           receivedBytes: stat.reduce((acc, current) => acc + current.receivedBytes, 0) / stat.length || 0,
           sendBytes: stat.reduce((acc, current) => acc + current.sendBytes, 0) / stat.length || 0,
@@ -104,7 +97,6 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
 
         result.values.push({
           requests: stat.reduce((acc, current) => acc + current.requests, 0),
-          memory: stat.reduce((acc, current) => acc + current.memory, 0) / stat.length || 0,
           cpu: stat.reduce((acc, current) => acc + current.cpuTime, 0) / stat.length || 0,
           receivedBytes: stat.reduce((acc, current) => acc + current.receivedBytes, 0) / stat.length || 0,
           sendBytes: stat.reduce((acc, current) => acc + current.sendBytes, 0) / stat.length || 0,
@@ -150,17 +142,11 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
             <Description title="Requests" total="100,000">
               {stats.reduce((acc, current) => acc + current.requests, 0)}
             </Description>
-            <Description title="CPU time" total={`${func?.timeout || 0}ms`}>
+            <Description title="Avg. CPU time" total={`${func?.timeout || 0}ms`}>
               {stats.length > 0 ? formatNs(stats.reduce((acc, current) => acc + current.cpuTime, 0) / stats.length) : 0}
               ms
             </Description>
-            <Description title="Memory" total={`${func?.memory || 0} MB`}>
-              {stats.length > 0
-                ? formatBytes(stats.reduce((acc, current) => acc + current.memory, 0) / stats.length)
-                : 0}
-              &nbsp;MB
-            </Description>
-            <Description title="Received bytes">
+            <Description title="Avg. Received bytes">
               {stats.length > 0
                 ? formatKb(
                     stats.reduce((acc, current) => acc + current.receivedBytes, 0) /
@@ -169,7 +155,7 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
                 : 0}
               &nbsp;KB
             </Description>
-            <Description title="Send bytes">
+            <Description title="Avg. Send bytes">
               {stats.length > 0
                 ? formatKb(
                     stats.reduce((acc, current) => acc + current.sendBytes, 0) /
@@ -218,7 +204,7 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
           />
         </div>
       </Card>
-      <Card title="Resources">
+      <Card title="CPU Time">
         <div className="h-72">
           <Chart
             labels={labels}
@@ -227,11 +213,6 @@ const FunctionOverview = ({ func }: FunctionOverviewProps) => {
                 label: 'CPU',
                 color: '#F59E0B',
                 data: values.map(({ cpu }) => formatNs(cpu)),
-              },
-              {
-                label: 'Memory',
-                color: '#EF4444',
-                data: values.map(({ memory }) => formatBytes(memory)),
               },
             ]}
           />

--- a/packages/website/lib/trpc/functionsRouter.ts
+++ b/packages/website/lib/trpc/functionsRouter.ts
@@ -193,7 +193,6 @@ export const functionsRouter = () =>
           select: {
             createdAt: true,
             requests: true,
-            memory: true,
             cpuTime: true,
             receivedBytes: true,
             sendBytes: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
   packages/cli:
     specifiers:
       '@lagon/common': workspace:1.0.0
-      '@lagon/runtime': 0.0.2
+      '@lagon/runtime': 0.0.3
       '@trpc/client': ^9.25.3
       '@types/inquirer': ^8.2.1
       '@types/update-notifier': ^5.1.0
@@ -161,7 +161,7 @@ importers:
       '@aws-sdk/client-s3': ^3.100.0
       '@lagon/common': workspace:1.0.0
       '@lagon/prisma': workspace:1.0.0
-      '@lagon/runtime': workspace:0.0.2
+      '@lagon/runtime': workspace:0.0.3
       '@sentry/node': ^7.1.1
       '@sentry/tracing': ^7.1.1
       '@types/node': ^17.0.35


### PR DESCRIPTION
Fix memory leaks from undeploy / cache cleared deployments. Also remove memory from stats as it's not precise at all.