### PR TITLE
fix(cli,dashboard): promote deployments without existing production deployments

### DIFF
--- a/.changeset/dry-mangos-allow.md
+++ b/.changeset/dry-mangos-allow.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix some commands returning an error due to wrong parsing

--- a/.changeset/sweet-kids-flash.md
+++ b/.changeset/sweet-kids-flash.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Allow promoting deployments for functions without a production deployment

--- a/packages/cli/src/commands/promote.rs
+++ b/packages/cli/src/commands/promote.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use dialoguer::Confirm;
 use std::path::PathBuf;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::utils::{
     get_function_config, info, print_progress, success, validate_code_file, Config, TrpcClient,
@@ -13,6 +13,12 @@ use crate::utils::{
 struct PromoteDeploymentRequest {
     function_id: String,
     deployment_id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct PromoteDeploymentResponse {
+    #[allow(dead_code)]
+    ok: bool,
 }
 
 pub async fn promote(file: PathBuf, deployment_id: String) -> Result<()> {
@@ -37,7 +43,7 @@ pub async fn promote(file: PathBuf, deployment_id: String) -> Result<()> {
             true => {
                 let end_progress = print_progress("Promoting Deployment...");
                 TrpcClient::new(&config)
-                    .mutation::<PromoteDeploymentRequest, ()>(
+                    .mutation::<PromoteDeploymentRequest, PromoteDeploymentResponse>(
                         "deploymentPromote",
                         PromoteDeploymentRequest {
                             function_id: function_config.function_id,

--- a/packages/cli/src/commands/rm.rs
+++ b/packages/cli/src/commands/rm.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use std::path::PathBuf;
 
 use dialoguer::Confirm;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::utils::{
     delete_function_config, get_function_config, info, print_progress, success, validate_code_file,
@@ -13,6 +13,12 @@ use crate::utils::{
 #[serde(rename_all = "camelCase")]
 struct DeleteFunctionRequest {
     function_id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct DeleteFunctionResponse {
+    #[allow(dead_code)]
+    ok: bool,
 }
 
 pub async fn rm(file: PathBuf) -> Result<()> {
@@ -37,7 +43,7 @@ pub async fn rm(file: PathBuf) -> Result<()> {
             true => {
                 let end_progress = print_progress("Deleting Function...");
                 TrpcClient::new(&config)
-                    .mutation::<DeleteFunctionRequest, ()>(
+                    .mutation::<DeleteFunctionRequest, DeleteFunctionResponse>(
                         "functionDelete",
                         DeleteFunctionRequest {
                             function_id: function_config.function_id,

--- a/packages/cli/src/commands/undeploy.rs
+++ b/packages/cli/src/commands/undeploy.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use dialoguer::Confirm;
 use std::path::PathBuf;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::utils::{
     get_function_config, info, print_progress, success, validate_code_file, Config, TrpcClient,
@@ -13,6 +13,12 @@ use crate::utils::{
 struct DeleteDeploymentRequest {
     function_id: String,
     deployment_id: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct DeleteDeploymentResponse {
+    #[allow(dead_code)]
+    ok: bool,
 }
 
 pub async fn undeploy(file: PathBuf, deployment_id: String) -> Result<()> {
@@ -35,7 +41,7 @@ pub async fn undeploy(file: PathBuf, deployment_id: String) -> Result<()> {
             true => {
                 let end_progress = print_progress("Deleting Deployment...");
                 TrpcClient::new(&config)
-                    .mutation::<DeleteDeploymentRequest, ()>(
+                    .mutation::<DeleteDeploymentRequest, DeleteDeploymentResponse>(
                         "deploymentDelete",
                         DeleteDeploymentRequest {
                             function_id: function_config.function_id,

--- a/packages/cli/src/utils/trpc.rs
+++ b/packages/cli/src/utils/trpc.rs
@@ -38,11 +38,11 @@ impl<'a> TrpcClient<'a> {
         Self { client, config }
     }
 
-    pub async fn query<T: Serialize, R: DeserializeOwned>(
-        &self,
-        key: &str,
-        body: Option<T>,
-    ) -> Result<TrpcResponse<R>> {
+    pub async fn query<T, R>(&self, key: &str, body: Option<T>) -> Result<TrpcResponse<R>>
+    where
+        T: Serialize,
+        R: DeserializeOwned,
+    {
         let input = match body {
             Some(body) => format!("?input={}", encode(&serde_json::to_string(&body)?)),
             None => String::new(),
@@ -73,11 +73,11 @@ impl<'a> TrpcClient<'a> {
         }
     }
 
-    pub async fn mutation<T: Serialize, R: DeserializeOwned>(
-        &self,
-        key: &str,
-        body: T,
-    ) -> Result<TrpcResponse<R>> {
+    pub async fn mutation<T, R>(&self, key: &str, body: T) -> Result<TrpcResponse<R>>
+    where
+        T: Serialize,
+        R: DeserializeOwned,
+    {
         let body = serde_json::to_string(&body)?;
 
         let request = Request::builder()

--- a/packages/dashboard/lib/api/deployments.ts
+++ b/packages/dashboard/lib/api/deployments.ts
@@ -137,9 +137,12 @@ export async function removeDeployment(
   );
 }
 
-export async function unpromoteProductionDeployment(functionId: string): Promise<{
-  id: string;
-}> {
+export async function unpromoteProductionDeployment(functionId: string): Promise<
+  | {
+      id: string;
+    }
+  | undefined
+> {
   const currentDeployment = await prisma.deployment.findFirst({
     where: {
       functionId,
@@ -151,9 +154,7 @@ export async function unpromoteProductionDeployment(functionId: string): Promise
   });
 
   if (!currentDeployment) {
-    throw new TRPCError({
-      code: 'NOT_FOUND',
-    });
+    return undefined;
   }
 
   return prisma.deployment.update({
@@ -223,7 +224,7 @@ export async function promoteProductionDeployment(functionId: string, newDeploym
   await redis.publish(
     'promote',
     JSON.stringify({
-      previousDeploymentId: previousDeployment.id,
+      previousDeploymentId: previousDeployment?.id || '',
       functionId: func.id,
       functionName: func.name,
       deploymentId: newDeploymentId,

--- a/packages/dashboard/lib/trpc/accountsRouter.ts
+++ b/packages/dashboard/lib/trpc/accountsRouter.ts
@@ -22,5 +22,7 @@ export const accountsRouter = (t: T) =>
           },
           select: null,
         });
+
+        return { ok: true };
       }),
   });

--- a/packages/dashboard/lib/trpc/deploymentsRouter.ts
+++ b/packages/dashboard/lib/trpc/deploymentsRouter.ts
@@ -105,11 +105,7 @@ export const deploymentsRouter = (t: T) =>
         });
 
         if (input.isProduction) {
-          try {
-            await unpromoteProductionDeployment(input.functionId);
-          } catch {
-            // this is the first deployment
-          }
+          await unpromoteProductionDeployment(input.functionId);
         }
 
         const [func, deployment] = await Promise.all([
@@ -183,6 +179,8 @@ export const deploymentsRouter = (t: T) =>
       )
       .mutation(async ({ input }) => {
         await promoteProductionDeployment(input.functionId, input.deploymentId);
+
+        return { ok: true };
       }),
     deploymentDelete: t.procedure
       .input(
@@ -231,5 +229,7 @@ export const deploymentsRouter = (t: T) =>
           },
           input.deploymentId,
         );
+
+        return { ok: true };
       }),
   });

--- a/packages/dashboard/lib/trpc/functionsRouter.ts
+++ b/packages/dashboard/lib/trpc/functionsRouter.ts
@@ -339,6 +339,8 @@ export const functionsRouter = (t: T) =>
             currentDomains,
           );
         }
+
+        return { ok: true };
       }),
     functionDelete: t.procedure
       .input(
@@ -393,5 +395,7 @@ export const functionsRouter = (t: T) =>
         }
 
         await removeFunction(func);
+
+        return { ok: true };
       }),
   });

--- a/packages/dashboard/lib/trpc/organizationsRouter.ts
+++ b/packages/dashboard/lib/trpc/organizationsRouter.ts
@@ -48,6 +48,8 @@ export const organizationsRouter = (t: T) =>
             currentOrganizationId: organization.id,
           },
         });
+
+        return { ok: true };
       }),
     organizationUpdate: t.procedure
       .input(
@@ -68,6 +70,8 @@ export const organizationsRouter = (t: T) =>
           },
           select: null,
         });
+
+        return { ok: true };
       }),
     organizationsDelete: t.procedure
       .input(
@@ -141,6 +145,8 @@ export const organizationsRouter = (t: T) =>
             currentOrganizationId: leftOrganization?.id,
           },
         });
+
+        return { ok: true };
       }),
     organizationSetCurrent: t.procedure
       .input(
@@ -157,5 +163,7 @@ export const organizationsRouter = (t: T) =>
             currentOrganizationId: input.organizationId,
           },
         });
+
+        return { ok: true };
       }),
   });

--- a/packages/dashboard/lib/trpc/tokensRouter.ts
+++ b/packages/dashboard/lib/trpc/tokensRouter.ts
@@ -118,5 +118,7 @@ export const tokensRouter = (t: T) =>
             id: input.tokenId,
           },
         });
+
+        return { ok: true };
       }),
   });


### PR DESCRIPTION
## About

- Allow promoting deployments when a function doesn't have any production deployment
- Always return data for tRPC to fix a bug in CLI while parsing empty responses