### PR TITLE
feat(cli,runtime): beautify errors

### DIFF
--- a/.changeset/fuzzy-panthers-sin.md
+++ b/.changeset/fuzzy-panthers-sin.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/runtime': patch
+---
+
+Beautify errors

--- a/packages/cli/src/utils/deployments.rs
+++ b/packages/cli/src/utils/deployments.rs
@@ -80,7 +80,7 @@ fn esbuild(file: &PathBuf) -> io::Result<FileCursor> {
         format!(
             "Unexpected status code {}:\n\n{}",
             result.status.code().unwrap_or(0),
-            String::from_utf8(result.stderr).unwrap_or("Unkown error.".to_string())
+            String::from_utf8(result.stderr).unwrap_or_else(|_| "Unknown error.".to_string())
         ),
     ))
 }

--- a/packages/cli/src/utils/deployments.rs
+++ b/packages/cli/src/utils/deployments.rs
@@ -77,7 +77,11 @@ fn esbuild(file: &PathBuf) -> io::Result<FileCursor> {
 
     Err(Error::new(
         ErrorKind::Other,
-        format!("Unexpected status code {}", result.status),
+        format!(
+            "Unexpected status code {}:\n\n{}",
+            result.status.code().unwrap_or(0),
+            String::from_utf8(result.stderr).unwrap_or("Unkown error.".to_string())
+        ),
     ))
 }
 

--- a/packages/runtime/src/isolate/mod.rs
+++ b/packages/runtime/src/isolate/mod.rs
@@ -212,8 +212,10 @@ impl Isolate {
         self.stream_status = StreamStatus::None;
         self.stream_response_sent = false;
 
-        let state = isolate_state.borrow();
-        let global = state.global.0.clone();
+        let global = {
+            let state = isolate_state.borrow();
+            state.global.0.clone()
+        };
 
         let scope = &mut v8::HandleScope::with_context(&mut self.isolate, global.clone());
         let try_catch = &mut v8::TryCatch::new(scope);
@@ -309,8 +311,6 @@ impl Isolate {
                 }
             }
         });
-
-        drop(state);
 
         match handler.call(try_catch, global.into(), &[request.into()]) {
             Some(response) => {
@@ -519,8 +519,19 @@ fn get_exception_message(
     exception: v8::Local<v8::Value>,
 ) -> String {
     let exception_message = v8::Exception::create_message(scope, exception);
+    let message = exception_message.get(scope).to_rust_string_lossy(scope);
 
-    exception_message.get(scope).to_rust_string_lossy(scope)
+    if let Some(line) = exception_message.get_source_line(scope) {
+        return format!(
+            "{}, at {}:{}:\n{}",
+            message,
+            exception_message.get_line_number(scope).unwrap_or(0),
+            exception_message.get_start_column(),
+            line.to_rust_string_lossy(scope),
+        );
+    }
+
+    message
 }
 
 fn handle_error(scope: &mut v8::TryCatch<v8::HandleScope>) -> RunResult {

--- a/packages/runtime/tests/errors.rs
+++ b/packages/runtime/tests/errors.rs
@@ -28,9 +28,7 @@ async fn handler_reject() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error(
-            "Uncaught Error: Rejected, at 2442:10:\n    throw new Error('Rejected');".into()
-        )
+        RunResult::Error("Uncaught Error: Rejected, at:\n    throw new Error('Rejected');".into())
     );
 }
 
@@ -48,7 +46,10 @@ async fn compilation_error() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("SyntaxError: Unexpected identifier 'syntax'".into()),
+        RunResult::Error(
+            "Uncaught SyntaxError: Unexpected identifier 'syntax', at:\n    this syntax is invalid"
+                .into()
+        ),
     );
 }
 

--- a/packages/runtime/tests/errors.rs
+++ b/packages/runtime/tests/errors.rs
@@ -28,7 +28,9 @@ async fn handler_reject() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("Uncaught Error: Rejected".into())
+        RunResult::Error(
+            "Uncaught Error: Rejected, at 2442:10:\n    throw new Error('Rejected');".into()
+        )
     );
 }
 


### PR DESCRIPTION
## About

Beautify errors:
- Add the line for all runtime errors, if available
- Output esbuild errors for cli