### PR TITLE
fix(cli): show help when no subcommand provided

### DIFF
--- a/.changeset/beige-stingrays-report.md
+++ b/.changeset/beige-stingrays-report.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Show help when no subcommand provided

--- a/packages/cli/src/commands/deploy.rs
+++ b/packages/cli/src/commands/deploy.rs
@@ -60,7 +60,7 @@ pub async fn deploy(
     file: PathBuf,
     client: Option<PathBuf>,
     public_dir: Option<PathBuf>,
-    force: bool,
+    _force: bool,
 ) -> io::Result<()> {
     let token = get_token()?;
 

--- a/packages/cli/src/commands/dev.rs
+++ b/packages/cli/src/commands/dev.rs
@@ -1,11 +1,11 @@
 use std::{io, path::PathBuf};
 
 pub fn dev(
-    file: PathBuf,
-    client: Option<PathBuf>,
-    public_dir: Option<PathBuf>,
-    port: Option<u16>,
-    hostname: Option<String>,
+    _file: PathBuf,
+    _client: Option<PathBuf>,
+    _public_dir: Option<PathBuf>,
+    _port: Option<u16>,
+    _hostname: Option<String>,
 ) -> io::Result<()> {
     println!("dev");
 

--- a/packages/cli/src/commands/login.rs
+++ b/packages/cli/src/commands/login.rs
@@ -17,15 +17,12 @@ struct CliRequest {
 }
 
 pub async fn login() -> io::Result<()> {
-    if let Some(_) = get_token()? {
-        if !Confirm::new()
+    if (get_token()?).is_some() && !Confirm::new()
             .with_prompt(info(
                 "You are already logged in. Are you sure you want to log in again?",
             ))
-            .interact()?
-        {
-            return Err(Error::new(ErrorKind::Other, "Login aborted."));
-        }
+            .interact()? {
+        return Err(Error::new(ErrorKind::Other, "Login aborted."));
     }
 
     println!();

--- a/packages/cli/src/commands/logout.rs
+++ b/packages/cli/src/commands/logout.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub fn logout() -> io::Result<()> {
-    if let None = get_token()? {
+    if (get_token()?).is_none() {
         return Err(Error::new(ErrorKind::Other, "You are not logged in."));
     }
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -9,7 +9,7 @@ mod commands;
 mod utils;
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = None, arg_required_else_help = true)]
 struct Cli {
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -101,7 +101,6 @@ async fn main() {
                 client,
                 public_dir,
             } => commands::build(file, client, public_dir),
-            _ => Ok(()),
         } {
             println!("{}", error(&err.to_string()));
         }

--- a/packages/cli/src/utils/deployments.rs
+++ b/packages/cli/src/utils/deployments.rs
@@ -89,7 +89,7 @@ fn esbuild(file: &PathBuf) -> io::Result<String> {
 pub fn bundle_function(
     index: PathBuf,
     client: Option<PathBuf>,
-    public_dir: PathBuf,
+    _public_dir: PathBuf,
 ) -> io::Result<(String, HashMap<String, String>)> {
     if let Err(_) = Command::new("esbuild").arg("--version").output() {
         return Err(Error::new(


### PR DESCRIPTION
## About

Show help when no subcommand is provided. Also, apply clippy suggestions.
