### PR TITLE
fix(runtime,serverless,cli): response streaming bug

### DIFF
--- a/.changeset/bright-peas-rule.md
+++ b/.changeset/bright-peas-rule.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Fix subsequent requests when streaming response

--- a/.changeset/selfish-rivers-yell.md
+++ b/.changeset/selfish-rivers-yell.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Correctly resolve stream bytes

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -12,7 +12,7 @@ colored = "2.0.0"
 dirs = "4.0.0"
 webbrowser = "0.8.0"
 tokio = { version = "1", features = ["full"] }
-hyper = { version = "0.14", features = ["client", "server", "http1", "http2", "runtime"] }
+hyper = { version = "0.14", features = ["client", "server", "http1", "http2", "runtime", "stream"] }
 mime = "0.3.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/packages/runtime/src/http/mod.rs
+++ b/packages/runtime/src/http/mod.rs
@@ -20,7 +20,7 @@ pub trait FromV8: Sized {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StreamResult {
     Start(Response),
-    Data(&'static [u8]),
+    Data(Vec<u8>),
     Done,
 }
 

--- a/packages/runtime/src/isolate/bindings/pull_stream.rs
+++ b/packages/runtime/src/isolate/bindings/pull_stream.rs
@@ -12,10 +12,8 @@ pub fn pull_stream_binding(
 
     if done.is_false() {
         let chunk = unsafe { v8::Local::<v8::Uint8Array>::cast(args.get(1)) };
-        let buf = chunk.buffer(scope).unwrap();
-
-        let buf: &[u8] =
-            unsafe { std::slice::from_raw_parts(buf.data() as *mut u8, chunk.byte_length()) };
+        let mut buf = vec![0; chunk.byte_length()];
+        chunk.copy_contents(&mut buf);
 
         state.stream_sender.send(StreamResult::Data(buf)).unwrap();
     } else {

--- a/packages/serverless/Cargo.toml
+++ b/packages/serverless/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hyper = { version = "0.14", features = ["server", "http1", "http2", "runtime"] }
+hyper = { version = "0.14", features = ["server", "http1", "http2", "runtime", "stream"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7.4", features = ["rt"] }
 lagon-runtime = { path = "../runtime" }


### PR DESCRIPTION
## About

Fix a bug with response streaming. The response channel is now unbounded to send the initial response as soon as possible.
