### PR TITLE
fix(serverless,cli): error on non-streamed response

### DIFF
--- a/.changeset/soft-terms-perform.md
+++ b/.changeset/soft-terms-perform.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Fix error if response aren't streamed

--- a/.changeset/two-ghosts-pay.md
+++ b/.changeset/two-ghosts-pay.md
@@ -1,0 +1,7 @@
+---
+'@lagon/cli': patch
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+---
+
+Add response streaming

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -152,7 +152,7 @@ export async function dev(
 
       const payload = streams.get(deployment.deploymentId) || response.body;
 
-      if (typeof payload !== 'string') {
+      if (payload instanceof Readable) {
         payload.on('end', () => {
           clearCache(deployment);
           streams.delete(deployment.deploymentId);

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -3,4 +3,4 @@ export const IS_DEV = process.env.NODE_ENV !== 'production';
 export const SITE_URL = IS_DEV ? 'http://localhost:3000' : 'https://dash.lagon.app';
 export const API_URL = `${SITE_URL}/api`;
 
-export const SUPPORTED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
+export const SUPPORTED_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx', '.mjs'];

--- a/packages/serverless/src/server.ts
+++ b/packages/serverless/src/server.ts
@@ -155,7 +155,7 @@ export default function startServer(port: number, host: string) {
 
       const payload = streams.get(deployment.deploymentId) || response.body;
 
-      if (typeof payload !== 'string') {
+      if (payload instanceof Readable) {
         payload.on('end', () => {
           streams.delete(deployment.deploymentId);
         });


### PR DESCRIPTION
## About

Fix regression of #85 that caused an error when `response` is not a string, but not a `Readable` (e.g `null`, an array...)