### PR TITLE
perf(runtime): use shorter keys for Request/Response

### DIFF
--- a/.changeset/honest-seals-grab.md
+++ b/.changeset/honest-seals-grab.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Use shorter keys for Request/Response

--- a/packages/js-runtime/src/__tests__/fetch.test.ts
+++ b/packages/js-runtime/src/__tests__/fetch.test.ts
@@ -164,23 +164,23 @@ describe('fetch', () => {
   it('should call Lagon.fetch', async () => {
     // @ts-expect-error Lagon is not defined
     globalThis.Lagon.fetch.mockReturnValueOnce({
-      body: 'Hello',
-      status: 200,
+      b: 'Hello',
+      s: 200,
     });
 
     await fetch('https://google.com');
 
     expect(globalThis.Lagon.fetch).toHaveBeenCalledWith({
-      method: 'GET',
-      url: 'https://google.com',
+      m: 'GET',
+      u: 'https://google.com',
     });
   });
 
   it('should call Lagon.fetch with options', async () => {
     // @ts-expect-error Lagon is not defined
     globalThis.Lagon.fetch.mockReturnValueOnce({
-      body: 'Hello',
-      status: 200,
+      b: 'Hello',
+      s: 200,
     });
 
     await fetch('https://google.com', {
@@ -189,9 +189,9 @@ describe('fetch', () => {
     });
 
     expect(globalThis.Lagon.fetch).toHaveBeenCalledWith({
-      method: 'POST',
-      url: 'https://google.com',
-      body: 'A body',
+      m: 'POST',
+      u: 'https://google.com',
+      b: 'A body',
     });
   });
 });

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -24,20 +24,10 @@ import './runtime/http/fetch';
 declare global {
   var Lagon: {
     log: (message: string) => void;
-    fetch: ({
-      headers,
-      method,
-      body,
-      url,
-    }: {
-      headers?: Map<string, string>;
-      method: string;
-      body?: string;
-      url: string;
-    }) => Promise<{
-      body: Uint8Array;
-      status: number;
-      headers?: Record<string, string>;
+    fetch: ({ h, m, b, u }: { h?: Map<string, string>; m: string; b?: string; u: string }) => Promise<{
+      b: Uint8Array;
+      s: number;
+      h?: Record<string, string>;
     }>;
     pullStream: (done: boolean, chunk?: Uint8Array) => void;
     uuid: () => string;
@@ -79,11 +69,20 @@ declare global {
   }
 }
 
-export async function masterHandler(request: { input: string } & Request): Promise<Response> {
-  const handlerRequest = new Request(request.input, {
-    method: request.method,
-    headers: request.headers,
-    body: request.body,
+export async function masterHandler(request: {
+  i: string;
+  m: RequestInit['method'];
+  h: RequestInit['headers'];
+  b: RequestInit['body'];
+}): Promise<{
+  b: string;
+  h: ResponseInit['headers'];
+  s: ResponseInit['status'];
+}> {
+  const handlerRequest = new Request(request.i, {
+    method: request.m,
+    headers: request.h,
+    body: request.b,
   });
 
   const response = await handler(handlerRequest);
@@ -113,5 +112,9 @@ export async function masterHandler(request: { input: string } & Request): Promi
     response.body = await response.text();
   }
 
-  return response;
+  return {
+    b: response.body as unknown as string,
+    h: response.headers,
+    s: response.status,
+  };
 }

--- a/packages/js-runtime/src/runtime/http/Headers.ts
+++ b/packages/js-runtime/src/runtime/http/Headers.ts
@@ -1,6 +1,6 @@
 (globalThis => {
   globalThis.Headers = class {
-    private headers: Map<string, string[]> = new Map();
+    private readonly h: Map<string, string[]> = new Map();
 
     constructor(init?: HeadersInit) {
       if (init) {
@@ -18,12 +18,12 @@
 
     private addValue(name: string, value: string) {
       name = name.toLowerCase();
-      const values = this.headers.get(name);
+      const values = this.h.get(name);
 
       if (values) {
         values.push(value);
       } else {
-        this.headers.set(name, [value]);
+        this.h.set(name, [value]);
       }
     }
 
@@ -34,11 +34,11 @@
 
     delete(name: string) {
       name = name.toLowerCase();
-      this.headers.delete(name);
+      this.h.delete(name);
     }
 
     *entries(): IterableIterator<[string, string]> {
-      for (const [key, values] of this.headers) {
+      for (const [key, values] of this.h) {
         for (const value of values) {
           yield [key, value];
         }
@@ -47,25 +47,25 @@
 
     get(name: string): string | null {
       name = name.toLowerCase();
-      return this.headers.get(name)?.[0] || null;
+      return this.h.get(name)?.[0] || null;
     }
 
     has(name: string): boolean {
       name = name.toLowerCase();
-      return this.headers.has(name);
+      return this.h.has(name);
     }
 
     keys(): IterableIterator<string> {
-      return this.headers.keys();
+      return this.h.keys();
     }
 
     set(name: string, value: string) {
       name = name.toLowerCase();
-      this.headers.set(name, [value]);
+      this.h.set(name, [value]);
     }
 
     *values(): IterableIterator<string> {
-      for (const [, values] of this.headers) {
+      for (const [, values] of this.h) {
         for (const value of values) {
           yield value;
         }

--- a/packages/js-runtime/src/runtime/http/body.ts
+++ b/packages/js-runtime/src/runtime/http/body.ts
@@ -60,7 +60,7 @@ export class RequestResponseBody {
       this.headersCache = new Headers();
     }
 
-    return this.headers;
+    return this.headersCache;
   }
 
   async arrayBuffer(): Promise<ArrayBuffer> {

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -39,18 +39,18 @@
       checkAborted();
 
       const response = await Lagon.fetch({
-        method: init?.method || 'GET',
-        url: input.toString(),
-        body,
-        headers,
+        m: init?.method || 'GET',
+        u: input.toString(),
+        b: body,
+        h: headers,
       });
 
       checkAborted();
 
-      return new Response(response.body, {
+      return new Response(response.b, {
         // url: response.init.url,
-        headers: response.headers,
-        status: response.status,
+        headers: response.h,
+        status: response.s,
       });
     } catch (error) {
       if (typeof error === 'string') {

--- a/packages/runtime/src/http/request.rs
+++ b/packages/runtime/src/http/request.rs
@@ -36,29 +36,28 @@ impl IntoV8 for Request {
     fn into_v8<'a>(self, scope: &mut v8::HandleScope<'a>) -> v8::Local<'a, v8::Object> {
         let request = v8::Object::new(scope);
 
-        let input_key = v8_string(scope, "input");
+        let input_key = v8_string(scope, "i");
         let input_value = v8_string(scope, &self.url);
         request
             .set(scope, input_key.into(), input_value.into())
             .unwrap();
 
-        let method_key = v8_string(scope, "method");
+        let method_key = v8_string(scope, "m");
         let method_value = v8_string(scope, self.method.into());
         request
             .set(scope, method_key.into(), method_value.into())
             .unwrap();
 
         if !self.body.is_empty() {
-            let body_key = v8_string(scope, "body");
+            let body_key = v8_string(scope, "b");
             let body_value = v8_string(scope, &String::from_utf8(self.body.to_vec()).unwrap());
             request
                 .set(scope, body_key.into(), body_value.into())
                 .unwrap();
         }
 
-        let headers_key = v8_string(scope, "headers");
-
         if let Some(headers) = self.headers {
+            let headers_key = v8_string(scope, "h");
             let headers_value = v8_headers_object(scope, headers);
             request
                 .set(scope, headers_key.into(), headers_value.into())
@@ -80,7 +79,7 @@ impl FromV8 for Request {
         };
 
         let mut body = Bytes::new();
-        let body_key = v8_string(scope, "body");
+        let body_key = v8_string(scope, "b");
 
         if let Some(body_value) = request.get(scope, body_key.into()) {
             if !body_value.is_null_or_undefined() {
@@ -89,7 +88,7 @@ impl FromV8 for Request {
         }
 
         let mut headers = None;
-        let headers_key = v8_string(scope, "headers");
+        let headers_key = v8_string(scope, "h");
 
         if let Some(headers_value) = request.get(scope, headers_key.into()) {
             if !headers_value.is_null_or_undefined() {
@@ -98,14 +97,14 @@ impl FromV8 for Request {
         }
 
         let mut method = Method::GET;
-        let method_key = v8_string(scope, "method");
+        let method_key = v8_string(scope, "m");
 
         if let Some(method_value) = request.get(scope, method_key.into()) {
             method = Method::from(extract_v8_string(method_value, scope)?.as_str());
         }
 
         let url;
-        let url_key = v8_string(scope, "url");
+        let url_key = v8_string(scope, "u");
 
         if let Some(url_value) = request.get(scope, url_key.into()) {
             url = extract_v8_string(url_value, scope)?;

--- a/packages/runtime/src/http/response.rs
+++ b/packages/runtime/src/http/response.rs
@@ -51,22 +51,22 @@ impl IntoV8 for Response {
     fn into_v8<'a>(self, scope: &mut v8::HandleScope<'a>) -> v8::Local<'a, v8::Object> {
         let response = v8::Object::new(scope);
 
-        let body_key = v8_string(scope, "body");
+        let body_key = v8_string(scope, "b");
         let body_value = v8_uint8array(scope, self.body.to_vec());
         response
             .set(scope, body_key.into(), body_value.into())
             .unwrap();
 
-        let status_key = v8_string(scope, "status");
+        let status_key = v8_string(scope, "s");
         let status_value = v8_integer(scope, self.status.into());
         response
             .set(scope, status_key.into(), status_value.into())
             .unwrap();
 
-        let headers_key = v8_string(scope, "headers");
-
         if let Some(headers) = self.headers {
             let headers_value = v8_headers_object(scope, headers);
+            let headers_key = v8_string(scope, "h");
+
             response
                 .set(scope, headers_key.into(), headers_value.into())
                 .unwrap();
@@ -87,7 +87,7 @@ impl FromV8 for Response {
         };
 
         let body;
-        let body_key = v8_string(scope, "body");
+        let body_key = v8_string(scope, "b");
 
         if let Some(body_value) = response.get(scope, body_key.into()) {
             body = extract_v8_string(body_value, scope)?;
@@ -96,7 +96,7 @@ impl FromV8 for Response {
         }
 
         let mut headers = None;
-        let headers_key = v8_string(scope, "headers");
+        let headers_key = v8_string(scope, "h");
 
         if let Some(headers_object) = response.get(scope, headers_key.into()) {
             if let Some(headers_object) = headers_object.to_object(scope) {
@@ -113,7 +113,7 @@ impl FromV8 for Response {
         }
 
         let status;
-        let status_key = v8_string(scope, "status");
+        let status_key = v8_string(scope, "s");
 
         if let Some(status_value) = response.get(scope, status_key.into()) {
             status = extract_v8_integer(status_value, scope)? as u16;


### PR DESCRIPTION
## About

Use shorter keys for Request/Response Rust <-> JS conversion.
