### PR TITLE
fix(cli,serverless): correctly bundle and deploy assets

### DIFF
--- a/.changeset/spotty-experts-whisper.md
+++ b/.changeset/spotty-experts-whisper.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Correctly bundle assets

--- a/.changeset/thin-vans-complain.md
+++ b/.changeset/thin-vans-complain.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Fix deployments not working with multiple assets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,9 +1150,11 @@ dependencies = [
  "lagon-runtime",
  "mime 0.3.16",
  "multipart",
+ "pathdiff",
  "serde",
  "serde_json",
  "tokio",
+ "walkdir",
  "webbrowser",
 ]
 
@@ -1924,6 +1926,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "peeking_take_while"

--- a/examples/preact-ssr/index.tsx
+++ b/examples/preact-ssr/index.tsx
@@ -13,7 +13,7 @@ const html = `<!DOCTYPE html>
 </head>
 <body>
   <div id="root">${render(<App />)}</div>
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="/App.js"></script>
 </body>
 </html>`;
 

--- a/examples/preact/index.tsx
+++ b/examples/preact/index.tsx
@@ -8,7 +8,7 @@ const html = `<!DOCTYPE html>
 </head>
 <body>
   <div id="root" />
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="/App.js"></script>
 </body>
 </html>`;
 

--- a/examples/react-ssr/index.tsx
+++ b/examples/react-ssr/index.tsx
@@ -12,7 +12,7 @@ const html = `<!DOCTYPE html>
 </head>
 <body>
   <div id="root">${renderToString(<App />)}</div>
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="/App.js"></script>
 </body>
 </html>`;
 

--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -8,7 +8,7 @@ const html = `<!DOCTYPE html>
 </head>
 <body>
   <div id="root" />
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="/App.js"></script>
 </body>
 </html>`;
 

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -17,3 +17,5 @@ multipart = "0.18.0"
 mime = "0.3.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+walkdir = "2.3.2"
+pathdiff = "0.2.1"

