### PR TITLE
feat(runtime,serverless,dashboard): add isolates startup timeout

### DIFF
--- a/.changeset/gold-pans-greet.md
+++ b/.changeset/gold-pans-greet.md
@@ -1,0 +1,7 @@
+---
+'@lagon/dashboard': patch
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+---
+
+Add `startupTimeout` to functions that is higher than `timeout`

--- a/packages/dashboard/lib/api/deployments.ts
+++ b/packages/dashboard/lib/api/deployments.ts
@@ -61,6 +61,7 @@ export async function removeDeployment(
     domains: string[];
     memory: number;
     timeout: number;
+    startupTimeout: number;
     cron: string | null;
     cronRegion: string;
     env: { key: string; value: string }[];
@@ -126,6 +127,7 @@ export async function removeDeployment(
       domains: func.domains,
       memory: func.memory,
       timeout: func.timeout,
+      startupTimeout: func.startupTimeout,
       cron: func.cron,
       cronRegion: func.cronRegion,
       env: envStringToObject(func.env),
@@ -178,6 +180,7 @@ export async function promoteProductionDeployment(functionId: string, newDeploym
       domains: true,
       memory: true,
       timeout: true,
+      startupTimeout: true,
       cron: true,
       cronRegion: true,
       env: {
@@ -227,6 +230,7 @@ export async function promoteProductionDeployment(functionId: string, newDeploym
       domains: func.domains.map(({ domain }) => domain),
       memory: func.memory,
       timeout: func.timeout,
+      startupTimeout: func.startupTimeout,
       cron: func.cron,
       cronRegion: func.cronRegion,
       env: envStringToObject(func.env),
@@ -243,6 +247,7 @@ export async function updateDomains(
     domains: string[];
     memory: number;
     timeout: number;
+    startupTimeout: number;
     cron: string | null;
     cronRegion: string;
     env: { key: string; value: string }[];
@@ -259,6 +264,7 @@ export async function updateDomains(
       domains: oldDomains,
       memory: func.memory,
       timeout: func.timeout,
+      startupTimeout: func.startupTimeout,
       cron: func.cron,
       cronRegion: func.cronRegion,
       env: envStringToObject(func.env),
@@ -276,6 +282,7 @@ export async function updateDomains(
       domains: func.domains,
       memory: func.memory,
       timeout: func.timeout,
+      startupTimeout: func.startupTimeout,
       cron: func.cron,
       cronRegion: func.cronRegion,
       env: envStringToObject(func.env),
@@ -295,6 +302,7 @@ export async function removeFunction(func: {
   }[];
   memory: number;
   timeout: number;
+  startupTimeout: number;
   cron: string | null;
   cronRegion: string;
   env: {

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -7,6 +7,7 @@ export const FUNCTION_NAME_MAX_LENGTH = 20;
 
 export const FUNCTION_DEFAULT_MEMORY = 128; // 128MB
 export const FUNCTION_DEFAULT_TIMEOUT = 50; // 50ms
+export const FUNCTION_DEFAULT_STARTUP_TIMEOUT = 200; // 200ms
 export const REGIONS = {
   'EU-WEST-3': 'eu-west-3 (Paris)',
 };

--- a/packages/dashboard/lib/trpc/deploymentsRouter.ts
+++ b/packages/dashboard/lib/trpc/deploymentsRouter.ts
@@ -123,6 +123,7 @@ export const deploymentsRouter = (t: T) =>
               domains: true,
               memory: true,
               timeout: true,
+              startupTimeout: true,
               cron: true,
               cronRegion: true,
               env: true,
@@ -158,6 +159,7 @@ export const deploymentsRouter = (t: T) =>
             domains: func.domains.map(({ domain }) => domain),
             memory: func.memory,
             timeout: func.timeout,
+            startupTimeout: func.startupTimeout,
             cron: func.cron,
             cronRegion: func.cronRegion,
             env: envStringToObject(func.env),
@@ -204,6 +206,7 @@ export const deploymentsRouter = (t: T) =>
             },
             memory: true,
             timeout: true,
+            startupTimeout: true,
             cron: true,
             cronRegion: true,
             env: {

--- a/packages/dashboard/lib/trpc/functionsRouter.ts
+++ b/packages/dashboard/lib/trpc/functionsRouter.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import prisma from 'lib/prisma';
-// import { t } from 'pages/api/trpc/[trpc]';
 import { LOG_LEVELS, TIMEFRAMES } from 'lib/types';
 import { getDeploymentCode, removeFunction, updateDomains } from 'lib/api/deployments';
 import {
   FUNCTION_DEFAULT_MEMORY,
+  FUNCTION_DEFAULT_STARTUP_TIMEOUT,
   FUNCTION_DEFAULT_TIMEOUT,
   FUNCTION_NAME_MAX_LENGTH,
   FUNCTION_NAME_MIN_LENGTH,
@@ -204,6 +204,7 @@ export const functionsRouter = (t: T) =>
             },
             memory: FUNCTION_DEFAULT_MEMORY,
             timeout: FUNCTION_DEFAULT_TIMEOUT,
+            startupTimeout: FUNCTION_DEFAULT_STARTUP_TIMEOUT,
             env: {
               createMany: {
                 data: input.env.map(({ key, value }) => ({
@@ -297,6 +298,7 @@ export const functionsRouter = (t: T) =>
             },
             memory: true,
             timeout: true,
+            startupTimeout: true,
             cron: true,
             cronRegion: true,
             env: {
@@ -361,6 +363,7 @@ export const functionsRouter = (t: T) =>
             },
             memory: true,
             timeout: true,
+            startupTimeout: true,
             cron: true,
             cronRegion: true,
             env: {

--- a/packages/dashboard/lib/trpc/organizationsRouter.ts
+++ b/packages/dashboard/lib/trpc/organizationsRouter.ts
@@ -92,6 +92,7 @@ export const organizationsRouter = (t: T) =>
             },
             memory: true,
             timeout: true,
+            startupTimeout: true,
             cron: true,
             cronRegion: true,
             env: {

--- a/packages/dashboard/prisma/migrations/20221125172950_add_startup_timeout_to_function/migration.sql
+++ b/packages/dashboard/prisma/migrations/20221125172950_add_startup_timeout_to_function/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Function` ADD COLUMN `startupTimeout` INTEGER NOT NULL DEFAULT 200;

--- a/packages/dashboard/prisma/schema.prisma
+++ b/packages/dashboard/prisma/schema.prisma
@@ -78,13 +78,14 @@ model Function {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  name       String        @unique
-  domains    Domain[]
-  memory     Int
-  timeout    Int
-  cron       String?
-  cronRegion String        @default("EU-WEST-3")
-  env        EnvVariable[]
+  name           String        @unique
+  domains        Domain[]
+  memory         Int
+  timeout        Int
+  startupTimeout Int           @default(200)
+  cron           String?
+  cronRegion     String        @default("EU-WEST-3")
+  env            EnvVariable[]
 
   organization   Organization @relation(fields: [organizationId], references: [id])
   organizationId String

--- a/packages/serverless/src/deployments/mod.rs
+++ b/packages/serverless/src/deployments/mod.rs
@@ -30,8 +30,9 @@ pub struct Deployment {
     pub domains: HashSet<String>,
     pub assets: HashSet<String>,
     pub environment_variables: HashMap<String, String>,
-    pub memory: usize,  // in MB (MegaBytes)
-    pub timeout: usize, // in ms (MilliSeconds)
+    pub memory: usize,          // in MB (MegaBytes)
+    pub timeout: usize,         // in ms (MilliSeconds)
+    pub startup_timeout: usize, // in ms (MilliSeconds)
     pub is_production: bool,
 }
 
@@ -77,6 +78,7 @@ pub async fn get_deployments(
             Function.name,
             Function.memory,
             Function.timeout,
+            Function.startupTimeout,
             Domain.domain,
             Asset.name
         FROM
@@ -88,11 +90,22 @@ pub async fn get_deployments(
         LEFT JOIN Asset
             ON Deployment.id = Asset.deploymentId
     ",
-        |(id, is_production, function_id, function_name, memory, timeout, domain, asset): (
+        |(
+            id,
+            is_production,
+            function_id,
+            function_name,
+            memory,
+            timeout,
+            startup_timeout,
+            domain,
+            asset,
+        ): (
             String,
             bool,
             String,
             String,
+            usize,
             usize,
             usize,
             Option<String>,
@@ -130,6 +143,7 @@ pub async fn get_deployments(
                     environment_variables: HashMap::new(),
                     memory,
                     timeout,
+                    startup_timeout,
                     is_production,
                 });
         },

--- a/packages/serverless/src/deployments/pubsub.rs
+++ b/packages/serverless/src/deployments/pubsub.rs
@@ -66,6 +66,7 @@ pub fn listen_pub_sub(
                     .collect::<HashMap<_, _>>(),
                 memory: value["memory"].as_u64().unwrap() as usize,
                 timeout: value["timeout"].as_u64().unwrap() as usize,
+                startup_timeout: value["startupTimeout"].as_u64().unwrap() as usize,
                 is_production: value["isProduction"].as_bool().unwrap(),
             };
 

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -162,6 +162,7 @@ async fn handle_request(
                             )
                             .with_memory(deployment.memory)
                             .with_timeout(deployment.timeout)
+                            .with_startup_timeout(deployment.startup_timeout)
                             .with_metadata(Some((deployment.id.clone(), deployment.function_id.clone())))
                             .with_on_drop_callback(Box::new(|metadata| {
                                 info!(deployment = metadata.unwrap().0; "Dropping isolate");


### PR DESCRIPTION
## About

Closes #277 

Add a new `startupTimeout` option to functions, which is different from `timeout`. When instantiating/evaluating large scripts, the timeout might be reached, even if executing the code itself wouldn't reach the timeout. So we introduce a larger `startupTimeout`, only when the isolate hasn't been created.