### PR TITLE
feat(website): use `unstable_getServerSession` to reduce API calls duration

### DIFF
--- a/packages/serverless/.env.example
+++ b/packages/serverless/.env.example
@@ -5,7 +5,6 @@ SENTRY_DSN=
 SENTRY_ENVIRONMENT=development
 
 REDIS_URL=redis://localhost:6379
-DATABASE_URL=mysql://root:mysql@localhost:3306/lagon
 
 S3_REGION=
 S3_BUCKET=

--- a/packages/website/pages/api/auth/[...nextauth].ts
+++ b/packages/website/pages/api/auth/[...nextauth].ts
@@ -1,97 +1,96 @@
-import NextAuth, { Session } from 'next-auth';
+import NextAuth, { Session, NextAuthOptions } from 'next-auth';
 import GithubProvider from 'next-auth/providers/github';
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import prisma from '@lagon/prisma';
 import apiHandler from 'lib/api';
 import * as Sentry from '@sentry/nextjs';
 
-export default apiHandler(
-  NextAuth({
-    adapter: PrismaAdapter(prisma),
-    providers: [
-      GithubProvider({
-        clientId: process.env.GITHUB_CLIENT_ID,
-        clientSecret: process.env.GITHUB_CLIENT_SECRET,
-      }),
-    ],
-    secret: process.env.NEXTAUTH_SECRET,
-    session: {
-      strategy: 'jwt',
-      maxAge: 30 * 24 * 60 * 60, // 30 days
-    },
-    callbacks: {
-      session: async ({ session, token }) => {
-        const userFromDB = await prisma.user.findFirst({
-          where: {
-            email: token.email,
-          },
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            currentOrganizationId: true,
-          },
-        });
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  providers: [
+    GithubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+  callbacks: {
+    session: async ({ session, token }) => {
+      const userFromDB = await prisma.user.findFirst({
+        where: {
+          email: token.email,
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          currentOrganizationId: true,
+        },
+      });
 
-        if (!userFromDB) {
-          throw new Error('User not found');
-        }
+      if (!userFromDB) {
+        throw new Error('User not found');
+      }
 
-        const organization = await prisma.organization.findFirst({
-          where: {
-            id: userFromDB.currentOrganizationId!,
-          },
-          select: {
-            id: true,
-            name: true,
-            description: true,
-          },
-        });
+      const organization = await prisma.organization.findFirst({
+        where: {
+          id: userFromDB.currentOrganizationId!,
+        },
+        select: {
+          id: true,
+          name: true,
+          description: true,
+        },
+      });
 
-        Sentry.setUser({
+      Sentry.setUser({
+        id: userFromDB.id,
+        username: userFromDB.name!,
+        email: userFromDB.email!,
+      });
+
+      return {
+        ...session,
+        user: {
           id: userFromDB.id,
-          username: userFromDB.name!,
-          email: userFromDB.email!,
-        });
-
-        return {
-          ...session,
-          user: {
-            id: userFromDB.id,
-            name: userFromDB.name,
-            email: userFromDB.email,
-          },
-          organization,
-        } as Session;
-      },
+          name: userFromDB.name,
+          email: userFromDB.email,
+        },
+        organization,
+      } as Session;
     },
-    events: {
-      createUser: async ({ user }) => {
-        const name = user.name || user.email;
+  },
+  events: {
+    createUser: async ({ user }) => {
+      const name = user.name || user.email;
 
-        const { id } = await prisma.organization.create({
-          data: {
-            // Email address is always returned for GitHub provider
-            // https://next-auth.js.org/providers/github#example
-            name: user.name || (user.email as string),
-            description: `${name}'s default organization.`,
-            ownerId: user.id,
-          },
-          select: {
-            id: true,
-          },
-        });
+      const { id } = await prisma.organization.create({
+        data: {
+          // Email address is always returned for GitHub provider
+          // https://next-auth.js.org/providers/github#example
+          name: user.name || (user.email as string),
+          description: `${name}'s default organization.`,
+          ownerId: user.id,
+        },
+        select: {
+          id: true,
+        },
+      });
 
-        await prisma.user.update({
-          where: {
-            id: user.id,
-          },
-          data: {
-            currentOrganizationId: id,
-          },
-        });
-      },
+      await prisma.user.update({
+        where: {
+          id: user.id,
+        },
+        data: {
+          currentOrganizationId: id,
+        },
+      });
     },
-  }),
-  { tokenAuth: false },
-);
+  },
+};
+
+export default apiHandler(NextAuth(authOptions), { tokenAuth: false });

--- a/packages/website/pages/api/trpc/[trpc].ts
+++ b/packages/website/pages/api/trpc/[trpc].ts
@@ -1,6 +1,7 @@
 import * as trpc from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 import { getSession } from 'next-auth/react';
+import { unstable_getServerSession } from 'next-auth/next';
 import { functionsRouter } from 'lib/trpc/functionsRouter';
 import { organizationsRouter } from 'lib/trpc/organizationsRouter';
 import { tokensRouter } from 'lib/trpc/tokensRouter';
@@ -10,6 +11,7 @@ import { Session } from 'next-auth';
 import * as Sentry from '@sentry/nextjs';
 import { accountsRouter } from 'lib/trpc/accountsRouter';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { authOptions } from '../auth/[...nextauth]';
 
 const createContext = async ({
   req,
@@ -67,7 +69,7 @@ const createContext = async ({
       } as Session,
     };
   } else {
-    const session = await getSession({ req });
+    const session = await unstable_getServerSession(req, res, authOptions);
 
     if (!session) {
       throw new trpc.TRPCError({


### PR DESCRIPTION
## About

Use `unstable_getServerSession` from [nextauth](https://next-auth.js.org/configuration/nextjs#unstable_getserversession) to reduce API calls duration by not fetching the session at every authenticated request.

The API is experimental but seems to work well.