### PR TITLE
feat(serverless,cli): Support .html and index.html for static file paths

### DIFF
--- a/.changeset/rude-days-help.md
+++ b/.changeset/rude-days-help.md
@@ -1,0 +1,6 @@
+---
+'@lagon/serverless': patch
+'@lagon/cli': patch
+---
+
+Support .html and index.html for static file paths

--- a/packages/cli/src/commands/dev.rs
+++ b/packages/cli/src/commands/dev.rs
@@ -62,7 +62,9 @@ async fn handle_request(
     let (tx, rx) = flume::unbounded();
     let (index, assets) = content.lock().await.to_owned();
 
-    if let Some(asset) = assets.iter().find(|asset| *asset.0 == url) {
+    if let Some(asset) = assets.iter().find(|asset| {
+        asset.0.replace(".html", "") == url || asset.0.replace("/index.html", "") == url
+    }) {
         println!("              {}", input("Asset found"));
 
         let extension = Path::new(asset.0).extension().unwrap().to_str().unwrap();

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -104,9 +104,9 @@ async fn handle_request(
                             ("function", deployment.function_id.clone()),
                         ];
 
-                        increment_counter!("lagon_requests", &labels);
-
-                        if let Some(asset) = deployment.assets.iter().find(|asset| *asset == &url) {
+                        if let Some(asset) = deployment.assets.iter().find(|asset| {
+                            asset.replace(".html", "") == url || asset.replace("/index.html", "") == url
+                        }) {
                             let run_result = match handle_asset(deployment, asset) {
                                 Ok(response) => RunResult::Response(response),
                                 Err(error) => {
@@ -118,6 +118,8 @@ async fn handle_request(
 
                             tx.send_async(run_result).await.unwrap_or(());
                         } else {
+                            increment_counter!("lagon_requests", &labels);
+
                             let mut request = match Request::from_hyper(req).await {
                                 Ok(request) => request,
                                 Err(error) => {


### PR DESCRIPTION
## About

Closes #232

Previously, static files were only served when the URL matched the file path. That causes issues for many frameworks, that rely on a `foo.html` to serve the `/foo` URL, or `bar/index.html` to serve the `/bar` URL.

The two above paths are now supported for both CLI and serverless, and allow to serve HTML files without having the extension (`.html`) in the URL.