### PR TITLE
feat(serverless): add LRU time cache for isolates

### DIFF
--- a/.changeset/few-foxes-cheat.md
+++ b/.changeset/few-foxes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Add configurable LRU time cache for isolates

--- a/.changeset/tender-walls-tap.md
+++ b/.changeset/tender-walls-tap.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Add on_drop callback and properly handle isolate termination

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "lagon-runtime",
  "lazy_static",
  "log",
+ "lru_time_cache",
  "metrics",
  "metrics-exporter-prometheus",
  "mysql",
@@ -1439,6 +1440,12 @@ checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown",
 ]
+
+[[package]]
+name = "lru_time_cache"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "mach"

--- a/packages/serverless/.env.example
+++ b/packages/serverless/.env.example
@@ -1,8 +1,7 @@
 LAGON_TOKEN=
 LAGON_ROOT_DOMAIN=lagon.app
 LAGON_REGION=
-SENTRY_DSN=
-SENTRY_ENVIRONMENT=development
+LAGON_ISOLATES_CACHE_SECONDS=60
 
 DATABASE_URL=mysql://root:mysql@localhost:3306/lagon
 REDIS_URL=redis://localhost:6379

--- a/packages/serverless/Cargo.toml
+++ b/packages/serverless/Cargo.toml
@@ -21,3 +21,4 @@ axiom-rs = "0.6.0"
 chrono = "0.4.22"
 lazy_static = "1.4.0"
 rand = { version = "0.8.5", features = ["std_rng"] }
+lru_time_cache = "0.11.11"


### PR DESCRIPTION
## About

Add configurable LRU time cache (aka [TLRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Time_aware_least_recently_used_(TLRU))) for isolates. It's configurable via the `LAGON_ISOLATES_CACHE_SECONDS` environment variables, and is set by default to 60 seconds for development.
