### PR TITLE
feat(runtime,js-runtime): handle `Uint8Array` in `Response` body

### DIFF
--- a/.changeset/violet-insects-wink.md
+++ b/.changeset/violet-insects-wink.md
@@ -1,0 +1,6 @@
+---
+'@lagon/js-runtime': patch
+'@lagon/runtime': patch
+---
+
+Handle Uint8Array in Response body

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -10,7 +10,9 @@ export * from './runtime/fetch';
 import './runtime/console';
 import './runtime/process';
 
-import type { RequestInit } from './runtime/Request';
+import { TextDecoder } from './runtime/encoding';
+import { Request, RequestInit } from './runtime/Request';
+import { Response } from './runtime/Response';
 
 declare global {
   const Lagon: {
@@ -22,4 +24,21 @@ declare global {
       body: string;
     };
   };
+  const handler: (request: Request) => Promise<Response>;
+}
+
+export async function masterHandler(request: { input: string } & Request): Promise<Response> {
+  const handlerRequest = new Request(request.input, {
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+  });
+
+  const response = await handler(handlerRequest);
+
+  if (response.body instanceof Uint8Array) {
+    response.body = new TextDecoder().decode(response.body);
+  }
+
+  return response;
 }

--- a/packages/runtime/src/http/mod.rs
+++ b/packages/runtime/src/http/mod.rs
@@ -92,7 +92,7 @@ impl Request {
 #[derive(Debug, PartialEq)]
 pub struct Response {
     pub headers: Option<HashMap<String, String>>,
-    pub body: String,
+    pub body: Vec<u8>,
     pub status: u16,
 }
 
@@ -101,7 +101,7 @@ impl Response {
         let response_object = v8::Object::new(scope);
         let body_key = v8::String::new(scope, "body").unwrap();
         let body_key = v8::Local::new(scope, body_key);
-        let body_value = v8::String::new(scope, &self.body).unwrap();
+        let body_value = v8::String::new(scope, std::str::from_utf8(&self.body).unwrap()).unwrap();
         let body_value = v8::Local::new(scope, body_value);
 
         response_object.set(scope, body_key.into(), body_value.into());
@@ -156,7 +156,7 @@ impl Response {
 
         Some(Self {
             headers,
-            body,
+            body: body.into_bytes(),
             status,
         })
     }

--- a/packages/runtime/src/isolate/bindings/fetch.rs
+++ b/packages/runtime/src/isolate/bindings/fetch.rs
@@ -29,8 +29,7 @@ pub fn fetch_binding(
 
         let response = client.request(request).await.unwrap();
         let status = response.status().as_u16();
-        let body = body::to_bytes(response.into_body()).await.unwrap();
-        let body = String::from_utf8(body.to_vec()).unwrap();
+        let body = body::to_bytes(response.into_body()).await.unwrap().to_vec();
 
         sender
             .send(Response {

--- a/packages/runtime/src/runtime/mod.rs
+++ b/packages/runtime/src/runtime/mod.rs
@@ -80,16 +80,6 @@ pub fn get_runtime_code<'a>(
 }})()
 
 {code}
-
-export async function masterHandler(request) {{
-    const handlerRequest = new Request(request.input, {{
-      method: request.method,
-      headers: request.headers,
-      body: request.body,
-    }});
-
-    return handler(handlerRequest);
-  }}
 "#
         ),
     )

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -287,6 +287,35 @@ async fn return_status() {
     );
 }
 
+#[tokio::test]
+async fn return_uint8array() {
+    setup();
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export function handler() {
+    // TextEncoder#encode returns a Uint8Array
+    const body = new TextEncoder().encode('Hello world');
+    return new Response(body);
+}"
+        .into(),
+    ));
+
+    assert_eq!(
+        isolate
+            .run(Request {
+                body: "".into(),
+                headers: HashMap::new(),
+                method: Method::GET,
+                url: "".into(),
+            })
+            .0,
+        RunResult::Response(Response {
+            body: "Hello world".into(),
+            headers: None,
+            status: 200,
+        })
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn timeout_reached() {
     setup();

--- a/packages/serverless/src/deployments/assets.rs
+++ b/packages/serverless/src/deployments/assets.rs
@@ -9,7 +9,7 @@ pub fn handle_asset(deployment: &Deployment, asset: &String) -> io::Result<Respo
         .join("deployments")
         .join(deployment.id.clone())
         .join(asset);
-    let body = fs::read_to_string(path)?;
+    let body = fs::read(path)?;
 
     let extension = Path::new(asset).extension().unwrap().to_str().unwrap();
     let content_type = match extension {


### PR DESCRIPTION
## About

Handle `Uint8Array` in `Response` body.
Replace `Response` struct body from `String` to `Vec<u8>` to reply with assets that aren't utf8 (`fs::read_to_string` -> `fs::read`).