### PR TITLE
feat(js-runtime): printf-like formatting for `console.*`

### DIFF
--- a/.changeset/fresh-pots-travel.md
+++ b/.changeset/fresh-pots-travel.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+printf-like formatting for console.\*

--- a/packages/js-runtime/src/__tests__/console.test.ts
+++ b/packages/js-runtime/src/__tests__/console.test.ts
@@ -40,19 +40,149 @@ describe('Console', () => {
     expect(Lagon.log).toHaveBeenCalledWith('[log] {"hello":"world","nested":{"hello":"world"}}');
   });
 
+  it('should log numbers', () => {
+    console.log(42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] 42');
+
+    console.log(42.42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] 42.42');
+  });
+
+  it('should log booleans', () => {
+    console.log(true);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] true');
+
+    console.log(false);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] false');
+  });
+
+  it('should log undefined and null', () => {
+    console.log(undefined);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] undefined');
+
+    console.log(null);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] null');
+  });
+
   it('should log arrays', () => {
     console.log(['hello', 'world']);
 
     expect(Lagon.log).toHaveBeenCalledWith('[log] ["hello","world"]');
   });
 
-  // TODO: test callbacks and functions
   it('should log functions', () => {
+    console.log(function () {
+      return 'Hello World';
+    });
+
+    expect(Lagon.log).toHaveBeenCalledWith('[log] [Function]');
+  });
+
+  it('should log callbacks', () => {
     console.log(() => {
       return 'Hello World';
     });
 
-    // TODO: should log function
-    expect(Lagon.log).toHaveBeenCalledWith('[log] undefined');
+    expect(Lagon.log).toHaveBeenCalledWith('[log] [Function]');
+  });
+
+  it('should log objects with toString', () => {
+    console.log(new Error('Hello World'));
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Error: Hello World');
+
+    class Empty {
+      toString() {
+        return 'Hello World';
+      }
+    }
+
+    console.log(new Empty());
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello World');
+  });
+
+  it('should format multiple strings', () => {
+    console.log('Hello', 'World');
+
+    expect(Lagon.log).toHaveBeenCalledWith('[log] Hello World');
+  });
+
+  it('should format multiple strings and objects', () => {
+    console.log('Hello', {
+      value: 'World',
+    });
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello {"value":"World"}');
+
+    console.log(
+      'Hello',
+      {
+        value: 'World',
+      },
+      42,
+      undefined,
+    );
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello {"value":"World"} 42 undefined');
+  });
+
+  it('should format printf like string', () => {
+    console.log('Hello %s', 'World');
+
+    expect(Lagon.log).toHaveBeenCalledWith('[log] Hello World');
+  });
+
+  it('should format printf like numbers', () => {
+    console.log('Hello %d', 42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello 42');
+
+    console.log('Hello %d', 42.42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello 42.42');
+  });
+
+  it('should format printf like integers', () => {
+    console.log('Hello %i', 42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello 42');
+
+    console.log('Hello %i', 42.42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello 42');
+  });
+
+  it('should format printf like floats', () => {
+    console.log('Hello %f', 42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello 42');
+
+    console.log('Hello %f', 42.42);
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello 42.42');
+  });
+
+  it('should format printf like objects', () => {
+    console.log('Hello %o', {
+      value: 'World',
+    });
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello {"value":"World"}');
+
+    console.log('Hello %O', {
+      value: 'World',
+    });
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello {"value":"World"}');
+
+    console.log('Hello %j', {
+      value: 'World',
+    });
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello {"value":"World"}');
+  });
+
+  it('should format print like multiple times', () => {
+    console.log('Hello %s, this is the %i test of printing %j', 'World', 42, {
+      value: 'World',
+    });
+
+    expect(Lagon.log).toHaveBeenCalledWith('[log] Hello World, this is the 42 test of printing {"value":"World"}');
+  });
+
+  it('should format print like with fallback', () => {
+    console.log('Hello %s, this is the %i test of printing %j', 'World');
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello World, this is the %i test of printing %j');
+
+    console.log('Hello %s, this is the %i test of printing %j');
+    expect(Lagon.log).toHaveBeenLastCalledWith('[log] Hello %s, this is the %i test of printing %j');
   });
 });

--- a/packages/js-runtime/src/runtime/console.ts
+++ b/packages/js-runtime/src/runtime/console.ts
@@ -1,27 +1,83 @@
 (globalThis => {
-  const format = (...args: unknown[]): string => {
-    let str = '';
+  const inspect = (input: unknown): string => {
+    if (typeof input === 'string') {
+      return input;
+    } else if (typeof input === 'number' || typeof input === 'boolean') {
+      return String(input);
+    } else if (typeof input === 'function') {
+      return '[Function]';
+    } else if (input === undefined || input === null) {
+      return input === undefined ? 'undefined' : 'null';
+    } else {
+      const result = JSON.stringify(input);
 
-    for (let i = 0; i < args.length; i++) {
-      str += ' ';
+      if (result === '{}' && typeof input === 'object' && 'toString' in input) {
+        return input.toString();
+      }
 
-      const arg = args[i];
+      return result;
+    }
+  };
 
-      if (typeof arg === 'string') {
-        str += arg;
-      } else {
-        str += JSON.stringify(arg);
+  const format = (input: unknown, ...args: unknown[]): string => {
+    const result: string[] = [];
+
+    if (typeof input !== 'string') {
+      result.push(inspect(input));
+
+      for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        result.push(inspect(arg));
+      }
+    } else {
+      let i = 0;
+
+      result.push(
+        input.replace(/%[sdifjoOc%]/g, match => {
+          const arg = args[i++];
+
+          if (!arg) {
+            return match;
+          }
+
+          switch (match) {
+            case '%s':
+              return String(arg);
+            case '%d':
+              return String(Number(arg));
+            case '%i':
+              return String(parseInt(arg as string, 10));
+            case '%f':
+              return String(parseFloat(arg as string));
+            case '%j':
+            case '%o':
+            case '%O':
+              return JSON.stringify(arg);
+            case '%%':
+              return '%';
+            case '%c':
+            default:
+              return match;
+          }
+        }),
+      );
+
+      for (let j = i; j < args.length; j++) {
+        const arg = args[j];
+
+        result.push(inspect(arg));
       }
     }
 
-    return str;
+    return result.join(' ');
   };
 
   const types = ['log', 'info', 'debug', 'error', 'warn'] as const;
 
   types.forEach(type => {
-    globalThis.console[type] = (...args: unknown[]) => {
-      Lagon.log(`[${type}]${format(...args)}`);
+    globalThis.console[type] = (input: unknown, ...args: unknown[]) => {
+      Lagon.log(`[${type}] ${format(input, ...args)}`);
     };
   });
 })(globalThis);


### PR DESCRIPTION
## About

Following Node.js [`util.format`](https://nodejs.org/api/util.html#utilformatformat-args) (which is used behind the scene for `console.*`), this PR implements almost the same behavior, except:
- `%j`, `%o`, `%O` all fallbacks to `JSON.stringify()`
- '%c' is completely ignored

Also add tests to cover the new cases.
