### PR TITLE
fix(js-runtime): allow no-args constructor for Response

### DIFF
--- a/.changeset/beige-ways-visit.md
+++ b/.changeset/beige-ways-visit.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+Allow null and undefined as the first argument of the Response constructor

--- a/packages/js-runtime/src/__tests__/fetch.test.ts
+++ b/packages/js-runtime/src/__tests__/fetch.test.ts
@@ -199,3 +199,28 @@ describe('fetch', () => {
     });
   });
 });
+
+describe('Response', () => {
+  it('should instanciate without arguments', async () => {
+    const response = new Response();
+    expect(await response.text()).toEqual('');
+  });
+
+  it('should instanciate with text body', () => {
+    const response = new Response('Hello');
+    expect(response).toBeDefined();
+  });
+
+  it('should instanciate with init', async () => {
+    const response = new Response('Hello', {
+      status: 404,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+    expect(response).toBeDefined();
+    expect(response.status).toEqual(404);
+    expect(response.headers.get('Content-Type')).toEqual('text/plain');
+    expect(await response.text()).toEqual('Hello');
+  });
+});

--- a/packages/js-runtime/src/runtime/Response.ts
+++ b/packages/js-runtime/src/runtime/Response.ts
@@ -8,14 +8,14 @@ export interface ResponseInit {
 }
 
 export class Response {
-  body: string | ArrayBuffer;
+  body: string | ArrayBuffer | null;
   headers: Headers;
   ok: boolean;
   status: number;
   statusText: string;
   url: string;
 
-  constructor(body: string | ArrayBuffer, options?: ResponseInit) {
+  constructor(body: string | ArrayBuffer | null = null, options?: ResponseInit) {
     this.body = body;
 
     if (options?.headers) {
@@ -44,7 +44,7 @@ export class Response {
       return globalThis.__lagon__.TEXT_DECODER.decode(this.body);
     }
 
-    return this.body;
+    return this.body || '';
   }
 
   async json<T>(): Promise<T> {
@@ -64,6 +64,6 @@ export class Response {
       return this.body;
     }
 
-    return globalThis.__lagon__.TEXT_ENCODER.encode(this.body);
+    return this.body ? globalThis.__lagon__.TEXT_ENCODER.encode(this.body) : new ArrayBuffer(0);
   }
 }


### PR DESCRIPTION
This PR implements `new Response()` with no arguments and `new Response(null)` as required [by the spec](https://fetch.spec.whatwg.org/#ref-for-dom-response%E2%91%A0) and adds a few tests for the Response constructor. 
