### PR TITLE
fix(serverless): Axiom logger

### DIFF
--- a/.changeset/angry-fans-live.md
+++ b/.changeset/angry-fans-live.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Fix Axiom logger

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "axiom-rs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6626ba177a8fe68b3a1c3be1c7011eecfd82fe306b65a52054d0cd9d0873f1"
+checksum = "f6f23438d5a370b25fdd40449ba1f5d93319f59171f1007dc674a2cfc44b4e25"
 dependencies = [
  "backoff",
  "bytes",
@@ -144,6 +144,7 @@ dependencies = [
  "serde_qs",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
 ]

--- a/packages/serverless/Cargo.toml
+++ b/packages/serverless/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 metrics = "0.20.1"
 metrics-exporter-prometheus = { version = "0.11.0", features = ["http-listener"] }
 log = { version = "0.4.17", features = ["std"] }
-axiom-rs = "0.5.0"
+axiom-rs = "0.6.0"
 chrono = "0.4.22"
 lazy_static = "1.4.0"
 rand = { version = "0.8.5", features = ["std_rng"] }

--- a/packages/serverless/src/logger.rs
+++ b/packages/serverless/src/logger.rs
@@ -19,11 +19,9 @@ impl SimpleLogger {
         match Client::new() {
             Ok(axiom_client) => {
                 tokio::spawn(async move {
-                    // TODO: batch values
-                    let value = rx.recv().unwrap();
                     axiom_client
                         .datasets
-                        .ingest("serverless", vec![value])
+                        .ingest_stream("serverless", rx.into_stream())
                         .await
                         .unwrap();
                 });
@@ -51,7 +49,7 @@ impl Log for SimpleLogger {
                 self.tx
                     .send(json!({
                         "region": dotenv::var("LAGON_REGION").expect("LAGON_REGION must be set"),
-                        "timestamp": Local::now().to_rfc3339(),
+                        "_time": Local::now().to_rfc3339(),
                         "level": record.level().to_string(),
                         "message": record.args().to_string(),
                     }))

--- a/packages/serverless/src/logger.rs
+++ b/packages/serverless/src/logger.rs
@@ -27,7 +27,7 @@ impl SimpleLogger {
                 });
             }
             Err(e) => {
-                warn!("Axiom is not configured: {}", e);
+                println!("Axiom is not configured: {}", e);
             }
         }
 

--- a/packages/serverless/src/logger.rs
+++ b/packages/serverless/src/logger.rs
@@ -68,7 +68,7 @@ impl Log for SimpleLogger {
     }
 }
 
-pub struct FlushGuard {}
+pub struct FlushGuard;
 
 impl Drop for FlushGuard {
     fn drop(&mut self) {
@@ -78,5 +78,5 @@ impl Drop for FlushGuard {
 
 pub fn init_logger() -> Result<FlushGuard, SetLoggerError> {
     set_boxed_logger(Box::new(SimpleLogger::new())).map(|()| set_max_level(LevelFilter::Info))?;
-    Ok(FlushGuard {})
+    Ok(FlushGuard)
 }

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -219,7 +219,7 @@ async fn handle_request(
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().expect("Failed to load .env file");
-    init_logger().expect("Failed to init logger");
+    let _flush_guard = init_logger().expect("Failed to init logger");
 
     let runtime = Runtime::new(RuntimeOptions::default());
     let addr = SocketAddr::from(([0, 0, 0, 0], 4000));


### PR DESCRIPTION
Hey everyone, this project looks exciting! I've noticed you're using Axiom so I fixed the logger for you, hope that's alright 😊 

## About

This PR fixes a bug where only the first log event would've been sent to Axiom. 
Instead of grabbing the first value from the receiver, it turns the receiver into an async stream and passes it to `ingest_stream` for ingestion.
There's more things that can be improved (e.g. `ingest_stream` should log errors and restart instead of panicking on error) but this is meant to be a first step.

It also changes the way Axiom is detected to using the client constructor which will automatically configure from environment variables.

And it renames the `timestamp` field name to `_time` so it's properly detected by Axiom.

Please let me know if you have any questions regarding Axiom, adding support for the `log` crate is already on our list 😁 