### PR TITLE
perf(runtime): avoid creating a new HTTP(S) client on each `fetch` call

### DIFF
--- a/.changeset/breezy-guests-nail.md
+++ b/.changeset/breezy-guests-nail.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Avoid creating a new HTTP(S) client on each `fetch` call

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-v8 = "0.60.0"
+v8 = "0.59.0"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["rt"] }
 futures = "0.3.25"

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-v8 = "0.59.0"
+v8 = "0.60.0"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["rt"] }
 futures = "0.3.25"

--- a/packages/runtime/src/isolate/bindings/fetch.rs
+++ b/packages/runtime/src/isolate/bindings/fetch.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
-use hyper::{http::request::Builder, Body, Client};
+use hyper::{client::HttpConnector, http::request::Builder, Body, Client};
 use hyper_tls::HttpsConnector;
+use lazy_static::lazy_static;
 
 use crate::{
     http::{FromV8, Request, Response},
@@ -8,6 +9,11 @@ use crate::{
 };
 
 use super::BindingResult;
+
+lazy_static! {
+    static ref CLIENT: Client<HttpsConnector<HttpConnector>> =
+        Client::builder().build::<_, Body>(HttpsConnector::new());
+}
 
 type Arg = Request;
 
@@ -41,9 +47,7 @@ pub async fn fetch_binding(id: usize, arg: Arg) -> BindingResult {
         }
     };
 
-    let client = Client::builder().build::<_, Body>(HttpsConnector::new());
-
-    let hyper_response = match client.request(hyper_request).await {
+    let hyper_response = match CLIENT.request(hyper_request).await {
         Ok(hyper_response) => hyper_response,
         Err(error) => {
             return BindingResult {


### PR DESCRIPTION
## About

Hoist the HTTP(S) client using `lazy_static` to avoid creating and allocating a new client on each `fetch` binding call.
