### PR TITLE
feat(serverless): add metrics for errors/timeouts/memory limits

### DIFF
--- a/.changeset/clever-ears-juggle.md
+++ b/.changeset/clever-ears-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Add metrics for errors/timeouts/memory limits

--- a/packages/dashboard/lib/trpc/statsRouter.ts
+++ b/packages/dashboard/lib/trpc/statsRouter.ts
@@ -71,7 +71,7 @@ export const statsRouter = (t: T) =>
       .query(async ({ input }) => {
         const step = getStep(input.timeframe);
         const { result } = await prometheus(
-          `increase(lagon_requests{function="${input.functionId}"}[${step}s])`,
+          `increase(lagon_isolate_requests{function="${input.functionId}"}[${step}s])`,
           input.timeframe,
         );
 

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -282,9 +282,11 @@ async fn handle_request(
         RunResult::Timeout | RunResult::MemoryLimit => {
             match result {
                 RunResult::Timeout => {
+                    increment_counter!("lagon_isolate_timeouts", &labels);
                     warn!(deployment = deployment_id; "Function execution timed out")
                 }
                 RunResult::MemoryLimit => {
+                    increment_counter!("lagon_isolate_memory_limits", &labels);
                     warn!(deployment = deployment_id; "Function execution memory limit reached")
                 }
                 _ => {}
@@ -293,6 +295,7 @@ async fn handle_request(
             Ok(HyperResponse::builder().status(502).body(PAGE_502.into())?)
         }
         RunResult::Error(error) => {
+            increment_counter!("lagon_isolate_errors", &labels);
             error!(deployment = deployment_id; "Function execution error: {}", error);
 
             Ok(HyperResponse::builder().status(500).body(PAGE_500.into())?)


### PR DESCRIPTION
## About

Add new metrics for other types of responses (errors, timeouts, memory limits) in serverless
