### PR TITLE
fix(serverless): assets directory not deleting on undeploys

### DIFF
--- a/.changeset/proud-pants-smell.md
+++ b/.changeset/proud-pants-smell.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Fix assets directory not deleting on undeploys

--- a/packages/serverless/src/deployments/filesystem.rs
+++ b/packages/serverless/src/deployments/filesystem.rs
@@ -64,7 +64,7 @@ pub fn rm_deployment(deployment_id: &str) -> io::Result<()> {
     fs::remove_file(Path::new("deployments").join(deployment_id.to_owned() + ".js"))?;
 
     // It's possible that the folder doesn't exists if the deployment has no assets
-    fs::remove_dir(Path::new("deployments").join(deployment_id)).unwrap_or(());
+    fs::remove_dir_all(Path::new("deployments").join(deployment_id)).unwrap_or(());
     info!("Deleted deployment: {}", deployment_id);
 
     Ok(())


### PR DESCRIPTION
## About

Fix a bug where the assets folder wasn't deleted on undeploys, because we used `fs::rm_dir` instead of `fs::rm_dir_all`. The former only rm if the directory is empty, but we don't care and always want to delete the whole directory.
