### PR TITLE
refactor(runtime,serverless): add functions statistics and fix timeout

### DIFF
--- a/.changeset/mighty-turkeys-joke.md
+++ b/.changeset/mighty-turkeys-joke.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Properly timeout and terminate long-running functions

--- a/.changeset/polite-ducks-scream.md
+++ b/.changeset/polite-ducks-scream.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+---
+
+Add functions statistics

--- a/packages/cli/src/commands/dev.rs
+++ b/packages/cli/src/commands/dev.rs
@@ -96,7 +96,7 @@ async fn handle_request(
             Ok(mut request) => {
                 request.add_header("X-Forwarded-For".into(), ip);
 
-                let mut isolate = Isolate::new(
+                let mut isolate = Isolate::<()>::new(
                     IsolateOptions::new(String::from_utf8(index.get_ref().to_vec())?)
                         .with_environment_variables(environment_variables),
                 );

--- a/packages/cli/src/commands/dev.rs
+++ b/packages/cli/src/commands/dev.rs
@@ -92,26 +92,25 @@ async fn handle_request(
             .await
             .unwrap_or(());
     } else {
-        let maybe_request = Request::from_hyper(req).await;
+        match Request::from_hyper(req).await {
+            Ok(mut request) => {
+                request.add_header("X-Forwarded-For".into(), ip);
 
-        if let Err(ref error) = maybe_request {
-            println!("Error while parsing request: {}", error);
+                let mut isolate = Isolate::new(
+                    IsolateOptions::new(String::from_utf8(index.get_ref().to_vec())?)
+                        .with_environment_variables(environment_variables),
+                );
 
-            tx.send_async(RunResult::Error("Error while parsing request".into()))
-                .await
-                .unwrap_or(());
-        }
+                isolate.run(request, tx).await;
+            }
+            Err(error) => {
+                println!("Error while parsing request: {}", error);
 
-        // Now it's safe to unwrap() since we checked for errors above
-        let mut request = maybe_request.unwrap();
-        request.add_header("X-Forwarded-For".into(), ip);
-
-        let mut isolate = Isolate::new(
-            IsolateOptions::new(String::from_utf8(index.get_ref().to_vec())?)
-                .with_environment_variables(environment_variables),
-        );
-
-        isolate.run(request, tx).await;
+                tx.send_async(RunResult::Error("Error while parsing request".into()))
+                    .await
+                    .unwrap_or(());
+            }
+        };
     }
 
     let result = rx.recv_async().await?;

--- a/packages/cli/src/utils/deployments.rs
+++ b/packages/cli/src/utils/deployments.rs
@@ -127,12 +127,12 @@ pub fn bundle_function(
         );
         let end_progress = print_progress(&msg);
 
-        for file in WalkDir::new(&public_dir) {
+        for file in WalkDir::new(public_dir) {
             let file = file?;
             let path = file.path();
 
             if path.is_file() {
-                let diff = diff_paths(path, &public_dir)
+                let diff = diff_paths(path, public_dir)
                     .unwrap()
                     .to_str()
                     .unwrap()

--- a/packages/runtime/src/isolate/bindings/fetch.rs
+++ b/packages/runtime/src/isolate/bindings/fetch.rs
@@ -17,7 +17,7 @@ pub fn fetch_binding(
     let promise = v8::PromiseResolver::new(scope).unwrap();
     retval.set(promise.into());
 
-    let state = Isolate::state(scope);
+    let state = Isolate::<()>::state(scope);
     let mut state = state.borrow_mut();
     let id = state.js_promises.len() + 1;
 

--- a/packages/runtime/src/isolate/bindings/pull_stream.rs
+++ b/packages/runtime/src/isolate/bindings/pull_stream.rs
@@ -5,7 +5,7 @@ pub fn pull_stream_binding(
     args: v8::FunctionCallbackArguments,
     mut _retval: v8::ReturnValue,
 ) {
-    let isolate_state = Isolate::state(scope);
+    let isolate_state = Isolate::<()>::state(scope);
     let state = isolate_state.borrow();
 
     let done = args.get(0).to_boolean(scope);

--- a/packages/runtime/src/runtime/mod.rs
+++ b/packages/runtime/src/runtime/mod.rs
@@ -42,9 +42,9 @@ impl Runtime {
     }
 }
 
-pub fn get_runtime_code<'a>(
+pub fn get_runtime_code<'a, T: Clone>(
     scope: &mut v8::HandleScope<'a>,
-    options: &IsolateOptions,
+    options: &IsolateOptions<T>,
 ) -> v8::Local<'a, v8::String> {
     let IsolateOptions {
         code,

--- a/packages/runtime/tests/errors.rs
+++ b/packages/runtime/tests/errors.rs
@@ -18,7 +18,7 @@ fn setup() {
 #[tokio::test(flavor = "multi_thread")]
 async fn handler_reject() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     throw new Error('Rejected');
 }"
@@ -36,7 +36,7 @@ async fn handler_reject() {
 #[tokio::test(flavor = "multi_thread")]
 async fn compilation_error() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     this syntax is invalid
 }"
@@ -57,7 +57,7 @@ async fn compilation_error() {
 #[tokio::test(flavor = "multi_thread")]
 async fn import_errors() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "import test from 'test';
 
 export function handler() {
@@ -80,7 +80,7 @@ export function handler() {
 #[tokio::test(flavor = "multi_thread")]
 async fn execution_timeout_reached() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     while(true) {}
     return new Response('Should not be reached');
@@ -96,7 +96,7 @@ async fn execution_timeout_reached() {
 #[tokio::test(flavor = "multi_thread")]
 async fn init_timeout_reached() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "while(true) {}
 export function handler() {
     return new Response('Should not be reached');
@@ -112,7 +112,7 @@ export function handler() {
 #[tokio::test(flavor = "multi_thread")]
 async fn memory_reached() {
     setup();
-    let mut isolate = Isolate::new(
+    let mut isolate = Isolate::<()>::new(
         IsolateOptions::new(
             "export function handler() {
     const storage = [];

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -1,4 +1,4 @@
-use std::sync::Once;
+use std::{sync::Once, time::Duration};
 
 use httptest::{matchers::*, responders::*, Expectation, Server};
 use lagon_runtime::{

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -25,7 +25,7 @@ async fn basic_fetch() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}').then(res => res.text());
     return new Response(body);
@@ -50,7 +50,7 @@ async fn request_method() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'POST'
@@ -78,7 +78,7 @@ async fn request_method_fallback() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'UNKNOWN'
@@ -109,7 +109,7 @@ async fn request_headers() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         headers: {{
@@ -142,7 +142,7 @@ async fn request_headers_class() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         headers: new Headers({{
@@ -175,7 +175,7 @@ async fn request_body() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'POST',
@@ -204,7 +204,7 @@ async fn response_headers() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = [];
@@ -238,7 +238,7 @@ async fn response_status() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.text();
@@ -265,7 +265,7 @@ async fn response_json() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.json();
@@ -292,7 +292,7 @@ async fn response_array_buffer() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.arrayBuffer();
@@ -312,7 +312,7 @@ async fn response_array_buffer() {
 #[tokio::test(flavor = "multi_thread")]
 async fn throw_invalid_url() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export async function handler() {
     const response = await fetch('doesnotexist');
     const body = await response.text();
@@ -336,7 +336,7 @@ async fn throw_invalid_url() {
 #[tokio::test(flavor = "multi_thread")]
 async fn throw_invalid_header() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export async function handler() {
     const response = await fetch('http://localhost:5555/', {
         headers: {

--- a/packages/runtime/tests/promises.rs
+++ b/packages/runtime/tests/promises.rs
@@ -21,7 +21,7 @@ fn setup() {
 #[tokio::test(flavor = "multi_thread")]
 async fn execute_async_handler() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export async function handler() {
     return new Response('Async handler');
 }"
@@ -54,7 +54,7 @@ async fn execute_promise() {
     });
 
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export async function handler() {
     const body = await fetch('http://localhost:5556').then((res) => res.text());
     return new Response(body);

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -18,7 +18,7 @@ fn setup() {
 #[tokio::test]
 async fn execute_function() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world');
 }"
@@ -36,7 +36,7 @@ async fn execute_function() {
 #[tokio::test]
 async fn environment_variables() {
     setup();
-    let mut isolate = Isolate::new(
+    let mut isolate = Isolate::<()>::new(
         IsolateOptions::new(
             "export function handler() {
     return new Response(process.env.TEST);
@@ -61,7 +61,7 @@ async fn environment_variables() {
 #[tokio::test]
 async fn get_body() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.body);
 }"
@@ -95,7 +95,7 @@ async fn get_body() {
 #[tokio::test]
 async fn get_input() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.url);
 }"
@@ -123,7 +123,7 @@ async fn get_input() {
 #[tokio::test]
 async fn get_method() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.method);
 }"
@@ -151,7 +151,7 @@ async fn get_method() {
 #[tokio::test]
 async fn get_headers() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.headers.get('x-auth'));
 }"
@@ -183,7 +183,7 @@ async fn get_headers() {
 #[tokio::test]
 async fn return_headers() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world', {
         headers: {
@@ -215,7 +215,7 @@ async fn return_headers() {
 #[tokio::test]
 async fn return_headers_from_headers_api() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world', {
         headers: new Headers({
@@ -247,7 +247,7 @@ async fn return_headers_from_headers_api() {
 #[tokio::test]
 async fn return_status() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response('Moved permanently', {
         status: 302,
@@ -271,7 +271,7 @@ async fn return_status() {
 #[tokio::test]
 async fn return_uint8array() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     // TextEncoder#encode returns a Uint8Array
     const body = new TextEncoder().encode('Hello world');
@@ -291,7 +291,7 @@ async fn return_uint8array() {
 #[tokio::test(flavor = "multi_thread")]
 async fn console_log() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     const types = ['log', 'info', 'debug', 'error', 'warn'];
 
@@ -315,7 +315,7 @@ async fn console_log() {
 #[tokio::test(flavor = "multi_thread")]
 async fn atob() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response(atob('SGVsbG8='));
 }"
@@ -333,7 +333,7 @@ async fn atob() {
 #[tokio::test(flavor = "multi_thread")]
 async fn btoa() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response(btoa('Hello'));
 }"

--- a/packages/runtime/tests/streams.rs
+++ b/packages/runtime/tests/streams.rs
@@ -19,7 +19,7 @@ fn setup() {
 #[tokio::test(flavor = "multi_thread")]
 async fn sync_streaming() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response(
         new ReadableStream({
@@ -55,7 +55,7 @@ async fn sync_streaming() {
 #[tokio::test(flavor = "multi_thread")]
 async fn queue_multiple() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     let count = 0;
     return new Response(
@@ -100,7 +100,7 @@ async fn queue_multiple() {
 #[tokio::test(flavor = "multi_thread")]
 async fn custom_response() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response(
         new ReadableStream({
@@ -146,7 +146,7 @@ async fn custom_response() {
 #[tokio::test(flavor = "multi_thread")]
 async fn start_and_pull() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(
         "export function handler() {
     return new Response(
         new ReadableStream({
@@ -198,7 +198,7 @@ async fn response_before_write() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+    let mut isolate = Isolate::<()>::new(IsolateOptions::new(format!(
         "export function handler() {{
     const transformStream = new TransformStream({{
         start(controller) {{

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -37,9 +37,10 @@ use crate::logger::init_logger;
 mod deployments;
 mod logger;
 
+type ThreadIsolates = LruCache<String, Isolate<(String, String)>>;
+
 lazy_static! {
-    pub static ref ISOLATES: RwLock<HashMap<usize, LruCache<String, Isolate<(String, String)>>>> =
-        RwLock::new(HashMap::new());
+    pub static ref ISOLATES: RwLock<HashMap<usize, ThreadIsolates>> = RwLock::new(HashMap::new());
     static ref X_FORWARDED_FOR: String = String::from("X-Forwarded-For");
     static ref ISOLATES_CACHE_SECONDS: Duration = Duration::from_secs(
         dotenv::var("LAGON_ISOLATES_CACHE_SECONDS")


### PR DESCRIPTION
## About

- Add back functions statistics
- Properly timeout and terminate long-running functions.