### PR TITLE
fix(js-runtime): include non-default port in URL's origin property

### DIFF
--- a/.changeset/afraid-fireants-flash.md
+++ b/.changeset/afraid-fireants-flash.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+URL class now includes non-default port in its origin property

--- a/packages/js-runtime/src/__tests__/url.test.ts
+++ b/packages/js-runtime/src/__tests__/url.test.ts
@@ -194,6 +194,17 @@ describe('URL', () => {
     it('should return the origin for blob', () => {
       expect(new URL('blob:https://mozilla.org:443/').origin).toEqual('https://mozilla.org');
     });
+
+    it('should strip default port', () => {
+      expect(new URL('https://mozilla.org:443/index.html?foo=bar&bar=foo#boo').port).toEqual('');
+      expect(new URL('https://mozilla.org:443/index.html?foo=bar&bar=foo#boo').origin).toEqual('https://mozilla.org');
+    });
+
+    it('should include non-default port in origin', () => {
+      expect(new URL('http://mozilla.org:1234/index.html?foo=bar&bar=foo#boo').origin).toEqual(
+        'http://mozilla.org:1234',
+      );
+    });
   });
 
   describe('password', () => {

--- a/packages/js-runtime/src/runtime/URL.ts
+++ b/packages/js-runtime/src/runtime/URL.ts
@@ -1,3 +1,12 @@
+// From https://url.spec.whatwg.org/#url-miscellaneous
+const DEFAULT_PORTS: Record<string, string> = {
+  'ftp:': '21',
+  'http:': '80',
+  'https:': '443',
+  'ws:': '80',
+  'wss:': '443',
+};
+
 export class URLSearchParams {
   private params: Map<string, string[]> = new Map();
 
@@ -141,13 +150,17 @@ export class URL {
       this.hostname = hostname;
       this.href = href;
 
+      this.port = port === DEFAULT_PORTS[protocol] ? '' : port;
+
       if (['http:', 'https:'].includes(protocol) || ['blob:', 'file:'].includes(origin)) {
         this.origin = protocol + '//' + hostname;
+        if (this.port) {
+          this.origin += ':' + this.port;
+        }
       }
 
       this.password = password;
       this.pathname = pathname === '' ? '/' : pathname;
-      this.port = port;
       this.protocol = protocol;
       this.search = search;
       this.searchParams = new URLSearchParams(search);


### PR DESCRIPTION
## About

This PR appends a port number to the `origin` property of the `URL` class when using a non-default port number and adds a test case for it.