### PR TITLE
feat(runtime): handle `fetch` errors

### DIFF
--- a/.changeset/eighty-moons-hunt.md
+++ b/.changeset/eighty-moons-hunt.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Handle fetch errors

--- a/packages/js-runtime/src/runtime/fetch.ts
+++ b/packages/js-runtime/src/runtime/fetch.ts
@@ -85,16 +85,21 @@ export async function fetch(resource: string, options?: RequestInit) {
     headers = new Map(Object.entries(options.headers));
   }
 
-  const response = await Lagon.fetch({
-    method: options?.method || 'GET',
-    url: resource,
-    body: options?.body,
-    headers,
-  });
+  try {
+    const response = await Lagon.fetch({
+      method: options?.method || 'GET',
+      url: resource,
+      body: options?.body,
+      headers,
+    });
 
-  return new Response(response.body, {
-    // url: response.options.url,
-    headers: response.headers,
-    status: response.status,
-  });
+    return new Response(response.body, {
+      // url: response.options.url,
+      headers: response.headers,
+      status: response.status,
+    });
+  } catch (error) {
+    // error is always a string
+    throw new Error(error as string);
+  }
 }

--- a/packages/runtime/src/http/request.rs
+++ b/packages/runtime/src/http/request.rs
@@ -147,8 +147,10 @@ impl FromV8 for Request {
     }
 }
 
-impl From<&Request> for http::request::Builder {
-    fn from(request: &Request) -> Self {
+impl TryFrom<&Request> for http::request::Builder {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(request: &Request) -> Result<Self, Self::Error> {
         let mut builder = HyperRequest::builder()
             .uri(&request.url)
             .method::<&str>(request.method.into());
@@ -157,14 +159,11 @@ impl From<&Request> for http::request::Builder {
 
         if let Some(headers) = &request.headers {
             for (key, value) in headers {
-                builder_headers.insert(
-                    HeaderName::from_str(key).unwrap(),
-                    HeaderValue::from_str(value).unwrap(),
-                );
+                builder_headers.insert(HeaderName::from_str(key)?, HeaderValue::from_str(value)?);
             }
         }
 
-        builder
+        Ok(builder)
     }
 }
 

--- a/packages/runtime/src/isolate/bindings/mod.rs
+++ b/packages/runtime/src/isolate/bindings/mod.rs
@@ -15,6 +15,7 @@ pub struct BindingResult {
 
 pub enum PromiseResult {
     Response(Response),
+    Error(String),
 }
 
 pub fn bind(scope: &mut v8::HandleScope<()>) -> v8::Global<v8::Context> {

--- a/packages/runtime/src/isolate/mod.rs
+++ b/packages/runtime/src/isolate/mod.rs
@@ -15,6 +15,7 @@ use v8::PromiseState;
 use crate::{
     http::{FromV8, IntoV8, Request, Response, RunResult, StreamResult},
     runtime::get_runtime_code,
+    utils::v8_string,
 };
 
 use self::bindings::{BindingResult, PromiseResult};
@@ -395,6 +396,10 @@ impl Isolate {
                     PromiseResult::Response(response) => {
                         let response = response.into_v8(scope);
                         promise.resolve(scope, response.into());
+                    }
+                    PromiseResult::Error(error) => {
+                        let error = v8_string(scope, &error).unwrap();
+                        promise.reject(scope, error.into());
                     }
                 };
             }


### PR DESCRIPTION
## About

Closes #200 

Handle `fetch` errors by rejecting the JS promise with the error. Also add tests.