### PR TITLE
fix(serverless): create folders in assets that are nested

### DIFF
--- a/.changeset/fast-poets-wash.md
+++ b/.changeset/fast-poets-wash.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Support nested folders for assets

--- a/packages/serverless/src/deployments/index.ts
+++ b/packages/serverless/src/deployments/index.ts
@@ -51,6 +51,7 @@ export function getAssetContent(deployment: Deployment, name: string): fs.ReadSt
 export function writeAssetContent(name: string, content: string): void {
   const file = path.join(DEPLOYMENTS_FOLDER, name);
 
+  fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, content, 'utf8');
 }
 


### PR DESCRIPTION
## About

Fix a bug where the server would crash if assets were nested in folders.
