### PR TITLE
ci: publish assets on release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,10 @@
 name: CD
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '@lagon/cli@*'
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## About

Trigger the CD workflow when the `Release` workflow is `completed` to upload the artifacts to the created release.
