### PR TITLE
feat(serverless): forward `X-Real-Ip` as `X-Forwarded-For` & `X-Lagon-Region`

### DIFF
--- a/.changeset/spotty-wombats-bathe.md
+++ b/.changeset/spotty-wombats-bathe.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Forward X-Real-Ip header to X-Forwarded-For

--- a/.changeset/wise-cooks-warn.md
+++ b/.changeset/wise-cooks-warn.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Forward X-Lagon-Region header

--- a/packages/runtime/tests/disallow_codegen.rs
+++ b/packages/runtime/tests/disallow_codegen.rs
@@ -51,4 +51,3 @@ async fn disallow_function() {
         RunResult::Error("Uncaught EvalError: Code generation from strings disallowed for this context, at:\n    const result = new Function('return 1 + 1')".into())
     );
 }
-


### PR DESCRIPTION
## About

Closes #330

- Forward the `X-Real-Ip` header as `X-Forwarded-For` (or fallback to the remote addr IP if the header is not found)
- Add a new `X-Lagon-Region` header