### PR TITLE
test(serverless): increase timeout for memory full

### DIFF
--- a/packages/serverless/src/__tests__/errors.test.ts
+++ b/packages/serverless/src/__tests__/errors.test.ts
@@ -202,7 +202,10 @@ export function handler(request) {
 
   it('should throw an error when memory is full', async () => {
     const deployment = getDeployment();
-    vi.spyOn(deploymentsConfig, 'getDeploymentFromRequest').mockReturnValue(deployment);
+    vi.spyOn(deploymentsConfig, 'getDeploymentFromRequest').mockReturnValue({
+      ...deployment,
+      timeout: 10000, // Increase timeout to make sure GH Actions doesn't fail due to timeout
+    });
     vi.spyOn(deployments, 'getDeploymentCode').mockResolvedValue(`export async function handler(request) {
   const storage = [];
   const twoMegabytes = 1024 * 1024 * 20;


### PR DESCRIPTION
## About

Increase timeout for memory full test to prevent GH action timeouts (e.g https://github.com/lagonapp/lagon/runs/7753463848?check_suite_focus=true)