--- a/packages/cli/src/commands/build.rs
+++ b/packages/cli/src/commands/build.rs
@@ -24,13 +24,13 @@ pub fn build(
 
     let end_progress = print_progress("Writting index.js...");
     fs::create_dir_all(".lagon")?;
-    fs::write(".lagon/index.js", index)?;
+    fs::write(".lagon/index.js", index.get_ref())?;
     end_progress();
 
     for (path, content) in assets {
         let message = format!("Writting {}...", path);
         let end_progress = print_progress(&message);
-        fs::write(format!(".lagon/{}", path), content)?;
+        fs::write(format!(".lagon/{}", path), content.get_ref())?;
         end_progress();
     }
 

--- a/packages/cli/src/commands/build.rs
+++ b/packages/cli/src/commands/build.rs
@@ -33,7 +33,9 @@ pub fn build(
         let message = format!("Writting {}...", path);
         let end_progress = print_progress(&message);
 
-        let dir = PathBuf::from(".lagon").join("public").join(PathBuf::from(&path).parent().unwrap());
+        let dir = PathBuf::from(".lagon")
+            .join("public")
+            .join(PathBuf::from(&path).parent().unwrap());
         fs::create_dir_all(dir)?;
         fs::write(format!(".lagon/public/{}", path), content.get_ref())?;
 

--- a/packages/cli/src/commands/build.rs
+++ b/packages/cli/src/commands/build.rs
@@ -23,14 +23,20 @@ pub fn build(
     let (index, assets) = bundle_function(file, client, public_dir)?;
 
     let end_progress = print_progress("Writting index.js...");
+
     fs::create_dir_all(".lagon")?;
     fs::write(".lagon/index.js", index.get_ref())?;
+
     end_progress();
 
     for (path, content) in assets {
         let message = format!("Writting {}...", path);
         let end_progress = print_progress(&message);
-        fs::write(format!(".lagon/{}", path), content.get_ref())?;
+
+        let dir = PathBuf::from(".lagon").join("public").join(PathBuf::from(&path).parent().unwrap());
+        fs::create_dir_all(dir)?;
+        fs::write(format!(".lagon/public/{}", path), content.get_ref())?;
+
         end_progress();
     }
 

--- a/packages/serverless/src/deployments/filesystem.rs
+++ b/packages/serverless/src/deployments/filesystem.rs
@@ -41,7 +41,9 @@ pub fn write_deployment_asset(deployment_id: String, asset: &str, buf: &[u8]) ->
     let asset = asset.replace("public/", "");
     let asset = asset.as_str();
 
-    let dir = PathBuf::from("deployments").join(&deployment_id).join(PathBuf::from(asset).parent().unwrap());
+    let dir = PathBuf::from("deployments")
+        .join(&deployment_id)
+        .join(PathBuf::from(asset).parent().unwrap());
     fs::create_dir_all(dir)?;
 
     let mut file = fs::File::create(Path::new("deployments").join(deployment_id + "/" + asset))?;

--- a/packages/serverless/src/deployments/filesystem.rs
+++ b/packages/serverless/src/deployments/filesystem.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::path::PathBuf;
 use std::{env, fs, io, path::Path};
 
 use super::Deployment;
@@ -37,7 +38,12 @@ pub fn write_deployment(deployment_id: String, buf: &[u8]) -> io::Result<()> {
 }
 
 pub fn write_deployment_asset(deployment_id: String, asset: &str, buf: &[u8]) -> io::Result<()> {
-    fs::create_dir(Path::new("deployments").join(&deployment_id))?;
+    let asset = asset.replace("public/", "");
+    let asset = asset.as_str();
+
+    let dir = PathBuf::from("deployments").join(&deployment_id).join(PathBuf::from(asset).parent().unwrap());
+    fs::create_dir_all(dir)?;
+
     let mut file = fs::File::create(Path::new("deployments").join(deployment_id + "/" + asset))?;
 
     file.write_all(buf)?;

--- a/packages/serverless/src/deployments/mod.rs
+++ b/packages/serverless/src/deployments/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, io, path::Path, sync::Arc};
+use std::{collections::{HashMap, HashSet}, fs, io, path::Path, sync::Arc};
 
 use mysql::{prelude::Queryable, PooledConn};
 use s3::Bucket;
@@ -18,8 +18,8 @@ pub mod pubsub;
 pub struct Deployment {
     pub id: String,
     pub function_id: String,
-    pub domains: Vec<String>,
-    pub assets: Vec<String>,
+    pub domains: HashSet<String>,
+    pub assets: HashSet<String>,
     pub environment_variables: HashMap<String, String>,
     pub memory: usize,  // in MB (MegaBytes)
     pub timeout: usize, // in ms (MilliSeconds)
@@ -31,7 +31,9 @@ pub async fn get_deployments(
 ) -> Arc<RwLock<HashMap<String, Deployment>>> {
     let deployments = Arc::new(RwLock::new(HashMap::new()));
 
-    let deployments_list = conn
+    let mut deployments_list: HashMap<String, Deployment> = HashMap::new();
+
+    conn
         .query_map(
             r"
         SELECT
@@ -57,17 +59,36 @@ pub async fn get_deployments(
                 usize,
                 Option<String>,
                 Option<String>,
-            )| Deployment {
-                id,
-                function_id,
-                domains: domain.map(|d| vec![d]).unwrap_or(vec![]),
-                assets: asset.map(|a| vec![a]).unwrap_or(vec![]),
-                environment_variables: HashMap::new(),
-                memory,
-                timeout,
+            )| {
+                deployments_list.entry(id.clone()).and_modify(|deployment| {
+                    if let Some(domain) = domain.clone() {
+                        deployment.domains.insert(domain);
+                    }
+
+                    if let Some(asset) = asset.clone() {
+                        deployment.assets.insert(asset);
+                    }
+                }).or_insert(Deployment {
+                    id,
+                    function_id,
+                    domains: domain.map(|domain| {
+                        let mut domains = HashSet::new();
+                        domains.insert(domain);
+                        domains
+                    }).unwrap_or_default(),
+                    assets: asset.map(|asset| {
+                        let mut assets = HashSet::new();
+                        assets.insert(asset);
+                        assets
+                    }).unwrap_or_default(),
+                    environment_variables: HashMap::new(),
+                    memory,
+                    timeout,
+                });
             },
-        )
-        .unwrap();
+        ).unwrap();
+
+    let deployments_list = deployments_list.values().cloned().collect();
 
     if let Err(error) = create_deployments_folder() {
         println!("Could not create deployments folder: {}", error);
@@ -82,7 +103,6 @@ pub async fn get_deployments(
 
         for deployment in deployments_list {
             if !has_deployment_code(&deployment) {
-                println!("deployment {:?}", deployment);
                 if let Err(error) = download_deployment(&deployment, &bucket).await {
                     println!("Failed to download deployment: {:?}", error);
                 }

--- a/packages/serverless/src/deployments/mod.rs
+++ b/packages/serverless/src/deployments/mod.rs
@@ -82,6 +82,7 @@ pub async fn get_deployments(
 
         for deployment in deployments_list {
             if !has_deployment_code(&deployment) {
+                println!("deployment {:?}", deployment);
                 if let Err(error) = download_deployment(&deployment, &bucket).await {
                     println!("Failed to download deployment: {:?}", error);
                 }

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -4,7 +4,7 @@ use hyper::{Body, Request as HyperRequest, Response as HyperResponse, Server};
 use lagon_runtime::http::RunResult;
 use lagon_runtime::isolate::{Isolate, IsolateOptions};
 use lagon_runtime::runtime::{Runtime, RuntimeOptions};
-use metrics::{histogram, increment_counter, counter};
+use metrics::{counter, histogram, increment_counter};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use mysql::Pool;
 use s3::creds::Credentials;

--- a/packages/website/pages/api/deployment.ts
+++ b/packages/website/pages/api/deployment.ts
@@ -68,7 +68,6 @@ const handler = async (request: NextApiRequest, response: NextApiResponse) => {
     if (formName === 'code') {
       code = fs.createReadStream(file.filepath);
     } else if (formName === 'assets') {
-      console.log(file.originalFilename);
       assets.push({
         name: file.originalFilename!,
         content: fs.createReadStream(file.filepath),

--- a/packages/website/pages/api/deployment.ts
+++ b/packages/website/pages/api/deployment.ts
@@ -68,6 +68,7 @@ const handler = async (request: NextApiRequest, response: NextApiResponse) => {
     if (formName === 'code') {
       code = fs.createReadStream(file.filepath);
     } else if (formName === 'assets') {
+      console.log(file.originalFilename);
       assets.push({
         name: file.originalFilename!,
         content: fs.createReadStream(file.filepath),


### PR DESCRIPTION
## About

Assets in the `public` folder (or the public folder specified using `-p`) weren't bundled and deployed.
This PR bundle all assets and:
- Outputs them in `.lagon` when using `lagon build`
- Send them to the API with the correct MIME type
Then, serverless correctly handles all assets, which are all prefixed by `public/`.