### PR TITLE
test(runtime): throw error if `handler` is not a function

### DIFF
--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -80,6 +80,10 @@ export async function masterHandler(request: {
   h: ResponseInit['headers'];
   s: ResponseInit['status'];
 }> {
+  if (typeof handler !== 'function') {
+    throw new Error('Handler function is not defined or is not a function');
+  }
+
   const handlerRequest = new Request(request.i, {
     method: request.m,
     headers: request.h,


### PR DESCRIPTION
## About

Throw an error if `handler` is not a function. Add 2 tests in `runtime` to test this behavior.
