### PR TITLE
fix(serverless): functions timeout

### DIFF
--- a/.changeset/wild-cups-care.md
+++ b/.changeset/wild-cups-care.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Fix functions timeout


### PR DESCRIPTION
## About

Fix functions timeout not working properly in serverless (but working fine in runtime).

This is because serverless uses a `LocalPoolHandle` to always execute an isolate on the same thread while allowing to have multiple threads to run a pool of isolate. Using `tokio::task::spawn`, the timeout future is spawned on the same thread as the isolate, and will be blocked when the isolate blocks (e.g long script parsing, infinite loops...).

The solution is to use a `tokio::task::spawn_blocking` to spawn the timeout future on another thread where we can block.