### PR TITLE
refactor(runtime): proper Rust -> JS promises through the event-loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
 name = "lagon-runtime"
 version = "0.1.0"
 dependencies = [
+ "flume",
  "futures",
  "hyper 0.14.20",
  "tokio",

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -8,3 +8,4 @@ v8 = "0.51.0"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.24"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
+flume = "0.10.14"

--- a/packages/runtime/src/isolate/bindings/fetch.rs
+++ b/packages/runtime/src/isolate/bindings/fetch.rs
@@ -1,6 +1,6 @@
 use hyper::{body, http::Request, Client};
 
-use crate::{http::Response, isolate::Isolate};
+use crate::{http::Response, isolate::{Isolate, bindings::PromiseResult}};
 
 pub fn fetch_binding(
     scope: &mut v8::HandleScope,
@@ -12,14 +12,7 @@ pub fn fetch_binding(
     let promise = v8::PromiseResolver::new(scope).unwrap();
     let promise = v8::Local::new(scope, promise);
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-
-    let (sender, receiver) = std::sync::mpsc::channel();
-
-    let join_handle = tokio::task::spawn_local(async move {
-        println!("spawning task");
-
+    let future = async move {
         let request = Request::builder()
             .method("GET")
             .uri(resource)
@@ -31,26 +24,21 @@ pub fn fetch_binding(
         let status = response.status().as_u16();
         let body = body::to_bytes(response.into_body()).await.unwrap().to_vec();
 
-        sender
-            .send(Response {
-                body,
-                headers: None,
-                status,
-            })
-            .unwrap();
-    });
+        let response = Response {
+            body,
+            headers: None,
+            status,
+        };
 
-    // state.promises.push(join_handle);
+        return PromiseResult::Response(response);
+    };
+
+    let state = Isolate::state(scope);
+    let mut state = state.borrow_mut();
+    state.promises.push(Box::pin(future));
+
+    let global_promise = v8::Global::new(scope, promise);
+    state.js_promises.push(global_promise);
 
     retval.set(promise.into());
-
-    // TODO: should be moved to a real even-loop
-    loop {
-        if let Ok(response) = receiver.try_recv() {
-            let response = response.to_v8_response(scope);
-
-            promise.resolve(scope, response.into());
-            break;
-        }
-    }
 }

--- a/packages/runtime/src/isolate/bindings/fetch.rs
+++ b/packages/runtime/src/isolate/bindings/fetch.rs
@@ -1,6 +1,9 @@
 use hyper::{body, http::Request, Client};
 
-use crate::{http::Response, isolate::{Isolate, bindings::PromiseResult}};
+use crate::{
+    http::Response,
+    isolate::{bindings::PromiseResult, Isolate},
+};
 
 pub fn fetch_binding(
     scope: &mut v8::HandleScope,

--- a/packages/runtime/src/isolate/bindings/mod.rs
+++ b/packages/runtime/src/isolate/bindings/mod.rs
@@ -1,8 +1,14 @@
 use console::console_binding;
 use fetch::fetch_binding;
 
+use crate::http::Response;
+
 mod console;
 mod fetch;
+
+pub enum PromiseResult {
+    Response(Response),
+}
 
 pub fn bind(scope: &mut v8::HandleScope<()>) -> v8::Global<v8::Context> {
     let global = v8::ObjectTemplate::new(scope);

--- a/packages/runtime/src/isolate/bindings/mod.rs
+++ b/packages/runtime/src/isolate/bindings/mod.rs
@@ -6,6 +6,11 @@ use crate::http::Response;
 mod console;
 mod fetch;
 
+pub struct BindingResult {
+    pub id: usize,
+    pub result: PromiseResult,
+}
+
 pub enum PromiseResult {
     Response(Response),
 }

--- a/packages/runtime/src/isolate/mod.rs
+++ b/packages/runtime/src/isolate/mod.rs
@@ -7,11 +7,11 @@ use std::{
         Arc, RwLock,
     },
     task::{Context, Poll},
-    time::{Duration, Instant},
+    time::{Duration, Instant}, pin::Pin,
 };
 
-use futures::future::poll_fn;
-use tokio::{spawn, sync::oneshot, task::JoinHandle};
+use futures::{future::poll_fn, stream::FuturesUnordered, Future, StreamExt};
+use tokio::spawn;
 use v8::PromiseState;
 
 use crate::{
@@ -19,6 +19,8 @@ use crate::{
     runtime::get_runtime_code,
     utils::extract_v8_string,
 };
+
+use self::bindings::PromiseResult;
 
 mod allocator;
 mod bindings;
@@ -35,26 +37,28 @@ enum ExecutionResult {
 struct GlobalRealm(v8::Global<v8::Context>);
 
 #[derive(Debug)]
-struct PromiseResult {
+struct HandlerResult {
     promise: v8::Global<v8::Promise>,
-    sender: oneshot::Sender<(RunResult, Option<IsolateStatistics>)>,
+    sender: flume::Sender<(RunResult, Option<IsolateStatistics>)>,
     statistics: IsolateStatistics,
 }
 
 #[derive(Debug)]
 struct TerminationResult {
-    sender: oneshot::Sender<(RunResult, Option<IsolateStatistics>)>,
+    sender: flume::Sender<(RunResult, Option<IsolateStatistics>)>,
     run_result: RunResult,
 }
 
 #[derive(Debug)]
 struct IsolateState {
     global: GlobalRealm,
-    promise_result: Option<PromiseResult>,
+    promises: FuturesUnordered<Pin<Box<dyn Future<Output = PromiseResult>>>>,
+    js_promises: Vec<v8::Global<v8::PromiseResolver>>,
+    handler_result: Option<HandlerResult>,
     termination_result: Option<TerminationResult>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct IsolateStatistics {
     pub cpu_time: Duration,
     pub memory_usage: usize,
@@ -132,7 +136,9 @@ impl Isolate {
 
             IsolateState {
                 global: GlobalRealm(global),
-                promise_result: None,
+                promises: FuturesUnordered::new(),
+                js_promises: Vec::new(),
+                handler_result: None,
                 termination_result: None,
             }
         };
@@ -153,22 +159,15 @@ impl Isolate {
         s.clone()
     }
 
-    pub(self) fn global_realm(&self) -> GlobalRealm {
-        let state = Isolate::state(&self.isolate);
-        let state = state.borrow();
-        state.global.clone()
-    }
-
     pub fn evaluate(
         &mut self,
         request: Request,
-    ) -> oneshot::Receiver<(RunResult, Option<IsolateStatistics>)> {
-        let (sender, receiver) = oneshot::channel();
+    ) -> flume::Receiver<(RunResult, Option<IsolateStatistics>)> {
+        let (sender, receiver) = flume::bounded(1);
         let thread_safe_handle = self.isolate.thread_safe_handle();
 
-        // let state = self.global_realm();
-        let isolate_state = Isolate::state(&self.isolate);
-        let mut isolate_state = isolate_state.borrow_mut();
+        let initial_isolate_state = Isolate::state(&self.isolate);
+        let isolate_state = initial_isolate_state.borrow();
         let state = isolate_state.global.clone();
 
         let scope = &mut v8::HandleScope::with_context(&mut self.isolate, state.0.clone());
@@ -286,6 +285,8 @@ impl Isolate {
             }
         });
 
+        drop(isolate_state);
+
         match handler.call(try_catch, global.into(), &[request.into()]) {
             Some(response) => {
                 *terminated.write().unwrap() = ExecutionResult::Run;
@@ -305,7 +306,8 @@ impl Isolate {
                     memory_usage,
                 };
 
-                isolate_state.promise_result = Some(PromiseResult {
+                let mut isolate_state = initial_isolate_state.borrow_mut();
+                isolate_state.handler_result = Some(HandlerResult {
                     promise,
                     sender,
                     statistics,
@@ -318,6 +320,7 @@ impl Isolate {
                     _ => handle_error(try_catch),
                 };
 
+                let mut isolate_state = initial_isolate_state.borrow_mut();
                 isolate_state.termination_result = Some(TerminationResult { sender, run_result });
             }
         };
@@ -332,14 +335,27 @@ impl Isolate {
     fn poll_event_loop(&mut self, cx: &mut Context) -> Poll<()> {
         let isolate_state = Isolate::state(&self.isolate);
         let mut isolate_state = isolate_state.borrow_mut();
-        let state = isolate_state.global.clone();
+        let realm = isolate_state.global.clone();
+        let scope = &mut v8::HandleScope::with_context(&mut self.isolate, realm.0);
 
-        let scope = &mut v8::HandleScope::with_context(&mut self.isolate, state.0.clone());
+        while v8::Platform::pump_message_loop(&v8::V8::get_current_platform(), scope, false) {}
+        scope.perform_microtask_checkpoint();
+
+        if isolate_state.promises.len() > 0 {
+            while let Poll::Ready(Some(result)) = isolate_state.promises.poll_next_unpin(cx) {
+                let promise = isolate_state.js_promises.remove(0);
+                let promise = promise.open(scope);
+
+                match result {
+                    PromiseResult::Response(response) => {
+                        let response = response.to_v8_response(scope);
+                        promise.resolve(scope, response.into());
+                    }
+                };
+            };
+        }
+
         let try_catch = &mut v8::TryCatch::new(scope);
-
-        while v8::Platform::pump_message_loop(&v8::V8::get_current_platform(), try_catch, false) {}
-
-        try_catch.perform_microtask_checkpoint();
 
         if let Some(TerminationResult { sender, run_result }) =
             isolate_state.termination_result.take()
@@ -348,11 +364,11 @@ impl Isolate {
             return Poll::Ready(());
         }
 
-        if let Some(PromiseResult {
+        if let Some(HandlerResult {
             promise,
             sender,
             statistics,
-        }) = isolate_state.promise_result.take()
+        }) = isolate_state.handler_result.as_ref()
         {
             let promise = promise.open(try_catch);
 
@@ -360,8 +376,8 @@ impl Isolate {
                 PromiseState::Fulfilled => {
                     let response = promise.result(try_catch);
                     let result = match Response::from_v8_response(try_catch, response) {
-                        Some(response) => (RunResult::Response(response), Some(statistics)),
-                        None => (handle_error(try_catch), Some(statistics)),
+                        Some(response) => (RunResult::Response(response), Some(statistics.clone())),
+                        None => (handle_error(try_catch), Some(statistics.clone())),
                     };
 
                     sender.send(result).unwrap();
@@ -390,7 +406,7 @@ impl Isolate {
         let receiver = self.evaluate(request);
         self.run_event_loop().await;
 
-        receiver.await.unwrap()
+        receiver.recv_async().await.unwrap()
     }
 }
 

--- a/packages/runtime/src/isolate/mod.rs
+++ b/packages/runtime/src/isolate/mod.rs
@@ -1,13 +1,14 @@
 use std::{
     cell::RefCell,
     collections::HashMap,
+    pin::Pin,
     rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, RwLock,
     },
     task::{Context, Poll},
-    time::{Duration, Instant}, pin::Pin,
+    time::{Duration, Instant},
 };
 
 use futures::{future::poll_fn, stream::FuturesUnordered, Future, StreamExt};
@@ -352,7 +353,7 @@ impl Isolate {
                         promise.resolve(scope, response.into());
                     }
                 };
-            };
+            }
         }
 
         let try_catch = &mut v8::TryCatch::new(scope);

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -329,15 +329,13 @@ async fn return_uint8array() {
 #[tokio::test(flavor = "multi_thread")]
 async fn promise() {
     setup();
-    let mut isolate = Isolate::new(
-        IsolateOptions::new(
-            "export async function handler() {
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export async function handler() {
     const body = await fetch('http://google.com').then((res) => res.text());
     return new Response(body);
 }"
-            .into(),
-        ),
-    );
+        .into(),
+    ));
 
     assert_eq!(
         isolate

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -327,7 +327,38 @@ async fn return_uint8array() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn promise_rejected() {
+async fn promise() {
+    setup();
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
+    const body = await fetch('http://google.com').then((res) => res.text());
+    return new Response(body);
+}"
+            .into(),
+        ),
+    );
+
+    assert_eq!(
+        isolate
+            .run(Request {
+                body: "".into(),
+                headers: HashMap::new(),
+                method: Method::GET,
+                url: "".into(),
+            })
+            .await
+            .0,
+        RunResult::Response(Response {
+            body: [].into(),
+            headers: None,
+            status: 200,
+        })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn handler_reject() {
     setup();
     let mut isolate = Isolate::new(IsolateOptions::new(
         "export function handler() {


### PR DESCRIPTION
## About

Properly implement Rust -> JS async bindings (using promises) polling in the event-loop.

Previously, each async binding would block its function, but now they are pooled when the event-loop ticks.
Also, replace `tokio::sync::oneshot` with `flume` to get `Copy` sender (which is still used once) and allows to not `take()` and consume the `handler_result`, which would cause infinite hanging when the returned promise state isn't `PromiseState::Ready` at the first event-loop tick.
