### PR TITLE
fix(website): crash on playground page

### DIFF
--- a/packages/website/pages/playground/[functionId].tsx
+++ b/packages/website/pages/playground/[functionId].tsx
@@ -67,7 +67,7 @@ const PlaygroundPage = () => {
           <div className="w-[50vw] flex justify-between px-2 items-center h-full">
             <Text>
               {t('title', {
-                functionName: func?.name as string,
+                functionName: func?.name || '',
               })}
             </Text>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## About

Fix a crash on playground page due to undefined being passed to a locale param.