### PR TITLE
feat(runtime): implement event loop

### DIFF
--- a/.changeset/gorgeous-lemons-wonder.md
+++ b/.changeset/gorgeous-lemons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Implement event loop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,7 @@ dependencies = [
 name = "lagon-runtime"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "hyper 0.14.20",
  "tokio",
  "v8",

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 v8 = "0.51.0"
 tokio = { version = "1", features = ["full"] }
+futures = "0.3.24"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -31,7 +31,7 @@ async fn execute_function() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -65,7 +65,7 @@ async fn environment_variables() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -92,7 +92,7 @@ async fn get_body() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -119,7 +119,7 @@ async fn get_input() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "https://hello.world".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "https://hello.world".into(),
@@ -146,7 +146,7 @@ async fn get_method() {
                 headers: HashMap::new(),
                 method: Method::POST,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "POST".into(),
@@ -176,7 +176,7 @@ async fn get_headers() {
                 headers,
                 method: Method::POST,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "token".into(),
@@ -212,7 +212,7 @@ async fn return_headers() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -248,7 +248,7 @@ async fn return_headers_from_headers_api() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -277,7 +277,7 @@ async fn return_status() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Moved permanently".into(),
@@ -306,7 +306,7 @@ async fn return_uint8array() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -334,7 +334,7 @@ async fn timeout_reached() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::Timeout(),
     );
@@ -369,7 +369,7 @@ async fn memory_reached() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            })
+            }).await
             .0,
         RunResult::MemoryLimit(),
     );

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -317,6 +317,29 @@ async fn return_uint8array() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn promise_rejected() {
+    setup();
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export function handler() {
+    throw new Error('Rejected');
+}"
+        .into(),
+    ));
+
+    assert_eq!(
+        isolate
+            .run(Request {
+                body: "".into(),
+                headers: HashMap::new(),
+                method: Method::GET,
+                url: "".into(),
+            }).await
+            .0,
+        RunResult::Error("Uncaught Error: Rejected".into()),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn timeout_reached() {
     setup();
     let mut isolate = Isolate::new(IsolateOptions::new(

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -31,7 +31,8 @@ async fn execute_function() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -65,7 +66,8 @@ async fn environment_variables() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -92,7 +94,8 @@ async fn get_body() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -119,7 +122,8 @@ async fn get_input() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "https://hello.world".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "https://hello.world".into(),
@@ -146,7 +150,8 @@ async fn get_method() {
                 headers: HashMap::new(),
                 method: Method::POST,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "POST".into(),
@@ -176,7 +181,8 @@ async fn get_headers() {
                 headers,
                 method: Method::POST,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "token".into(),
@@ -212,7 +218,8 @@ async fn return_headers() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -248,7 +255,8 @@ async fn return_headers_from_headers_api() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -277,7 +285,8 @@ async fn return_status() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Moved permanently".into(),
@@ -306,7 +315,8 @@ async fn return_uint8array() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Response(Response {
             body: "Hello world".into(),
@@ -333,7 +343,8 @@ async fn promise_rejected() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Error("Uncaught Error: Rejected".into()),
     );
@@ -357,7 +368,8 @@ async fn timeout_reached() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::Timeout(),
     );
@@ -392,7 +404,8 @@ async fn memory_reached() {
                 headers: HashMap::new(),
                 method: Method::GET,
                 url: "".into(),
-            }).await
+            })
+            .await
             .0,
         RunResult::MemoryLimit(),
     );

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -156,7 +156,7 @@ async fn main() {
                                 Isolate::new(options)
                             });
 
-                            let (run_result, maybe_statistics) = isolate.run(request);
+                            let (run_result, maybe_statistics) = isolate.run(request).await;
 
                             if let Some(statistics) = maybe_statistics {
                                 histogram!("lagon_isolate_cpu_time", statistics.cpu_time, &labels);


### PR DESCRIPTION
## About

Implement a very very basic event loop that:
- Pumps the message loop
- Runs microtasks
- Check if the isolate has been terminated (for CPU timeout / too much memory)
- Check the state of the handler's promise and repeat until it resolves / rejected