### PR TITLE
feat(cli,serverless): forward client IP through `X-Forwarded-For` header

### DIFF
--- a/.changeset/kind-boats-attack.md
+++ b/.changeset/kind-boats-attack.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Forward client IP through X-Forwarded-For header

--- a/packages/runtime/src/http/request.rs
+++ b/packages/runtime/src/http/request.rs
@@ -200,4 +200,10 @@ impl Request {
             url,
         }
     }
+
+    pub fn add_header(&mut self, key: String, value: String) {
+        if let Some(ref mut headers) = self.headers {
+            headers.insert(key, value);
+        }
+    }
 }

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -10,7 +10,7 @@ use lagon_runtime::isolate::{Isolate, IsolateOptions};
 use lagon_runtime::runtime::{Runtime, RuntimeOptions};
 use lazy_static::lazy_static;
 use log::error;
-use metrics::{counter, /*histogram,*/ increment_counter};
+use metrics::increment_counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use mysql::{Opts, Pool};
 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
## About

Closes #209 

Forward client IP address through `X-Forwarded-For` header for both CLI and serverless.

Example:
```ts
export function handler(request: Request): Response {
  return new Response('My IP is: ' + request.headers.get('X-Forwarded-For'));
}
```
