### PR TITLE
refactor(runtime): use macros for Rust <-> JS bindings

### DIFF
--- a/.changeset/real-ladybugs-scream.md
+++ b/.changeset/real-ladybugs-scream.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Use macros for Rust <-> JS bindings

--- a/packages/runtime/src/isolate/bindings/crypto/decrypt.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/decrypt.rs
@@ -1,77 +1,46 @@
 use crate::{
     crypto::{extract_algorithm_object, extract_cryptokey_key_value, Algorithm},
-    isolate::{
-        bindings::{BindingResult, PromiseResult},
-        Isolate,
-    },
-    utils::{extract_v8_uint8array, v8_string},
+    isolate::bindings::{BindingResult, PromiseResult},
+    utils::extract_v8_uint8array,
 };
 use aes_gcm::{aead::Aead, Aes256Gcm};
 use aes_gcm::{KeyInit, Nonce};
+use anyhow::Result;
 
-pub fn decrypt_binding(
+type Arg = (Algorithm, Vec<u8>, Vec<u8>);
+
+pub fn decrypt_init(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
-    mut retval: v8::ReturnValue,
-) {
-    let promise = v8::PromiseResolver::new(scope).unwrap();
+) -> Result<Arg> {
+    let algorithm = extract_algorithm_object(scope, args.get(0))?;
+    let key_value = extract_cryptokey_key_value(scope, args.get(1))?;
+    let data = extract_v8_uint8array(args.get(2))?;
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-    let id = state.js_promises.len() + 1;
+    Ok((algorithm, key_value, data))
+}
 
-    let algorithm = match extract_algorithm_object(scope, args.get(0)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
+pub async fn decrypt_binding(id: usize, arg: Arg) -> BindingResult {
+    let algorithm = arg.0;
+    let key_value = arg.1;
+    let data = arg.2;
+
+    let result = match algorithm {
+        Algorithm::AesGcm(iv) => {
+            let cipher = Aes256Gcm::new_from_slice(&key_value).unwrap();
+            let nonce = Nonce::from_slice(&iv);
+            cipher.decrypt(nonce, data.as_ref()).unwrap()
         }
-    };
-
-    let key_value = match extract_cryptokey_key_value(scope, args.get(1)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let data = match extract_v8_uint8array(args.get(2)) {
-        Ok(value) => value,
-        Err(_) => {
-            let error = v8_string(scope, "Data must be an Uint8Array");
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let future = async move {
-        let result = match algorithm {
-            Algorithm::AesGcm(iv) => {
-                let cipher = Aes256Gcm::new_from_slice(&key_value).unwrap();
-                let nonce = Nonce::from_slice(&iv);
-                cipher.decrypt(nonce, data.as_ref()).unwrap()
+        _ => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error("Algorithm not supported".into()),
             }
-            _ => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error("Algorithm not supported".into()),
-                }
-            }
-        };
-
-        BindingResult {
-            id,
-            result: PromiseResult::ArrayBuffer(result),
         }
     };
 
-    state.promises.push(Box::pin(future));
-
-    let global_promise = v8::Global::new(scope, promise);
-    state.js_promises.insert(id, global_promise);
-
-    retval.set(promise.into());
+    BindingResult {
+        id,
+        result: PromiseResult::ArrayBuffer(result),
+    }
 }

--- a/packages/runtime/src/isolate/bindings/crypto/digest.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/digest.rs
@@ -1,77 +1,54 @@
+use anyhow::Result;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{
     crypto::extract_algorithm_object_or_string,
-    isolate::{
-        bindings::{BindingResult, PromiseResult},
-        Isolate,
-    },
-    utils::{extract_v8_uint8array, v8_string},
+    isolate::bindings::{BindingResult, PromiseResult},
+    utils::extract_v8_uint8array,
 };
 
-pub fn digest_binding(
+type Arg = (String, Vec<u8>);
+
+pub fn digest_init(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
-    mut retval: v8::ReturnValue,
-) {
-    let promise = v8::PromiseResolver::new(scope).unwrap();
-    retval.set(promise.into());
+) -> Result<Arg> {
+    let name = extract_algorithm_object_or_string(scope, args.get(0))?;
+    let data = extract_v8_uint8array(args.get(1))?;
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-    let id = state.js_promises.len() + 1;
+    Ok((name, data))
+}
 
-    let global_promise = v8::Global::new(scope, promise);
-    state.js_promises.insert(id, global_promise);
+pub async fn digest_binding(id: usize, arg: Arg) -> BindingResult {
+    let name = arg.0;
+    let data = arg.1;
 
-    let name = match extract_algorithm_object_or_string(scope, args.get(0)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
+    let result = match name.as_str() {
+        "SHA-256" => {
+            let mut hasher = Sha256::new();
+            hasher.update(data);
+            hasher.finalize().to_vec()
+        }
+        "SHA-384" => {
+            let mut hasher = Sha384::new();
+            hasher.update(data);
+            hasher.finalize().to_vec()
+        }
+        "SHA-512" => {
+            let mut hasher = Sha512::new();
+            hasher.update(data);
+            hasher.finalize().to_vec()
+        }
+        _ => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error("Algorithm not found".into()),
+            }
         }
     };
 
-    let data = match extract_v8_uint8array(args.get(1)) {
-        Ok(value) => value,
-        Err(_) => {
-            let error = v8_string(scope, "Data must be an Uint8Array");
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let future = async move {
-        let result = match name.as_str() {
-            "SHA-256" => {
-                let mut hasher = Sha256::new();
-                hasher.update(data);
-                hasher.finalize().to_vec()
-            }
-            "SHA-384" => {
-                let mut hasher = Sha384::new();
-                hasher.update(data);
-                hasher.finalize().to_vec()
-            }
-            "SHA-512" => {
-                let mut hasher = Sha512::new();
-                hasher.update(data);
-                hasher.finalize().to_vec()
-            }
-            _ => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error("Algorithm not found".into()),
-                }
-            }
-        };
-
-        BindingResult {
-            id,
-            result: PromiseResult::ArrayBuffer(result),
-        }
-    };
-
-    state.promises.push(Box::pin(future));
+    BindingResult {
+        id,
+        result: PromiseResult::ArrayBuffer(result),
+    }
 }

--- a/packages/runtime/src/isolate/bindings/crypto/encrypt.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/encrypt.rs
@@ -1,77 +1,46 @@
 use crate::{
     crypto::{extract_algorithm_object, extract_cryptokey_key_value, Algorithm},
-    isolate::{
-        bindings::{BindingResult, PromiseResult},
-        Isolate,
-    },
-    utils::{extract_v8_uint8array, v8_string},
+    isolate::bindings::{BindingResult, PromiseResult},
+    utils::extract_v8_uint8array,
 };
 use aes_gcm::{aead::Aead, Aes256Gcm};
 use aes_gcm::{KeyInit, Nonce};
+use anyhow::Result;
 
-pub fn encrypt_binding(
+type Arg = (Algorithm, Vec<u8>, Vec<u8>);
+
+pub fn encrypt_init(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
-    mut retval: v8::ReturnValue,
-) {
-    let promise = v8::PromiseResolver::new(scope).unwrap();
+) -> Result<Arg> {
+    let algorithm = extract_algorithm_object(scope, args.get(0))?;
+    let key_value = extract_cryptokey_key_value(scope, args.get(1))?;
+    let data = extract_v8_uint8array(args.get(2))?;
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-    let id = state.js_promises.len() + 1;
+    Ok((algorithm, key_value, data))
+}
 
-    let algorithm = match extract_algorithm_object(scope, args.get(0)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
+pub async fn encrypt_binding(id: usize, arg: Arg) -> BindingResult {
+    let algorithm = arg.0;
+    let key_value = arg.1;
+    let data = arg.2;
+
+    let result = match algorithm {
+        Algorithm::AesGcm(iv) => {
+            let cipher = Aes256Gcm::new_from_slice(&key_value).unwrap();
+            let nonce = Nonce::from_slice(&iv);
+            cipher.encrypt(nonce, data.as_ref()).unwrap()
         }
-    };
-
-    let key_value = match extract_cryptokey_key_value(scope, args.get(1)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let data = match extract_v8_uint8array(args.get(2)) {
-        Ok(value) => value,
-        Err(_) => {
-            let error = v8_string(scope, "Data must be an Uint8Array");
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let future = async move {
-        let result = match algorithm {
-            Algorithm::AesGcm(iv) => {
-                let cipher = Aes256Gcm::new_from_slice(&key_value).unwrap();
-                let nonce = Nonce::from_slice(&iv);
-                cipher.encrypt(nonce, data.as_ref()).unwrap()
+        _ => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error("Algorithm not supported".into()),
             }
-            _ => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error("Algorithm not supported".into()),
-                }
-            }
-        };
-
-        BindingResult {
-            id,
-            result: PromiseResult::ArrayBuffer(result),
         }
     };
 
-    state.promises.push(Box::pin(future));
-
-    let global_promise = v8::Global::new(scope, promise);
-    state.js_promises.insert(id, global_promise);
-
-    retval.set(promise.into());
+    BindingResult {
+        id,
+        result: PromiseResult::ArrayBuffer(result),
+    }
 }

--- a/packages/runtime/src/isolate/bindings/crypto/mod.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/mod.rs
@@ -8,10 +8,10 @@ mod uuid;
 mod verify;
 
 pub use self::uuid::uuid_binding;
-pub use decrypt::decrypt_binding;
-pub use digest::digest_binding;
-pub use encrypt::encrypt_binding;
+pub use decrypt::{decrypt_binding, decrypt_init};
+pub use digest::{digest_binding, digest_init};
+pub use encrypt::{encrypt_binding, encrypt_init};
 pub use get_key_value::get_key_value_binding;
 pub use random_values::random_values_binding;
-pub use sign::sign_binding;
-pub use verify::verify_binding;
+pub use sign::{sign_binding, sign_init};
+pub use verify::{verify_binding, verify_init};

--- a/packages/runtime/src/isolate/bindings/crypto/sign.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/sign.rs
@@ -3,89 +3,55 @@ use crate::{
         extract_algorithm_object, extract_cryptokey_key_value, Algorithm, HmacSha256, HmacSha384,
         HmacSha512, Sha,
     },
-    isolate::{
-        bindings::{BindingResult, PromiseResult},
-        Isolate,
-    },
-    utils::{extract_v8_uint8array, v8_string},
+    isolate::bindings::{BindingResult, PromiseResult},
+    utils::extract_v8_uint8array,
 };
+use anyhow::Result;
 use hmac::Mac;
 
-pub fn sign_binding(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    mut retval: v8::ReturnValue,
-) {
-    let promise = v8::PromiseResolver::new(scope).unwrap();
+type Arg = (Algorithm, Vec<u8>, Vec<u8>);
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-    let id = state.js_promises.len() + 1;
+pub fn sign_init(scope: &mut v8::HandleScope, args: v8::FunctionCallbackArguments) -> Result<Arg> {
+    let algorithm = extract_algorithm_object(scope, args.get(0))?;
+    let key_value = extract_cryptokey_key_value(scope, args.get(1))?;
+    let data = extract_v8_uint8array(args.get(2))?;
 
-    let algorithm = match extract_algorithm_object(scope, args.get(0)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
+    Ok((algorithm, key_value, data))
+}
 
-    let key_value = match extract_cryptokey_key_value(scope, args.get(1)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
+pub async fn sign_binding(id: usize, arg: Arg) -> BindingResult {
+    let algorithm = arg.0;
+    let key_value = arg.1;
+    let data = arg.2;
 
-    let data = match extract_v8_uint8array(args.get(2)) {
-        Ok(value) => value,
-        Err(_) => {
-            let error = v8_string(scope, "Data must be an Uint8Array");
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let future = async move {
-        let result = match algorithm {
-            Algorithm::Hmac(sha) => match sha {
-                Sha::Sha256 => {
-                    let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
-                    mac.update(&data);
-                    mac.finalize().into_bytes().to_vec()
-                }
-                Sha::Sha384 => {
-                    let mut mac = HmacSha384::new_from_slice(&key_value).unwrap();
-                    mac.update(&data);
-                    mac.finalize().into_bytes().to_vec()
-                }
-                Sha::Sha512 => {
-                    let mut mac = HmacSha512::new_from_slice(&key_value).unwrap();
-                    mac.update(&data);
-                    mac.finalize().into_bytes().to_vec()
-                }
-            },
-            _ => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error("Algorithm not supported".into()),
-                }
+    let result = match algorithm {
+        Algorithm::Hmac(sha) => match sha {
+            Sha::Sha256 => {
+                let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
+                mac.update(&data);
+                mac.finalize().into_bytes().to_vec()
             }
-        };
-
-        BindingResult {
-            id,
-            result: PromiseResult::ArrayBuffer(result),
+            Sha::Sha384 => {
+                let mut mac = HmacSha384::new_from_slice(&key_value).unwrap();
+                mac.update(&data);
+                mac.finalize().into_bytes().to_vec()
+            }
+            Sha::Sha512 => {
+                let mut mac = HmacSha512::new_from_slice(&key_value).unwrap();
+                mac.update(&data);
+                mac.finalize().into_bytes().to_vec()
+            }
+        },
+        _ => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error("Algorithm not supported".into()),
+            }
         }
     };
 
-    state.promises.push(Box::pin(future));
-
-    let global_promise = v8::Global::new(scope, promise);
-    state.js_promises.insert(id, global_promise);
-
-    retval.set(promise.into());
+    BindingResult {
+        id,
+        result: PromiseResult::ArrayBuffer(result),
+    }
 }

--- a/packages/runtime/src/isolate/bindings/crypto/verify.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/verify.rs
@@ -3,97 +3,60 @@ use crate::{
         extract_algorithm_object, extract_cryptokey_key_value, Algorithm, HmacSha256, HmacSha384,
         Sha,
     },
-    isolate::{
-        bindings::{BindingResult, PromiseResult},
-        Isolate,
-    },
-    utils::{extract_v8_uint8array, v8_string},
+    isolate::bindings::{BindingResult, PromiseResult},
+    utils::extract_v8_uint8array,
 };
+use anyhow::Result;
 use hmac::Mac;
 
-pub fn verify_binding(
+type Arg = (Algorithm, Vec<u8>, Vec<u8>, Vec<u8>);
+
+pub fn verify_init(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
-    mut retval: v8::ReturnValue,
-) {
-    let promise = v8::PromiseResolver::new(scope).unwrap();
-    retval.set(promise.into());
+) -> Result<Arg> {
+    let algorithm = extract_algorithm_object(scope, args.get(0))?;
+    let key_value = extract_cryptokey_key_value(scope, args.get(1))?;
+    let signature = extract_v8_uint8array(args.get(2))?;
+    let data = extract_v8_uint8array(args.get(3))?;
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-    let id = state.js_promises.len() + 1;
+    Ok((algorithm, key_value, signature, data))
+}
 
-    let global_promise = v8::Global::new(scope, promise);
-    state.js_promises.insert(id, global_promise);
+pub async fn verify_binding(id: usize, arg: Arg) -> BindingResult {
+    let algorithm = arg.0;
+    let key_value = arg.1;
+    let signature = arg.2;
+    let data = arg.3;
 
-    let algorithm = match extract_algorithm_object(scope, args.get(0)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let key_value = match extract_cryptokey_key_value(scope, args.get(1)) {
-        Ok(value) => value,
-        Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let signature = match extract_v8_uint8array(args.get(2)) {
-        Ok(value) => value,
-        Err(_) => {
-            let error = v8_string(scope, "Signature must be an Uint8Array");
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let data = match extract_v8_uint8array(args.get(3)) {
-        Ok(value) => value,
-        Err(_) => {
-            let error = v8_string(scope, "Data must be an Uint8Array");
-            promise.reject(scope, error.into());
-            return;
-        }
-    };
-
-    let future = async move {
-        let result = match algorithm {
-            Algorithm::Hmac(sha) => match sha {
-                Sha::Sha256 => {
-                    let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
-                    mac.update(&data);
-                    mac.verify_slice(&signature).is_ok()
-                }
-                Sha::Sha384 => {
-                    let mut mac = HmacSha384::new_from_slice(&key_value).unwrap();
-                    mac.update(&data);
-                    mac.verify_slice(&signature).is_ok()
-                }
-                Sha::Sha512 => {
-                    let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
-                    mac.update(&data);
-                    mac.verify_slice(&signature).is_ok()
-                }
-            },
-            _ => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error("Algorithm not supported".into()),
-                }
+    let result = match algorithm {
+        Algorithm::Hmac(sha) => match sha {
+            Sha::Sha256 => {
+                let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
+                mac.update(&data);
+                mac.verify_slice(&signature).is_ok()
             }
-        };
-
-        BindingResult {
-            id,
-            result: PromiseResult::Boolean(result),
+            Sha::Sha384 => {
+                let mut mac = HmacSha384::new_from_slice(&key_value).unwrap();
+                mac.update(&data);
+                mac.verify_slice(&signature).is_ok()
+            }
+            Sha::Sha512 => {
+                let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
+                mac.update(&data);
+                mac.verify_slice(&signature).is_ok()
+            }
+        },
+        _ => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error("Algorithm not supported".into()),
+            }
         }
     };
 
-    state.promises.push(Box::pin(future));
+    BindingResult {
+        id,
+        result: PromiseResult::Boolean(result),
+    }
 }

--- a/packages/runtime/src/isolate/bindings/fetch.rs
+++ b/packages/runtime/src/isolate/bindings/fetch.rs
@@ -1,87 +1,62 @@
+use anyhow::{anyhow, Result};
 use hyper::{http::request::Builder, Body, Client};
 use hyper_tls::HttpsConnector;
 
 use crate::{
     http::{FromV8, Request, Response},
-    isolate::{bindings::PromiseResult, Isolate},
-    utils::v8_string,
+    isolate::bindings::PromiseResult,
 };
 
 use super::BindingResult;
 
-pub fn fetch_binding(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    mut retval: v8::ReturnValue,
-) {
-    let promise = v8::PromiseResolver::new(scope).unwrap();
-    retval.set(promise.into());
+type Arg = Request;
 
-    let state = Isolate::state(scope);
-    let mut state = state.borrow_mut();
-    let id = state.js_promises.len() + 1;
-
-    let global_promise = v8::Global::new(scope, promise);
-    state.js_promises.insert(id, global_promise);
-
+pub fn fetch_init(scope: &mut v8::HandleScope, args: v8::FunctionCallbackArguments) -> Result<Arg> {
     let request = match args.get(0).to_object(scope) {
         Some(request) => request,
-        None => {
-            let error = v8_string(scope, "Invalid request");
-            promise.reject(scope, error.into());
-            return;
-        }
+        None => return Err(anyhow!("Invalid request")),
     };
 
-    let request = match Request::from_v8(scope, request.into()) {
-        Ok(request) => request,
+    Request::from_v8(scope, request.into())
+}
+
+pub async fn fetch_binding(id: usize, arg: Arg) -> BindingResult {
+    let hyper_request = match Builder::try_from(&arg) {
+        Ok(hyper_request) => hyper_request,
         Err(error) => {
-            let error = v8_string(scope, &error.to_string());
-            promise.reject(scope, error.into());
-            return;
+            return BindingResult {
+                id,
+                result: PromiseResult::Error(error.to_string()),
+            }
         }
     };
 
-    let future = async move {
-        let hyper_request = match Builder::try_from(&request) {
-            Ok(hyper_request) => hyper_request,
-            Err(error) => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error(error.to_string()),
-                }
+    let hyper_request = match hyper_request.body(Body::from(arg.body)) {
+        Ok(hyper_request) => hyper_request,
+        Err(error) => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error(error.to_string()),
             }
-        };
-
-        let hyper_request = match hyper_request.body(Body::from(request.body)) {
-            Ok(hyper_request) => hyper_request,
-            Err(error) => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error(error.to_string()),
-                }
-            }
-        };
-
-        let client = Client::builder().build::<_, Body>(HttpsConnector::new());
-
-        let hyper_response = match client.request(hyper_request).await {
-            Ok(hyper_response) => hyper_response,
-            Err(error) => {
-                return BindingResult {
-                    id,
-                    result: PromiseResult::Error(error.to_string()),
-                }
-            }
-        };
-
-        let result = match Response::from_hyper(hyper_response).await {
-            Ok(response) => PromiseResult::Response(response),
-            Err(error) => PromiseResult::Error(error.to_string()),
-        };
-
-        BindingResult { id, result }
+        }
     };
 
-    state.promises.push(Box::pin(future));
+    let client = Client::builder().build::<_, Body>(HttpsConnector::new());
+
+    let hyper_response = match client.request(hyper_request).await {
+        Ok(hyper_response) => hyper_response,
+        Err(error) => {
+            return BindingResult {
+                id,
+                result: PromiseResult::Error(error.to_string()),
+            }
+        }
+    };
+
+    let result = match Response::from_hyper(hyper_response).await {
+        Ok(response) => PromiseResult::Response(response),
+        Err(error) => PromiseResult::Error(error.to_string()),
+    };
+
+    BindingResult { id, result }
 }

--- a/packages/runtime/src/isolate/bindings/mod.rs
+++ b/packages/runtime/src/isolate/bindings/mod.rs
@@ -1,11 +1,17 @@
 use console::console_binding;
-use crypto::{encrypt_binding, random_values_binding, sign_binding, uuid_binding, verify_binding};
-use fetch::fetch_binding;
+use crypto::{
+    decrypt_binding, decrypt_init, digest_binding, encrypt_binding, encrypt_init,
+    get_key_value_binding, random_values_binding, sign_binding, sign_init, uuid_binding,
+    verify_binding, verify_init,
+};
+use fetch::{fetch_binding, fetch_init};
 use pull_stream::pull_stream_binding;
 
-use crate::{http::Response, utils::v8_string};
-
-use self::crypto::{decrypt_binding, digest_binding, get_key_value_binding};
+use crate::{
+    http::Response,
+    isolate::{bindings::crypto::digest_init, Isolate},
+    utils::v8_string,
+};
 
 mod console;
 mod crypto;
@@ -24,64 +30,77 @@ pub enum PromiseResult {
     Error(String),
 }
 
+macro_rules! binding {
+    ($scope: ident, $lagon_object: ident, $name: literal, $binding: ident) => {
+        $lagon_object.set(
+            v8_string($scope, $name).into(),
+            v8::FunctionTemplate::new($scope, $binding).into(),
+        );
+    };
+}
+
+macro_rules! async_binding {
+    ($scope: ident, $lagon_object: ident, $name: literal, $init: expr, $binding: expr) => {
+        let binding = |scope: &mut v8::HandleScope,
+                       args: v8::FunctionCallbackArguments,
+                       mut retval: v8::ReturnValue| {
+            let promise = v8::PromiseResolver::new(scope).unwrap();
+            retval.set(promise.into());
+
+            let state = Isolate::state(scope);
+            let mut state = state.borrow_mut();
+            let id = state.js_promises.len() + 1;
+
+            let global_promise = v8::Global::new(scope, promise);
+            state.js_promises.insert(id, global_promise);
+
+            match $init(scope, args) {
+                Ok(args) => {
+                    let future = $binding(id, args);
+
+                    state.promises.push(Box::pin(future));
+                }
+                Err(error) => {
+                    let error = v8_string(scope, &error.to_string());
+                    promise.reject(scope, error.into());
+                }
+            }
+        };
+
+        $lagon_object.set(
+            v8_string($scope, $name).into(),
+            v8::FunctionTemplate::new($scope, binding).into(),
+        );
+    };
+}
+
 pub fn bind(scope: &mut v8::HandleScope<()>) -> v8::Global<v8::Context> {
     let global = v8::ObjectTemplate::new(scope);
 
     let lagon_object = v8::ObjectTemplate::new(scope);
 
-    lagon_object.set(
-        v8_string(scope, "log").into(),
-        v8::FunctionTemplate::new(scope, console_binding).into(),
+    binding!(scope, lagon_object, "log", console_binding);
+    async_binding!(scope, lagon_object, "fetch", fetch_init, fetch_binding);
+    binding!(scope, lagon_object, "pullStream", pull_stream_binding);
+    binding!(scope, lagon_object, "uuid", uuid_binding);
+    binding!(scope, lagon_object, "randomValues", random_values_binding);
+    async_binding!(scope, lagon_object, "sign", sign_init, sign_binding);
+    async_binding!(scope, lagon_object, "verify", verify_init, verify_binding);
+    binding!(scope, lagon_object, "getKeyValue", get_key_value_binding);
+    async_binding!(scope, lagon_object, "digest", digest_init, digest_binding);
+    async_binding!(
+        scope,
+        lagon_object,
+        "encrypt",
+        encrypt_init,
+        encrypt_binding
     );
-
-    lagon_object.set(
-        v8_string(scope, "fetch").into(),
-        v8::FunctionTemplate::new(scope, fetch_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "pullStream").into(),
-        v8::FunctionTemplate::new(scope, pull_stream_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "uuid").into(),
-        v8::FunctionTemplate::new(scope, uuid_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "randomValues").into(),
-        v8::FunctionTemplate::new(scope, random_values_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "sign").into(),
-        v8::FunctionTemplate::new(scope, sign_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "verify").into(),
-        v8::FunctionTemplate::new(scope, verify_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "getKeyValue").into(),
-        v8::FunctionTemplate::new(scope, get_key_value_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "digest").into(),
-        v8::FunctionTemplate::new(scope, digest_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "encrypt").into(),
-        v8::FunctionTemplate::new(scope, encrypt_binding).into(),
-    );
-
-    lagon_object.set(
-        v8_string(scope, "decrypt").into(),
-        v8::FunctionTemplate::new(scope, decrypt_binding).into(),
+    async_binding!(
+        scope,
+        lagon_object,
+        "decrypt",
+        decrypt_init,
+        decrypt_binding
     );
 
     global.set(v8_string(scope, "Lagon").into(), lagon_object.into());


### PR DESCRIPTION
## About

Use two macros for Rust <-> JS bindings, instead of duplicating code (particularly with async bindings).

Now you can use
- `binding!()` for sync bindings, that take the same binding function as before
- `async_binding!()` for async bindings, which take a function to return the parsed args, and a second function that is async and returns a `PromiseResult`. This last function is basically the future we created before.
