### PR TITLE
feat(cli,runtime): allow code generation via a flag

### DIFF
--- a/.changeset/cyan-points-eat.md
+++ b/.changeset/cyan-points-eat.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Configurable code generation

--- a/.changeset/grumpy-oranges-marry.md
+++ b/.changeset/grumpy-oranges-marry.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Add --allow-code-generation flag to dev command

--- a/.changeset/serious-ties-join.md
+++ b/.changeset/serious-ties-join.md
@@ -1,0 +1,5 @@
+---
+'@lagon/docs': patch
+---
+
+Add --allow-code-generation docs for lagon dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,12 +11,7 @@ RUN npm run build
 FROM rust:1.65-buster as builder
 
 WORKDIR /app
-RUN mkdir ./packages
-COPY ./Cargo.toml ./
-COPY ./packages/cli/ ./packages/cli
-COPY ./packages/wpt-runner/ ./packages/wpt-runner
-COPY ./packages/runtime/ ./packages/runtime
-COPY ./packages/serverless/ ./packages/serverless
+COPY . ./
 
 WORKDIR /app/packages/serverless
 COPY --from=runtime /app/dist/index.js /app/packages/js-runtime/dist/

--- a/packages/cli/src/commands/dev.rs
+++ b/packages/cli/src/commands/dev.rs
@@ -21,7 +21,8 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 
 use crate::utils::{
-    bundle_function, info, input, success, validate_code_file, validate_public_dir, FileCursor,
+    bundle_function, info, input, success, validate_code_file, validate_public_dir, warn,
+    FileCursor,
 };
 
 use log::{
@@ -208,6 +209,7 @@ pub async fn dev(
     port: Option<u16>,
     hostname: Option<String>,
     env: Option<PathBuf>,
+    allow_code_generation: bool,
 ) -> Result<()> {
     validate_code_file(&file)?;
 
@@ -224,7 +226,8 @@ pub async fn dev(
 
     let content = Arc::new(Mutex::new((index, assets)));
 
-    let runtime = Runtime::new(RuntimeOptions::default());
+    let runtime =
+        Runtime::new(RuntimeOptions::default().with_allow_code_generation(allow_code_generation));
     let addr = format!(
         "{}:{}",
         hostname.unwrap_or_else(|| "127.0.0.1".into()),
@@ -284,6 +287,14 @@ pub async fn dev(
 
     println!();
     println!("{}", success("Dev Server started!"));
+
+    if allow_code_generation {
+        println!(
+            "{}",
+            warn("Code generation is allowed due to `--allow-code-generation`")
+        );
+    }
+
     println!();
     println!(" {} http://{}", "➤".black(), format!("{}", addr).blue());
     println!();

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -72,6 +72,9 @@ enum Commands {
         /// Path to a env file to parse
         #[clap(short, long, value_parser)]
         env: Option<PathBuf>,
+        /// Allow code generation from strings using `eval` / `new Function`
+        #[clap(long)]
+        allow_code_generation: bool,
     },
     /// Build a Function without deploying it
     Build {
@@ -137,7 +140,19 @@ async fn main() {
                 port,
                 hostname,
                 env,
-            } => commands::dev(file, client, public_dir, port, hostname, env).await,
+                allow_code_generation,
+            } => {
+                commands::dev(
+                    file,
+                    client,
+                    public_dir,
+                    port,
+                    hostname,
+                    env,
+                    allow_code_generation,
+                )
+                .await
+            }
             Commands::Build {
                 file,
                 client,

--- a/packages/cli/src/utils/console.rs
+++ b/packages/cli/src/utils/console.rs
@@ -25,6 +25,10 @@ pub fn error(message: &str) -> String {
     format!("{} {}", "✖".red(), message)
 }
 
+pub fn warn(message: &str) -> String {
+    format!("{} {}", "○".yellow(), message)
+}
+
 pub fn print_progress(message: &str) -> impl Fn() + '_ {
     let index_progress = ProgressBar::new_spinner();
     index_progress.set_style(ProgressStyle::default_spinner());

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -132,6 +132,7 @@ This command accept the same arguments and options as `lagon deploy` and `lagon 
 - `--hostname <HOSTNAME>` allows you to specify a custom hostname the start the server on. (Default: `127.0.0.1`)
 - `--port <PORT>` allows you to specify a custom port the start the server on. (Default: `1234`)
 - `--env <PATH>` allows you to specify an environment file (typically `.env`) to use to inject environment variables.
+- `--allow-code-generation` allows you to enable code generation from strings (`eval` / `new Function`)
 
 <Callout type="warning">
   Although the `dev` command uses the exact same Runtime as when deployed, the local HTTP server itself doesn't have the

--- a/packages/runtime/src/runtime/mod.rs
+++ b/packages/runtime/src/runtime/mod.rs
@@ -16,7 +16,14 @@ lazy_static! {
 
 #[derive(Default)]
 pub struct RuntimeOptions {
-    allow_eval: bool,
+    allow_code_generation: bool,
+}
+
+impl RuntimeOptions {
+    pub fn with_allow_code_generation(mut self, allow_code_generation: bool) -> Self {
+        self.allow_code_generation = allow_code_generation;
+        self
+    }
 }
 
 pub struct Runtime;
@@ -27,8 +34,8 @@ impl Runtime {
         // https://github.com/denoland/deno/blob/a55b194638bcaace38917703b7d9233fb1989d44/core/runtime.rs#L223
         v8::icu::set_common_data_71(&ICU_DATA.0).expect("Failed to load ICU data");
 
-        // Disable code generation from `eval(...)` / `new Function(...)`
-        if !options.allow_eval {
+        // Disable code generation from `code_generation(...)` / `new Function(...)`
+        if !options.allow_code_generation {
             V8::set_flags_from_string("--disallow-code-generation-from-strings");
         }
 

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -66,7 +66,11 @@ async fn handle_request(
     let hostname = match req.headers().get(HOST) {
         Some(hostname) => hostname.to_str()?.to_string(),
         None => {
-            increment_counter!("lagon_ignored_requests", "reason" => "No hostname");
+            increment_counter!(
+                "lagon_ignored_requests",
+                "reason" => "No hostname",
+                "region" => REGION.clone(),
+            );
             warn!(request = as_debug!(req), ip = ip; "No hostname found in request");
 
             return Ok(Builder::new().status(404).body(PAGE_404.into())?);
@@ -77,7 +81,12 @@ async fn handle_request(
     let deployment = match deployments.get(&hostname) {
         Some(deployment) => Arc::clone(deployment),
         None => {
-            increment_counter!("lagon_ignored_requests", "reason" => "No deployment", "hostname" => hostname.clone());
+            increment_counter!(
+                "lagon_ignored_requests",
+                "reason" => "No deployment",
+                "hostname" => hostname.clone(),
+                "region" => REGION.clone(),
+            );
             warn!(request = as_debug!(req), ip = ip, hostname = hostname; "No deployment found for hostname");
 
             return Ok(HyperResponse::builder().status(404).body(PAGE_404.into())?);


### PR DESCRIPTION
## About

Allow code generation in the CLI with a new `--allow-code-generation` flag in `lagon dev`.
Also fix the runtime to be able to configure this option, which wasn't possible before.