### PR TITLE
fix(website): deployments creation domains array

### DIFF
--- a/.changeset/kind-peas-sort.md
+++ b/.changeset/kind-peas-sort.md
@@ -1,0 +1,5 @@
+---
+'@lagon/website': patch
+---
+
+Fix deployments domain field that wasn't an array

--- a/packages/website/lib/trpc/deploymentsRouter.ts
+++ b/packages/website/lib/trpc/deploymentsRouter.ts
@@ -140,7 +140,7 @@ export const deploymentsRouter = (t: T) =>
             functionId: func.id,
             functionName: func.name,
             deploymentId: deployment.id,
-            domains: func.domains,
+            domains: func.domains.map(({ domain }) => domain),
             memory: func.memory,
             timeout: func.timeout,
             cron: func.cron,


### PR DESCRIPTION
## About

Fix a bug when website send deployment information, where `domains` wasn't an array of string but an array of `Domain`
