### PR TITLE
perf(serverless): avoid expensive clones

### DIFF
--- a/.changeset/eighty-moons-smoke.md
+++ b/.changeset/eighty-moons-smoke.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Improve performances by avoiding expensive clones

--- a/packages/serverless/src/deployments/assets.rs
+++ b/packages/serverless/src/deployments/assets.rs
@@ -9,7 +9,7 @@ use super::Deployment;
 pub fn handle_asset(deployment: &Deployment, asset: &String) -> Result<Response> {
     let path = Path::new(env::current_dir()?.as_path())
         .join("deployments")
-        .join(deployment.id.clone())
+        .join(&deployment.id)
         .join(asset);
     let body = fs::read(path)?;
 

--- a/packages/serverless/src/deployments/mod.rs
+++ b/packages/serverless/src/deployments/mod.rs
@@ -62,7 +62,7 @@ impl Deployment {
 pub async fn get_deployments(
     mut conn: PooledConn,
     bucket: Bucket,
-) -> Result<Arc<RwLock<HashMap<String, Deployment>>>> {
+) -> Result<Arc<RwLock<HashMap<String, Arc<Deployment>>>>> {
     let deployments = Arc::new(RwLock::new(HashMap::new()));
 
     let mut deployments_list: HashMap<String, Deployment> = HashMap::new();
@@ -160,7 +160,7 @@ pub async fn get_deployments(
             }
 
             for domain in deployment.get_domains() {
-                deployments.insert(domain, deployment.clone());
+                deployments.insert(domain, Arc::new(deployment.clone()));
             }
         }
     }

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -280,10 +280,10 @@ async fn main() -> Result<()> {
     let url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
-    // #[cfg(not(debug_assertions))]
-    // let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(
-    //     SslOpts::default().with_danger_accept_invalid_certs(true),
-    // ));
+    #[cfg(not(debug_assertions))]
+    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(
+        SslOpts::default().with_danger_accept_invalid_certs(true),
+    ));
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 


### PR DESCRIPTION
## About

Improve performances by avoiding expensive clones, mostly on `Deployment` by using an `Arc`.
