### PR TITLE
feat(js-runtime): support `application/x-www-form-urlencoded` in Request/Response `formData()`

### DIFF
--- a/.changeset/calm-cougars-appear.md
+++ b/.changeset/calm-cougars-appear.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+Add support for application/x-www-form-urlencoded in Request/Response formData()

--- a/packages/js-runtime/src/__tests__/formData.test.ts
+++ b/packages/js-runtime/src/__tests__/formData.test.ts
@@ -90,7 +90,30 @@ describe('FormData', () => {
     expect(Array.from(fields.values())).toEqual(['b', 'd']);
   });
 
-  describe('Parse', () => {
+  describe('application/x-www-form-urlencoded', () => {
+    it('should parse FormData', async () => {
+      const fields = await new Response('hello=world', {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+      }).formData();
+
+      expect(fields.get('hello')).toEqual('world');
+    });
+
+    it('should parse multiple fields', async () => {
+      const fields = await new Response('username=john&password=Pa%24%24w0rd', {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+      }).formData();
+
+      expect(fields.get('username')).toEqual('john');
+      expect(fields.get('password')).toEqual('Pa$$w0rd');
+    });
+  });
+
+  describe('multipart/form-data', () => {
     it('should parse FormData', async () => {
       const fields = await new Response(
         `-----------------------------9051914041544843365972754266
@@ -165,5 +188,11 @@ aωb
       expect(fields.get('file1')).toEqual('Content of a.txt.');
       expect(fields.get('file2')).toEqual('<!DOCTYPE html><title>Content of a.html.</title>');
     });
+  });
+
+  it('should throw with unsupported content-type', async () => {
+    await expect(() =>
+      new Response('unknown', { headers: { 'content-type': 'unknown' } }).formData(),
+    ).rejects.toThrowError('Unsupported content type: unknown');
   });
 });

--- a/packages/js-runtime/src/__tests__/url.test.ts
+++ b/packages/js-runtime/src/__tests__/url.test.ts
@@ -243,7 +243,7 @@ describe('URL', () => {
   describe('searchParams', () => {
     it('should return the searchParams', () => {
       const { searchParams } = new URL('https://example.com/?name=Jonathan%20Smith&age=18');
-      expect(searchParams?.get('name')).toEqual('Jonathan%20Smith');
+      expect(searchParams?.get('name')).toEqual('Jonathan Smith');
       expect(searchParams?.get('age')).toEqual('18');
     });
   });

--- a/packages/js-runtime/src/runtime/http/URLSearchParams.ts
+++ b/packages/js-runtime/src/runtime/http/URLSearchParams.ts
@@ -11,7 +11,7 @@
             .forEach(entry => {
               const [key, value] = entry.split('=');
 
-              this.addValue(key, value);
+              this.addValue(key, decodeURIComponent(value));
             });
         } else if (typeof init === 'object') {
           if (Array.isArray(init)) {


### PR DESCRIPTION
## About

Add support for `application/x-www-form-urlencoded` in Request/Response `formData()`, using the existing `URLSearchParams` API.

Initially raised on Twitter:
https://twitter.com/cyco130/status/1591876005735563265