### PR TITLE
feat(runtime): disable code evaluation

### DIFF
--- a/packages/runtime/src/__tests__/eval.test.ts
+++ b/packages/runtime/src/__tests__/eval.test.ts
@@ -1,0 +1,57 @@
+import { clearCache, Deployment } from '../deployments';
+import { getIsolate } from '../isolate';
+import { describe, it, expect } from 'vitest';
+import { HandlerRequest } from '..';
+
+const getDeployment = (): Deployment => ({
+  functionId: 'functionId',
+  functionName: 'functionName',
+  deploymentId: Math.random().toString(),
+  domains: [],
+  memory: 128,
+  timeout: 50,
+  env: {},
+  isCurrent: false,
+  assets: [],
+});
+
+const request: HandlerRequest = {
+  input: 'http://localhost',
+  options: {
+    method: 'GET',
+    headers: {},
+  },
+};
+
+describe('eval', () => {
+  it('should prevent eval used from global', async () => {
+    const deployment = getDeployment();
+    const runIsolate = await getIsolate({
+      deployment,
+      getDeploymentCode: async () => `export function handler(request) {
+  eval('console.log("escape")')
+  return new Response('Hello World!');
+}`,
+    });
+
+    await expect(runIsolate(request)).rejects.toThrow('eval is not a function');
+
+    clearCache(deployment);
+  });
+
+  it('should prevent eval used without eval keyword', async () => {
+    const deployment = getDeployment();
+    const runIsolate = await getIsolate({
+      deployment,
+      getDeploymentCode: async () => `export function handler(request) {
+  const evalName = ['e', 'v', 'a', 'l'].join('');
+  global[evalName]('console.log("escape")')
+  return new Response('Hello World!');
+}`,
+    });
+
+    await expect(runIsolate(request)).rejects.toThrow('global[evalName] is not a function');
+
+    clearCache(deployment);
+  });
+});

--- a/packages/runtime/src/isolate/index.ts
+++ b/packages/runtime/src/isolate/index.ts
@@ -63,9 +63,6 @@ export async function getIsolate({
 
     let code = await getDeploymentCode(deployment);
 
-    // TODO: disable `eval` within the isolate?
-    code = code.replace(/eval.*\)/g, '');
-
     code += `
   async function masterHandler(request) {
     const handlerRequest = new Request(request.input, request.options);

--- a/packages/runtime/src/isolate/runtime.ts
+++ b/packages/runtime/src/isolate/runtime.ts
@@ -94,6 +94,7 @@ export async function initRuntime({
   onDeploymentLog?: OnDeploymentLog;
 }) {
   await context.global.set('global', context.global.derefInto());
+  await context.global.set('eval', undefined);
 
   const environmentVariables = getEnvironmentVariables(deployment);
 


### PR DESCRIPTION
Closes #14 

It would be a lot safer to disable code generation in `isolated-vm`, but it's currently allowed to run:
https://github.com/laverdet/isolated-vm/blob/195ae83f3e99310a7a6a190bccfe81272d56ac68/src/isolate/environment.cc#L141