### PR TITLE
perf(js-runtime): more lazy Request/Response

### DIFF
--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -73,6 +73,10 @@ declare global {
     TEXT_DECODER: TextDecoder;
   };
   var handler: (request: Request) => Promise<Response>;
+
+  interface Response {
+    readonly isStream: boolean;
+  }
 }
 
 export async function masterHandler(request: { input: string } & Request): Promise<Response> {
@@ -84,7 +88,6 @@ export async function masterHandler(request: { input: string } & Request): Promi
 
   const response = await handler(handlerRequest);
 
-  // @ts-expect-error isStream is not part of the spec in Response
   if (response.body && response.isStream) {
     const reader = response.body.getReader();
 

--- a/packages/js-runtime/src/runtime/http/Request.ts
+++ b/packages/js-runtime/src/runtime/http/Request.ts
@@ -13,22 +13,13 @@ import { RequestResponseBody } from './body';
     readonly redirect: RequestRedirect;
     readonly referrer: string;
     readonly referrerPolicy: ReferrerPolicy;
-    readonly signal: AbortSignal;
+
+    private readonly init?: RequestInit;
 
     constructor(input: RequestInfo | URL, init?: RequestInit) {
-      let headers: Headers;
+      super(init?.body, init?.headers);
 
-      if (init?.headers) {
-        if (init.headers instanceof Headers) {
-          headers = init.headers;
-        } else {
-          headers = new Headers(init.headers);
-        }
-      } else {
-        headers = new Headers();
-      }
-
-      super(init?.body, headers);
+      this.init = init;
 
       this.method = init?.method || 'GET';
       this.url = input.toString();
@@ -41,7 +32,10 @@ import { RequestResponseBody } from './body';
       this.redirect = init?.redirect || 'follow';
       this.referrer = init?.referrer || '';
       this.referrerPolicy = init?.referrerPolicy || '';
-      this.signal = init?.signal || new AbortSignal();
+    }
+
+    get signal(): AbortSignal {
+      return this.init?.signal || new AbortSignal();
     }
 
     clone(): Request {

--- a/packages/js-runtime/src/runtime/http/Response.ts
+++ b/packages/js-runtime/src/runtime/http/Response.ts
@@ -10,19 +10,7 @@ import { RequestResponseBody } from './body';
     redirected: boolean;
 
     constructor(body?: BodyInit | null, init?: ResponseInit) {
-      let headers: Headers;
-
-      if (init?.headers) {
-        if (init.headers instanceof Headers) {
-          headers = init.headers;
-        } else {
-          headers = new Headers(init.headers);
-        }
-      } else {
-        headers = new Headers();
-      }
-
-      super(body, headers);
+      super(body, init?.headers);
 
       if (init?.status) {
         this.ok = init.status >= 200 && init.status < 300;

--- a/packages/js-runtime/src/runtime/http/body.ts
+++ b/packages/js-runtime/src/runtime/http/body.ts
@@ -1,21 +1,26 @@
 export class RequestResponseBody {
   readonly body: ReadableStream<Uint8Array> | null;
   bodyUsed: boolean;
-  headers: Headers;
+
   // isStream is not part of the spec, but required to only stream
   // responses when the body is a stream.
-  isStream: boolean;
+  readonly isStream: boolean;
+
+  private headersInit?: HeadersInit;
+  private headersCache: Headers | undefined;
 
   constructor(
     body: string | ArrayBuffer | ArrayBufferView | FormData | ReadableStream | Blob | null = null,
-    headers: Headers,
+    headersInit?: HeadersInit,
   ) {
     if (body !== null) {
-      if (body instanceof ReadableStream) {
+      if (body instanceof ReadableStream || typeof body === 'string') {
+        // @ts-expect-error the type doesn't allow body to be a string, but we
+        // bypass this to avoid allocating huge stream objects for small strings
         this.body = body;
         this.bodyUsed = false;
-        this.headers = headers;
-        this.isStream = true;
+        this.headersInit = headersInit;
+        this.isStream = body instanceof ReadableStream;
         return;
       }
 
@@ -36,8 +41,26 @@ export class RequestResponseBody {
     }
 
     this.bodyUsed = false;
-    this.headers = headers;
+    this.headersInit = headersInit;
     this.isStream = false;
+  }
+
+  get headers(): Headers {
+    if (this.headersCache) {
+      return this.headersCache;
+    }
+
+    if (this.headersInit) {
+      if (this.headersInit instanceof Headers) {
+        this.headersCache = this.headersInit;
+      } else {
+        this.headersCache = new Headers(this.headersInit);
+      }
+    } else {
+      this.headersCache = new Headers();
+    }
+
+    return this.headers;
   }
 
   async arrayBuffer(): Promise<ArrayBuffer> {
@@ -59,16 +82,22 @@ export class RequestResponseBody {
   }
 
   async text(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      if (this.bodyUsed) {
-        return reject(new TypeError('Body is already used'));
-      }
+    if (this.bodyUsed) {
+      throw new TypeError('Body is already used');
+    }
 
-      if (!this.body) {
-        return resolve('');
-      }
+    if (!this.body) {
+      this.bodyUsed = true;
+      return '';
+    }
 
-      const reader = this.body.getReader();
+    if (typeof this.body === 'string') {
+      this.bodyUsed = true;
+      return this.body;
+    }
+
+    return new Promise(resolve => {
+      const reader = (this.body as ReadableStream<Uint8Array>).getReader();
       let result = '';
 
       const pull = () => {

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Once};
 
 use hyper::body::Bytes;
 use lagon_runtime::{
-    http::{Method, Request, Response, RunResult, StreamResult},
+    http::{Method, Request, Response, RunResult},
     isolate::{Isolate, IsolateOptions},
     runtime::{Runtime, RuntimeOptions},
 };
@@ -82,13 +82,7 @@ async fn get_body() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Data(vec![
-            72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100
-        ]))
-    );
-    assert_eq!(
-        rx.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Done)
+        RunResult::Response(Response::from("Hello world"))
     );
 }
 


### PR DESCRIPTION
## About

Since #240, performances were degraded a lot due to huge objects being allocated at each function call. Now, `Request/Response`'s `body` can be a `string` instead of always being a `ReadableStream` when it's not needed.

https://twitter.com/tomlienard/status/1592209845155164161
