### PR TITLE
fix(cli): binary name on Windows & correctly install

### DIFF
--- a/.changeset/afraid-llamas-divide.md
+++ b/.changeset/afraid-llamas-divide.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Correctly install the binary before executing it

--- a/.changeset/rotten-turkeys-tan.md
+++ b/.changeset/rotten-turkeys-tan.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix executable name on Windows

--- a/packages/cli/npm/getBinary.js
+++ b/packages/cli/npm/getBinary.js
@@ -5,23 +5,43 @@ function getPlatform() {
   const type = os.type();
   const arch = os.arch();
 
-  if (type === 'Windows_NT') return 'win-x64';
-  if (type === 'Linux' && arch === 'x64') return 'linux-x64';
-  if (type === 'Linux' && arch === 'arm64') return 'linux-arm64';
-  if (type === 'Darwin') return 'darwin-x64';
+  if (type === 'Windows_NT') {
+    return {
+      platform: 'lagon-win-x64',
+      name: 'lagon.exe',
+    };
+  }
+
+  if (type === 'Linux' && arch === 'x64') {
+    return {
+      platform: 'lagon-linux-x64',
+      name: 'lagon',
+    };
+  }
+
+  if (type === 'Linux' && arch === 'arm64') {
+    return {
+      platform: 'lagon-linux-arm64',
+      name: 'lagon',
+    };
+  }
+
+  if (type === 'Darwin') {
+    return {
+      platform: 'lagon-darwin-x64',
+      name: 'lagon',
+    };
+  }
 
   throw new Error(`Unsupported platform: ${type} ${arch}`);
 }
 
 function getBinary() {
-  // Prevent exiting with code 1
-  process.exit = () => {};
+  const { platform, name } = getPlatform();
+  const { name: packageName, version } = require('../package.json');
 
-  const platform = getPlatform();
-  const { version } = require('../package.json');
-  // %40lagon%2Fcli%40 translates to @lagon/cli@
-  const url = `https://github.com/lagonapp/lagon/releases/download/%40lagon%2Fcli%40${version}/lagon-${platform}.tar.gz`;
-  const name = 'lagon';
+  const url = `https://github.com/lagonapp/lagon/releases/download/${packageName}@${version}/${platform}.tar.gz`;
+
   return new Binary(name, url);
 }
 

--- a/packages/cli/npm/install.js
+++ b/packages/cli/npm/install.js
@@ -1,6 +1,4 @@
-try {
-  const getBinary = require('./getBinary');
-  getBinary().install();
-} catch (err) {
-  console.log(error);
-}
+#!/usr/bin/env node
+
+const getBinary = require('./getBinary');
+getBinary().install();

--- a/packages/cli/npm/run.js
+++ b/packages/cli/npm/run.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 
 const getBinary = require('./getBinary');
-getBinary().run();
+const binary = getBinary();
+
+// Try to install the binary before executing the CLI
+binary.install().then(binary.run);

--- a/packages/cli/npm/uninstall.js
+++ b/packages/cli/npm/uninstall.js
@@ -1,6 +1,4 @@
-try {
-  const getBinary = require('./getBinary');
-  getBinary().uninstall();
-} catch (err) {
-  console.log(error);
-}
+#!/usr/bin/env node
+
+const getBinary = require('./getBinary');
+getBinary().uninstall();


### PR DESCRIPTION
## About

- Fix binary name on WIndows (add `.exe`)
- Correctly install the CLI before executing it
