### PR TITLE
fix(cli): type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
     - name: Install dependencies
       run: pnpm install
     - name: Run TSC
-      # TODO: remove the || true when all type errors are resolved
-      run: pnpm typecheck || true
+      run: pnpm typecheck
   build:
     runs-on: ubuntu-20.04
     env:

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -128,6 +128,7 @@ export async function dev(
 
       const headers: Record<string, string> = {};
 
+      // @ts-expect-error we access `headers` which is the private map inside `Headers`
       for (const [key, values] of response.headers.headers.entries()) {
         headers[key] = values[0];
       }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -42,7 +42,7 @@ export async function login() {
 
   const { token } = auth;
 
-  setAuthFile(token);
+  setAuthFile(token as string);
   logSpace();
   logSuccess('You can now close the browser tab.');
 }

--- a/packages/cli/src/utils/deployments.ts
+++ b/packages/cli/src/utils/deployments.ts
@@ -154,7 +154,7 @@ export async function createDeployment(
     body,
   });
 
-  return response.json();
+  return (await response.json()) as { functionName: string };
 }
 
 export async function createFunction(name: string, file: string, preact: boolean, assetsDir: string) {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,6 +11,11 @@
     "strict": true,
     "skipLibCheck": true,
     "incremental": true,
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
-  }
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "baseUrl": "../website"
+  },
+  "include": [
+    "./**/*.ts",
+    "../website/global.d.ts"
+  ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,9 @@
       "outputs": []
     },
     "typecheck": {
-      "dependsOn": [],
+      "dependsOn": [
+        "^build"
+      ],
       "outputs": []
     },
     "build": {


### PR DESCRIPTION
## About

- Fix type errors in `@lagon/cli`, mostly due to trpc `AppRouter` type that wasn't working
- Remove `|| true` to typechek job
