### PR TITLE
refactor(serverless): add more context to logs

### DIFF
--- a/.changeset/flat-nails-hunt.md
+++ b/.changeset/flat-nails-hunt.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Add more context to logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe7fe9d71fc403a41672475b8895d6b817cac0fe23c471e01d36f5af503008c"
 dependencies = [
  "snailquote",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1432,6 +1451,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "serde",
+ "value-bag",
 ]
 
 [[package]]
@@ -2458,6 +2479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2963a69a2b3918c1dc75a45a18bd3fcd1120e31d3f59deb1b2f9b5d5ffb8baa4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2655,15 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
+name = "sval"
+version = "1.0.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "syn"
@@ -2941,6 +2980,20 @@ dependencies = [
  "lazy_static",
  "libc",
  "which",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+ "sval",
+ "version_check",
 ]
 
 [[package]]

--- a/packages/serverless/Cargo.toml
+++ b/packages/serverless/Cargo.toml
@@ -16,7 +16,7 @@ redis = { version = "0.21.6", features = ["tls"] }
 serde_json = "1.0"
 metrics = "0.20.1"
 metrics-exporter-prometheus = { version = "0.11.0", features = ["http-listener"] }
-log = { version = "0.4.17", features = ["std"] }
+log = { version = "0.4.17", features = ["std", "kv_unstable", "kv_unstable_serde"] }
 axiom-rs = "0.6.0"
 chrono = "0.4.22"
 lazy_static = "1.4.0"

--- a/packages/serverless/src/deployments/filesystem.rs
+++ b/packages/serverless/src/deployments/filesystem.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs, path::Path};
@@ -34,11 +35,10 @@ pub fn get_deployment_code(deployment: &Deployment) -> Result<String> {
 }
 
 pub fn write_deployment(deployment_id: &str, buf: &[u8]) -> Result<()> {
-    let mut file =
-        fs::File::create(Path::new("deployments").join(deployment_id.to_owned() + ".js"))?;
+    let mut file = File::create(Path::new("deployments").join(deployment_id.to_owned() + ".js"))?;
 
     file.write_all(buf)?;
-    info!("Wrote deployment: {}", deployment_id);
+    info!(deployment = deployment_id; "Wrote deployment");
 
     Ok(())
 }
@@ -53,10 +53,10 @@ pub fn write_deployment_asset(deployment_id: &str, asset: &str, buf: &[u8]) -> R
     fs::create_dir_all(dir)?;
 
     let mut file =
-        fs::File::create(Path::new("deployments").join(deployment_id.to_owned() + "/" + asset))?;
+        File::create(Path::new("deployments").join(deployment_id.to_owned() + "/" + asset))?;
 
     file.write_all(buf)?;
-    info!("Wrote deployment ({}) asset: {}", deployment_id, asset);
+    info!(deployment = deployment_id, asset = asset; "Wrote deployment asset");
 
     Ok(())
 }
@@ -66,7 +66,7 @@ pub fn rm_deployment(deployment_id: &str) -> Result<()> {
 
     // It's possible that the folder doesn't exists if the deployment has no assets
     fs::remove_dir_all(Path::new("deployments").join(deployment_id)).unwrap_or(());
-    info!("Deleted deployment: {}", deployment_id);
+    info!(deployment = deployment_id; "Deleted deployment");
 
     Ok(())
 }

--- a/packages/serverless/src/deployments/mod.rs
+++ b/packages/serverless/src/deployments/mod.rs
@@ -152,9 +152,9 @@ pub async fn get_deployments(
         for deployment in deployments_list {
             if !has_deployment_code(&deployment) {
                 if let Err(error) = download_deployment(&deployment, &bucket).await {
-                    error!(
-                        "Failed to download deployment ({}): {:?}",
-                        deployment.id, error
+                    error!(deployment = deployment.id;
+                        "Failed to download deployment: {:?}",
+                        error
                     );
                 }
             }

--- a/packages/serverless/src/deployments/pubsub.rs
+++ b/packages/serverless/src/deployments/pubsub.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Result;
-use log::error;
+use log::{error, warn};
 use s3::Bucket;
 use serde_json::Value;
 use tokio::{sync::RwLock, task::JoinHandle};
@@ -82,10 +82,10 @@ pub fn listen_pub_sub(
 
                             clear_deployments_cache(&domains).await;
                         }
-                        Err(err) => {
+                        Err(error) => {
                             error!(
-                                "Failed to download deployment ({}): {:?}",
-                                deployment.id, err
+                                deployment = deployment.id;
+                                "Failed to download deployment: {}", error
                             );
                         }
                     };
@@ -102,8 +102,8 @@ pub fn listen_pub_sub(
 
                             clear_deployments_cache(&domains).await;
                         }
-                        Err(err) => {
-                            error!("Failed to delete deployment ({}): {:?}", deployment.id, err);
+                        Err(error) => {
+                            error!(deployment = deployment.id; "Failed to delete deployment: {}", error);
                         }
                     };
                 }
@@ -132,7 +132,7 @@ pub fn listen_pub_sub(
 
                     clear_deployments_cache(&domains).await;
                 }
-                _ => error!("Unknown channel: {}", channel),
+                _ => warn!("Unknown channel: {}", channel),
             };
         }
     })


### PR DESCRIPTION
## About

Add more context to logs using the [KV feature of log](https://docs.rs/log/latest/log/kv/index.html). This allows us to pass context like deployment id, request... to logs, and transfer them to Axiom.