### PR TITLE
fix(dashboard): use `query` instead of `queryLegacy` for axiom

### DIFF
--- a/.changeset/bright-spoons-switch.md
+++ b/.changeset/bright-spoons-switch.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Use query instead of queryLegacy for axiom


### PR DESCRIPTION
## About

Use `query` instead of `queryLegacy` for axiom logs, using an apl query string.
