### PR TITLE
fix(serverless): don't use a .env file on release

### DIFF
--- a/.changeset/green-flowers-cross.md
+++ b/.changeset/green-flowers-cross.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Don't use a .env file on release builds

--- a/docker/serverless.Dockerfile
+++ b/docker/serverless.Dockerfile
@@ -10,7 +10,10 @@ RUN cargo build --release
 FROM rust:1.65
 
 COPY --from=builder /app/target/release/lagon-serverless /usr/local/bin/lagon-serverless
-COPY --from=builder /app/.env ./.env
 
+# Serverless
 EXPOSE 4000
+# Prometheus
+EXPOSE 9000
+
 CMD ["lagon-serverless"]

--- a/packages/serverless/src/deployments/cache.rs
+++ b/packages/serverless/src/deployments/cache.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    env,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -13,10 +14,10 @@ const CACHE_TASK_INTERVAL: Duration = Duration::from_secs(60);
 
 pub fn run_cache_clear_task(last_requests: Arc<RwLock<HashMap<String, Instant>>>) {
     let isolates_cache_seconds = Duration::from_secs(
-        dotenv::var("LAGON_ISOLATES_CACHE_SECONDS")
-            .expect("LAGON_ISOLATES_CACHE_SECONDS must be set")
+        env::var("LAGON_ISOLATES_CACHE_SECONDS")
+            .expect("LAGON_ISOLATES_CACHE_SECONDS is not set")
             .parse()
-            .expect("Failed to parse LAGON_ISOLATES_CACHE_SECONDS"),
+            .expect("LAGON_ISOLATES_CACHE_SECONDS is not a valid number"),
     );
 
     tokio::spawn(async move {

--- a/packages/serverless/src/deployments/mod.rs
+++ b/packages/serverless/src/deployments/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    fs,
+    env, fs,
     path::Path,
     sync::Arc,
 };
@@ -43,7 +43,7 @@ impl Deployment {
         domains.push(format!(
             "{}.{}",
             self.id,
-            dotenv::var("LAGON_ROOT_DOMAIN").expect("LAGON_ROOT_DOMAIN must be set")
+            env::var("LAGON_ROOT_DOMAIN").expect("LAGON_ROOT_DOMAIN must be set")
         ));
 
         // Default domain (function's name) and custom domains are only set in production deployments
@@ -51,7 +51,7 @@ impl Deployment {
             domains.push(format!(
                 "{}.{}",
                 self.function_name,
-                dotenv::var("LAGON_ROOT_DOMAIN").expect("LAGON_ROOT_DOMAIN must be set")
+                env::var("LAGON_ROOT_DOMAIN").expect("LAGON_ROOT_DOMAIN must be set")
             ));
 
             domains.extend(self.domains.clone());

--- a/packages/serverless/src/deployments/pubsub.rs
+++ b/packages/serverless/src/deployments/pubsub.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, env, sync::Arc};
 
 use anyhow::Result;
 use log::{error, warn};
@@ -26,7 +26,7 @@ pub fn listen_pub_sub(
     deployments: Arc<RwLock<HashMap<String, Arc<Deployment>>>>,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
-        let url = dotenv::var("REDIS_URL").expect("REDIS_URL must be set");
+        let url = env::var("REDIS_URL").expect("REDIS_URL must be set");
         let client = redis::Client::open(url)?;
         let mut conn = client.get_connection()?;
         let mut pub_sub = conn.as_pubsub();

--- a/packages/serverless/src/logger.rs
+++ b/packages/serverless/src/logger.rs
@@ -2,7 +2,10 @@ use axiom_rs::Client;
 use chrono::prelude::Local;
 use flume::Sender;
 use serde_json::{json, Value};
-use std::sync::{Arc, RwLock};
+use std::{
+    env,
+    sync::{Arc, RwLock},
+};
 
 use log::{
     as_debug, kv::source::as_map, set_boxed_logger, set_max_level, Level, LevelFilter, Log,
@@ -35,7 +38,7 @@ impl SimpleLogger {
 
         Self {
             tx: Arc::new(RwLock::new(Some(tx))),
-            region: dotenv::var("LAGON_REGION").expect("LAGON_REGION must be set"),
+            region: env::var("LAGON_REGION").expect("LAGON_REGION must be set"),
         }
     }
 }

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -22,6 +22,7 @@ use s3::creds::Credentials;
 use s3::Bucket;
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -262,7 +263,10 @@ async fn handle_request(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Only load a .env file on development
+    #[cfg(debug_assertions)]
     dotenv::dotenv().expect("Failed to load .env file");
+
     let _flush_guard = init_logger().expect("Failed to init logger");
 
     let runtime = Runtime::new(RuntimeOptions::default());
@@ -271,7 +275,7 @@ async fn main() -> Result<()> {
     let builder = PrometheusBuilder::new();
     builder.install().expect("Failed to start metrics exporter");
 
-    let url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
     #[cfg(not(debug_assertions))]
@@ -281,11 +285,11 @@ async fn main() -> Result<()> {
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 
-    let bucket_name = dotenv::var("S3_BUCKET").expect("S3_BUCKET must be set");
+    let bucket_name = env::var("S3_BUCKET").expect("S3_BUCKET must be set");
     let region = "eu-west-3".parse()?;
     let credentials = Credentials::new(
-        Some(&dotenv::var("S3_ACCESS_KEY_ID").expect("S3_ACCESS_KEY_ID must be set")),
-        Some(&dotenv::var("S3_SECRET_ACCESS_KEY").expect("S3_SECRET_ACCESS_KEY must be set")),
+        Some(&env::var("S3_ACCESS_KEY_ID").expect("S3_ACCESS_KEY_ID must be set")),
+        Some(&env::var("S3_SECRET_ACCESS_KEY").expect("S3_SECRET_ACCESS_KEY must be set")),
         None,
         None,
         None,


### PR DESCRIPTION
## About

- Only load a `.env` file on debug builds.
- Expose the prometheus port on the Dockerfile (9000)
