### PR TITLE
perf(serverless): don't spawn a thread on each request

### DIFF
--- a/.changeset/funny-peaches-tie.md
+++ b/.changeset/funny-peaches-tie.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Improve performances by not spawning a thread on each request

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,10 +1383,12 @@ dependencies = [
  "httptest",
  "hyper",
  "hyper-tls",
+ "lazy_static",
  "log",
  "rand",
  "sha2",
  "tokio",
+ "tokio-util",
  "uuid",
  "v8",
 ]

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 v8 = "0.58.0"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7.4", features = ["rt"] }
 futures = "0.3.25"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
 hyper-tls = { version = "0.5.0", features = ["vendored"] }
@@ -14,6 +15,7 @@ anyhow = "1.0.66"
 uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 rand = "0.8.5"
 log = { version = "0.4.17", features = ["std", "kv_unstable"] }
+lazy_static = "1.4.0"
 # Cryptography
 hmac = "0.12.1"
 sha2 = "0.10.6"

--- a/packages/runtime/src/runtime/mod.rs
+++ b/packages/runtime/src/runtime/mod.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+use tokio_util::task::LocalPoolHandle;
 use v8::V8;
 
 use crate::{isolate::IsolateOptions, utils::v8_string};
@@ -7,6 +9,10 @@ struct IcuData([u8; 10454784]);
 
 static JS_RUNTIME: &str = include_str!("../../runtime.js");
 static ICU_DATA: IcuData = IcuData(*include_bytes!("../../icudtl.dat"));
+
+lazy_static! {
+    pub static ref POOL: LocalPoolHandle = LocalPoolHandle::new(1);
+}
 
 #[derive(Default)]
 pub struct RuntimeOptions {


### PR DESCRIPTION
## About

Instead of using `spawn_blocking` which spawns a dedicated blocking thread (until the default limit of 512) to run the task, we can use a `LocalPoolHandle` of size 1 to always run the timeout futures on the same thread.
