### PR TITLE
feat(cli): rename `--preact` to `--client <file>`

### DIFF
--- a/.changeset/long-lobsters-look.md
+++ b/.changeset/long-lobsters-look.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Add --client <file> option to replace deprecated --preact

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,7 +15,8 @@ export function runCli() {
     .command('deploy')
     .description('Deploy the given file')
     .argument('<file>', 'The file to deploy')
-    .option('--preact', 'Bundle the function as a preact site')
+    .option('--preact', 'Bundle the function as a preact site (deprecated, use --client)')
+    .option('-c, --client <file>', 'Bundle this file as a client-side script')
     .option('-p, --public-dir <dir>', 'The directory to serve the public assets from', 'public')
     .action(loggedInGuard(deploy));
   program
@@ -30,7 +31,8 @@ export function runCli() {
     .argument('<file>', 'The file to serve')
     .option('--port <port>', 'Specify dev server port number', '1234')
     .option('--host <host>', 'Specify dev server host name', 'localhost')
-    .option('--preact', 'Bundle the function as a preact site')
+    .option('--preact', 'Bundle the function as a preact site (deprecated, use --client)')
+    .option('-c, --client <file>', 'Bundle this file as a client-side script')
     .option('-p, --public-dir <dir>', 'The directory to serve the public assets from', 'public')
     .action(dev);
 

--- a/packages/cli/src/utils/deployments.ts
+++ b/packages/cli/src/utils/deployments.ts
@@ -45,11 +45,15 @@ export function removeDeploymentFile(file: string) {
   fs.rmSync(configFile);
 }
 
-export async function bundleFunction(
-  file: string,
-  preact: boolean,
-  assetsDir: string,
-): Promise<{ code: string; assets: { name: string; content: string }[] }> {
+export async function bundleFunction({
+  file,
+  clientFile,
+  assetsDir,
+}: {
+  file: string;
+  clientFile?: string;
+  assetsDir: string;
+}): Promise<{ code: string; assets: { name: string; content: string }[] }> {
   const assets: { name: string; content: string }[] = [];
 
   logInfo('Bundling function handler...');
@@ -75,11 +79,11 @@ export async function bundleFunction(
     minifySyntax: true,
   });
 
-  if (preact) {
-    logInfo(`Bundling 'preact' code...`);
+  if (clientFile) {
+    logInfo(`Bundling client file...`);
 
     const { outputFiles: clientOutputFiles } = await build({
-      entryPoints: [path.join(path.parse(file).dir, 'App.tsx')],
+      entryPoints: [clientFile],
       bundle: true,
       write: false,
       loader: {
@@ -99,7 +103,7 @@ export async function bundleFunction(
     });
 
     assets.push({
-      name: 'app.js',
+      name: `${path.basename(clientFile).toLowerCase()}.js`,
       content: clientOutputFiles[0].text,
     });
   }
@@ -131,13 +135,18 @@ export async function bundleFunction(
   };
 }
 
-export async function createDeployment(
-  functionId: string,
-  file: string,
-  preact: boolean,
-  assetsDir: string,
-): Promise<{ functionName: string }> {
-  const { code, assets } = await bundleFunction(file, preact, assetsDir);
+export async function createDeployment({
+  functionId,
+  file,
+  clientFile,
+  assetsDir,
+}: {
+  functionId: string;
+  file: string;
+  clientFile?: string;
+  assetsDir: string;
+}): Promise<{ functionName: string }> {
+  const { code, assets } = await bundleFunction({ file, clientFile, assetsDir });
   const body = new FormData();
 
   body.set('functionId', functionId);
@@ -157,8 +166,18 @@ export async function createDeployment(
   return (await response.json()) as { functionName: string };
 }
 
-export async function createFunction(name: string, file: string, preact: boolean, assetsDir: string) {
-  const { code, assets } = await bundleFunction(file, preact, assetsDir);
+export async function createFunction({
+  name,
+  file,
+  clientFile,
+  assetsDir,
+}: {
+  name: string;
+  file: string;
+  clientFile?: string;
+  assetsDir: string;
+}) {
+  const { code, assets } = await bundleFunction({ file, clientFile, assetsDir });
   const func = await trpc(authToken).mutation('functions.create', {
     name,
     domains: [],

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -32,6 +32,24 @@ export function getAssetsDir(fileToDeploy: string, publicDir: string): string | 
   return assetsDir;
 }
 
+export function getClientFile(fileToDeploy: string, client: string): string | undefined {
+  const clientFile = path.join(path.parse(fileToDeploy).dir, client);
+
+  if (!fs.existsSync(clientFile) || fs.statSync(clientFile).isDirectory()) {
+    logError(`Client file '${client}' does not exist.`);
+    return;
+  }
+
+  const extension = path.extname(clientFile);
+
+  if (!SUPPORTED_EXTENSIONS.includes(extension)) {
+    logError(`Extension '${extension}' is not supported (${SUPPORTED_EXTENSIONS.join(', ')})`);
+    return;
+  }
+
+  return clientFile;
+}
+
 export function getEnvironmentVariables(fileToDeploy: string): Record<string, string> {
   const envFile = path.join(path.parse(fileToDeploy).dir, '.env');
 

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -4,6 +4,10 @@ export function logError(message: string) {
   console.log(`${chalk.red.bold('error  ')} ${message}`);
 }
 
+export function logWarn(message: string) {
+  console.log(`${chalk.yellow.bold('warn   ')} ${message}`);
+}
+
 export function logSuccess(message: string) {
   console.log(`${chalk.green.bold('success')} ${message}`);
 }


### PR DESCRIPTION
## About

Add `--client <file>` option to `dev` and `deploy` commands to replace `--preact`.

Previously, `--preact` allowed to bundle an `App.tsx` file as a client file (similar to if it was bundled and placed inside the public folder), and it was hard-coded. Now, you can pass any file to `--client` and it will be bundled and available as an asset, with the name of the file + `.js` and in lowercase.