### PR TITLE
fix(serverless,cli): always transform the body to a string

### DIFF
--- a/.changeset/modern-islands-join.md
+++ b/.changeset/modern-islands-join.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Correctly handle POST with JSON body

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -160,7 +160,7 @@ export async function dev(
         options: {
           method: request.method,
           headers: request.headers,
-          body: request.body as string,
+          body: typeof request.body === 'object' ? JSON.stringify(request.body) : String(request.body),
         },
       };
 

--- a/packages/serverless/src/server.ts
+++ b/packages/serverless/src/server.ts
@@ -135,7 +135,7 @@ export default function startServer(port: number, host: string) {
         options: {
           method: request.method,
           headers: request.headers,
-          body: request.body as string,
+          body: typeof request.body === 'object' ? JSON.stringify(request.body) : String(request.body),
         },
       };
 


### PR DESCRIPTION
## About

Always transform `body` to a string, because fastify can give us an object if we post JSON for example.