### PR TITLE
feat(runtime,js-runtime,cli,examples): add Satori example

### DIFF
--- a/.changeset/small-pillows-lick.md
+++ b/.changeset/small-pillows-lick.md
@@ -1,0 +1,6 @@
+---
+'@lagon/js-runtime': patch
+'@lagon/runtime': patch
+---
+
+Add `arrayBuffer()` method to `Response`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bufstream"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1011,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "httptest"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f25cfb6def593d43fae1ead24861f217e93bc70768a45cc149a69b5f049df4"
+dependencies = [
+ "bstr",
+ "bytes",
+ "crossbeam-channel",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1252,7 @@ version = "0.1.0"
 dependencies = [
  "flume",
  "futures",
+ "httptest",
  "hyper",
  "hyper-tls",
  "tokio",
@@ -2166,6 +2200,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"

--- a/examples/satori/index.tsx
+++ b/examples/satori/index.tsx
@@ -1,7 +1,10 @@
 import satori, { init } from 'satori/wasm';
 import initYoga from 'yoga-wasm-web';
 import yogaWasm from './node_modules/yoga-wasm-web/dist/yoga.wasm';
+import React from 'react';
 
+// "Dynamic text generated as image" Vercel example:
+// https://vercel.com/docs/concepts/functions/edge-functions/og-image-examples#dynamic-text-generated-as-image
 export async function handler(request: Request): Promise<Response> {
   const getYoga = initYoga(yogaWasm);
   const yoga = await getYoga;
@@ -10,17 +13,62 @@ export async function handler(request: Request): Promise<Response> {
   const robotoArrayBuffer = await fetch(
     'https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/roboto-webfont/Roboto-Regular-webfont.ttf',
   ).then(res => res.arrayBuffer());
+
+  const { searchParams } = new URL(request.url);
+
+  // ?title=<title>
+  const hasTitle = searchParams.has('title');
+  const title = hasTitle ? searchParams.get('title')?.slice(0, 100) : 'My default title';
+
   const svg = await satori(
+    <div
+      style={{
+        backgroundColor: 'black',
+        backgroundSize: '150px 150px',
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        textAlign: 'center',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        flexWrap: 'nowrap',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          justifyItems: 'center',
+        }}
+      >
+        <img
+          alt="Vercel"
+          height={200}
+          src="data:image/svg+xml,%3Csvg width='116' height='100' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M57.5 0L115 100H0L57.5 0z' /%3E%3C/svg%3E"
+          style={{ margin: '0 30px' }}
+          width={232}
+        />
+      </div>
+      <div
+        style={{
+          fontSize: 60,
+          fontStyle: 'normal',
+          letterSpacing: '-0.025em',
+          color: 'white',
+          marginTop: 30,
+          padding: '0 120px',
+          lineHeight: 1.4,
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {title}
+      </div>
+    </div>,
     {
-      type: 'div',
-      props: {
-        children: 'hello, world',
-        style: { color: 'black' },
-      },
-    },
-    {
-      width: 600,
-      height: 400,
+      width: 1200,
+      height: 630,
       fonts: [
         {
           name: 'Roboto Regular',

--- a/examples/satori/index.tsx
+++ b/examples/satori/index.tsx
@@ -1,0 +1,40 @@
+import satori, { init } from 'satori/wasm';
+import initYoga from 'yoga-wasm-web';
+import yogaWasm from './node_modules/yoga-wasm-web/dist/yoga.wasm';
+
+export async function handler(request: Request): Promise<Response> {
+  const getYoga = initYoga(yogaWasm);
+  const yoga = await getYoga;
+  init(yoga);
+
+  const robotoArrayBuffer = await fetch(
+    'https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/roboto-webfont/Roboto-Regular-webfont.ttf',
+  ).then(res => res.arrayBuffer());
+  const svg = await satori(
+    {
+      type: 'div',
+      props: {
+        children: 'hello, world',
+        style: { color: 'black' },
+      },
+    },
+    {
+      width: 600,
+      height: 400,
+      fonts: [
+        {
+          name: 'Roboto Regular',
+          data: robotoArrayBuffer,
+          weight: 400,
+          style: 'normal',
+        },
+      ],
+    },
+  );
+
+  return new Response(svg, {
+    headers: {
+      'Content-Type': 'text/html',
+    },
+  });
+}

--- a/examples/satori/package.json
+++ b/examples/satori/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lagon/example-react-ssr",
+  "version": "0.0.1",
+  "private": true,
+  "dependencies": {
+    "@lagon/types": "workspace:0.0.1",
+    "satori": "^0.0.41",
+    "yoga-wasm-web": "^0.1.2"
+  }
+}

--- a/examples/satori/package.json
+++ b/examples/satori/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@lagon/types": "workspace:0.0.1",
+    "react": "18.1.0",
     "satori": "^0.0.41",
     "yoga-wasm-web": "^0.1.2"
   }

--- a/examples/satori/package.json
+++ b/examples/satori/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lagon/example-react-ssr",
+  "name": "@lagon/example-satori",
   "version": "0.0.1",
   "private": true,
   "dependencies": {

--- a/packages/cli/src/utils/deployments.rs
+++ b/packages/cli/src/utils/deployments.rs
@@ -68,6 +68,7 @@ fn esbuild(file: &PathBuf) -> io::Result<FileCursor> {
         .arg("--format=esm")
         .arg("--target=es2020")
         .arg("--platform=browser")
+        .arg("--loader:.wasm=binary")
         .output()?;
 
     // TODO: check status code

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -35,7 +35,7 @@ declare global {
       body?: string;
       url: string;
     }) => Promise<{
-      body: string;
+      body: Uint8Array;
       status: number;
       headers?: Record<string, string>;
     }>;

--- a/packages/js-runtime/src/runtime/encoding.ts
+++ b/packages/js-runtime/src/runtime/encoding.ts
@@ -68,7 +68,7 @@ export class TextEncoder {
 export class TextDecoder {
   encoding = 'utf-8';
 
-  decode(buffer: Iterable<number>): string {
+  decode(buffer: ArrayBuffer): string {
     const bytes = new Uint8Array(buffer);
     let pos = 0;
     const len = bytes.length;

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -12,4 +12,4 @@ hyper-tls = { version = "0.5.0", features = ["vendored"] }
 flume = "0.10.14"
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["server", "client", "http1", "http2", "tcp"] }
+httptest = "0.15.4"

--- a/packages/runtime/src/http/response.rs
+++ b/packages/runtime/src/http/response.rs
@@ -43,8 +43,11 @@ impl IntoV8 for Response {
         let response = v8::Object::new(scope);
 
         let body_key = v8_string(scope, "body").unwrap();
-        let body_value = v8::String::new(scope, std::str::from_utf8(&self.body).unwrap()).unwrap();
-        let body_value = v8::Local::new(scope, body_value);
+        let buf = self.body.to_vec();
+        let backing_store = v8::ArrayBuffer::new_backing_store_from_boxed_slice(buf.into());
+        let backing_store_shared = backing_store.make_shared();
+        let ab = v8::ArrayBuffer::with_backing_store(scope, &backing_store_shared);
+        let body_value = v8::Uint8Array::new(scope, ab, 0, self.body.len()).unwrap();
         response.set(scope, body_key.into(), body_value.into());
 
         let status_key = v8_string(scope, "status").unwrap();

--- a/packages/runtime/src/isolate/mod.rs
+++ b/packages/runtime/src/isolate/mod.rs
@@ -351,8 +351,10 @@ impl Isolate {
 
     fn poll_v8(&mut self) {
         let isolate_state = Isolate::state(&self.isolate);
-        let isolate_state = isolate_state.borrow();
-        let global = isolate_state.global.0.clone();
+        let global = {
+            let isolate_state = isolate_state.borrow();
+            isolate_state.global.0.clone()
+        };
         let scope = &mut v8::HandleScope::with_context(&mut self.isolate, global);
 
         while v8::Platform::pump_message_loop(&v8::V8::get_current_platform(), scope, false) {}
@@ -385,8 +387,10 @@ impl Isolate {
         }
 
         if let Some(promises) = promises {
-            let isolate_state = isolate_state.borrow();
-            let global = isolate_state.global.0.clone();
+            let global = {
+                let isolate_state = isolate_state.borrow();
+                isolate_state.global.0.clone()
+            };
             let scope = &mut v8::HandleScope::with_context(&mut self.isolate, global);
 
             for (result, promise) in promises {

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -1,10 +1,6 @@
-use std::{convert::Infallible, net::SocketAddr, sync::Once};
+use std::sync::Once;
 
-use hyper::{
-    body,
-    service::{make_service_fn, service_fn},
-    Body, Request as HyperRequest, Response as HyperResponse, Server,
-};
+use httptest::{matchers::*, responders::*, Expectation, Server};
 use lagon_runtime::{
     http::{Request, Response, RunResult},
     isolate::{Isolate, IsolateOptions},
@@ -16,60 +12,25 @@ fn setup() {
 
     START.call_once(|| {
         Runtime::new(RuntimeOptions::default());
-
-        let addr = SocketAddr::from(([127, 0, 0, 1], 5555));
-
-        async fn handler(req: HyperRequest<Body>) -> Result<HyperResponse<Body>, Infallible> {
-            match req.uri().to_string().as_str() {
-                "/request-method" => Ok(HyperResponse::new(req.method().to_string().into())),
-                "/request-headers" => {
-                    let mut body = req
-                        .headers()
-                        .iter()
-                        .map(|(key, value)| format!("{}: {}", key, value.to_str().unwrap()))
-                        .collect::<Vec<String>>();
-                    body.sort();
-
-                    let body = body.join(" ");
-
-                    Ok(HyperResponse::new(body.into()))
-                }
-                "/request-body" => {
-                    let body = body::to_bytes(req.into_body()).await.unwrap();
-
-                    return Ok(HyperResponse::new(Body::from(body)));
-                }
-                "/response-headers" => Ok(HyperResponse::builder()
-                    .header("x-token", "hello")
-                    .body(Body::empty())
-                    .unwrap()),
-                "/response-status" => Ok(HyperResponse::builder()
-                    .status(302)
-                    .body("Moved".into())
-                    .unwrap()),
-                _ => Ok(HyperResponse::new("Hello, World".into())),
-            }
-        }
-
-        let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handler)) });
-
-        tokio::task::spawn(async move {
-            let server = Server::bind(&addr).serve(make_svc);
-            server.await.unwrap();
-        });
     });
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn basic_fetch() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const body = await fetch('http://localhost:5555').then(res => res.text());
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(200).body("Hello, World")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const body = await fetch('{url}').then(res => res.text());
     return new Response(body);
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -82,137 +43,182 @@ async fn basic_fetch() {
 #[tokio::test(flavor = "multi_thread")]
 async fn request_method() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const body = await fetch('http://localhost:5555/request-method', {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("POST", "/"))
+            .respond_with(status_code(200).body("Hello, World")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const body = await fetch('{url}', {{
         method: 'POST'
-    }).then(res => res.text());
+    }}).then(res => res.text());
 
     return new Response(body);
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Response(Response::from("POST"))
+        RunResult::Response(Response::from("Hello, World"))
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn request_method_fallback() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const body = await fetch('http://localhost:5555/request-method', {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(200).body("Hello, World")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const body = await fetch('{url}', {{
         method: 'UNKNOWN'
-    }).then(res => res.text());
+    }}).then(res => res.text());
 
     return new Response(body);
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Response(Response::from("GET"))
+        RunResult::Response(Response::from("Hello, World"))
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn request_headers() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const body = await fetch('http://localhost:5555/request-headers', {
-        headers: {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/"),
+            request::headers(contains(("x-token", "hello")))
+        ])
+        .respond_with(status_code(200).body("Hello, World")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const body = await fetch('{url}', {{
+        headers: {{
             'x-token': 'hello'
-        }
-    }).then(res => res.text());
+        }}
+    }}).then(res => res.text());
 
     return new Response(body);
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Response(Response::from("host: localhost:5555 x-token: hello"))
+        RunResult::Response(Response::from("Hello, World"))
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn request_headers_class() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const body = await fetch('http://localhost:5555/request-headers', {
-        headers: new Headers({
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("GET", "/"),
+            request::headers(contains(("x-token", "hello")))
+        ])
+        .respond_with(status_code(200).body("Hello, World")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const body = await fetch('{url}', {{
+        headers: new Headers({{
             'x-token': 'hello'
-        })
-    }).then(res => res.text());
+        }})
+    }}).then(res => res.text());
 
     return new Response(body);
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Response(Response::from("host: localhost:5555 x-token: hello"))
+        RunResult::Response(Response::from("Hello, World"))
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn request_body() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const body = await fetch('http://localhost:5555/request-body', {
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(all_of![
+            request::method_path("POST", "/"),
+            request::body("Hello!")
+        ])
+        .respond_with(status_code(200).body("Hello, World")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const body = await fetch('{url}', {{
         method: 'POST',
         body: 'Hello!'
-    }).then(res => res.text());
+    }}).then(res => res.text());
 
     return new Response(body);
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Response(Response::from("Hello!"))
+        RunResult::Response(Response::from("Hello, World"))
     );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn response_headers() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const response = await fetch('http://localhost:5555/response-headers');
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(200).insert_header("x-token", "hello")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const response = await fetch('{url}');
     const body = [];
 
-    for (const [key, value] of response.headers.entries()) {
+    for (const [key, value] of response.headers.entries()) {{
         // The date is different at each call so we skip it
         if (key === 'date') continue;
 
-        body.push(`${key}: ${value}`);
-    }
-    
+        body.push(`${{key}}: ${{value}}`);
+    }}
+
     return new Response(body.sort((a, b) => a.localeCompare(b)).join(' '));
-}"
-        .into(),
-    ));
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -225,15 +231,21 @@ async fn response_headers() {
 #[tokio::test(flavor = "multi_thread")]
 async fn response_status() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
-    const response = await fetch('http://localhost:5555/response-status');
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(302).body("Moved")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const response = await fetch('{url}');
     const body = await response.text();
 
-    return new Response(`${body}: ${response.status}`);
-}"
-        .into(),
-    ));
+    return new Response(`${{body}}: ${{response.status}}`);
+}}"
+    )));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,10 +144,12 @@ importers:
   examples/satori:
     specifiers:
       '@lagon/types': workspace:0.0.1
+      react: 18.1.0
       satori: ^0.0.41
       yoga-wasm-web: ^0.1.2
     dependencies:
       '@lagon/types': link:../../packages/types
+      react: 18.1.0
       satori: 0.0.41
       yoga-wasm-web: 0.1.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,16 @@ importers:
     dependencies:
       '@lagon/types': link:../../packages/types
 
+  examples/satori:
+    specifiers:
+      '@lagon/types': workspace:0.0.1
+      satori: ^0.0.41
+      yoga-wasm-web: ^0.1.2
+    dependencies:
+      '@lagon/types': link:../../packages/types
+      satori: 0.0.41
+      yoga-wasm-web: 0.1.2
+
   packages/astro:
     specifiers:
       astro: 1.0.0-rc.7
@@ -4274,6 +4284,15 @@ packages:
       - supports-color
     dev: false
 
+  /@shuding/opentype.js/1.4.0-beta.0:
+    resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+    dependencies:
+      fflate: 0.7.4
+      string.prototype.codepointat: 0.2.1
+    dev: false
+
   /@storybook/addon-actions/6.5.9_ef5jwxihqo6n7gxfmzogljlgcm:
     resolution: {integrity: sha512-wDYm3M1bN+zcYZV3Q24M03b/P8DDpvj1oSoY6VLlxDAi56h8qZB/voeIS2I6vWXOB79C5tbwljYNQO0GsufS0g==}
     peerDependencies:
@@ -6135,6 +6154,10 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
+  /@types/yoga-layout/1.9.2:
+    resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
+    dev: false
+
   /@typescript-eslint/eslint-plugin/5.30.5_6zdoc3rn4mpiddqwhppni2mnnm:
     resolution: {integrity: sha512-lftkqRoBvc28VFXEoRgyZuztyVUQ04JvUnATSPtIRFAccbXTWL6DEtXGYMcbg998kXw1NLUJm7rTQ9eUt+q6Ig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7766,6 +7789,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /camelize/1.0.1:
+    resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
+    dev: false
+
   /caniuse-lite/1.0.30001363:
     resolution: {integrity: sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==}
 
@@ -8429,6 +8456,19 @@ packages:
       randomfill: 1.0.4
     dev: true
 
+  /css-background-parser/0.1.0:
+    resolution: {integrity: sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==}
+    dev: false
+
+  /css-box-shadow/1.0.0-3:
+    resolution: {integrity: sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==}
+    dev: false
+
+  /css-color-keywords/1.0.0:
+    resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
+    engines: {node: '>=4'}
+    dev: false
+
   /css-loader/3.6.0:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
@@ -8500,6 +8540,14 @@ packages:
       domutils: 2.8.0
       nth-check: 2.1.1
     dev: true
+
+  /css-to-react-native/3.0.0:
+    resolution: {integrity: sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==}
+    dependencies:
+      camelize: 1.0.1
+      css-color-keywords: 1.0.0
+      postcss-value-parser: 4.2.0
+    dev: false
 
   /css-what/6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
@@ -9993,6 +10041,10 @@ packages:
 
   /fflate/0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+    dev: false
+
+  /fflate/0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
     dev: false
 
   /figgy-pudding/3.5.2:
@@ -14547,7 +14599,6 @@ packages:
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-    dev: true
 
   /postcss/7.0.39:
     resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==}
@@ -15788,6 +15839,18 @@ packages:
       - supports-color
     dev: true
 
+  /satori/0.0.41:
+    resolution: {integrity: sha512-AOkOxeZeDCrBJc+JZHcpWs5b7CEoLhWR5/RWhBblAZ0yKi1BNzepUzfPHz5JuYcjES2V3yVIlPVdxrumTe+gyA==}
+    engines: {node: '>=16'}
+    dependencies:
+      '@shuding/opentype.js': 1.4.0-beta.0
+      css-background-parser: 0.1.0
+      css-box-shadow: 1.0.0-3
+      css-to-react-native: 3.0.0
+      postcss-value-parser: 4.2.0
+      yoga-layout-prebuilt: 1.10.0
+    dev: false
+
   /scheduler/0.22.0:
     resolution: {integrity: sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==}
     dependencies:
@@ -16340,6 +16403,10 @@ packages:
       emoji-regex: 9.2.2
       strip-ansi: 7.0.1
     dev: true
+
+  /string.prototype.codepointat/0.2.1:
+    resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+    dev: false
 
   /string.prototype.matchall/4.0.7:
     resolution: {integrity: sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==}
@@ -18354,6 +18421,17 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /yoga-layout-prebuilt/1.10.0:
+    resolution: {integrity: sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/yoga-layout': 1.9.2
+    dev: false
+
+  /yoga-wasm-web/0.1.2:
+    resolution: {integrity: sha512-8SkgawHcA0RUbMrnhxbaQkZDBi8rMed8pQHixkFF9w32zGhAwZ9/cOHWlpYfr6RCx42Yp3siV45/jPEkJxsk6w==}
+    dev: false
 
   /zod/3.17.3:
     resolution: {integrity: sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==}


### PR DESCRIPTION
## About

Add [Satori](https://github.com/vercel/satori) example. Required a few changes:

### CLI
- Add esbuild binary loader for `.wasm`

### Runtime
- Response body is converted to `Uint8Array` instead of trying to parse to a UTF string, which might fail
- Drop the isolate state when possible after cloning global

### JS Runtime
- Response body is now a `string | ArrayBuffer`
- Add the `arrayBuffer()` method on Response