### PR TITLE
feat(js-runtime,docs): add `navigator.userAgent` API

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,18 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.0.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "lagonapp/lagon" }],
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "lagonapp/lagon"
+    }
+  ],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@lagon/runtime",
+      "@lagon/js-runtime"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/tricky-dogs-impress.md
+++ b/.changeset/tricky-dogs-impress.md
@@ -1,0 +1,6 @@
+---
+'@lagon/docs': minor
+'@lagon/js-runtime': minor
+---
+
+Add `navigator.userAgent` API

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -32,7 +32,7 @@ You can log multiple objects, and use string substitution. [See the documentatio
 
 ### `process`
 
-The only usage of `process` is to get [environment variables](/cloud/environment-variables) via `process.env`.
+The only usage of `process` is to access [environment variables](/cloud/environment-variables) via `process.env`.
 
 Example:
 
@@ -41,6 +41,12 @@ export function handler(request: Request): Response {
   return new Response(`My secret is: ${process.env.SECRET}`);
 }
 ```
+
+---
+
+### `navigator.userAgent`
+
+`navigator.userAgent` is a fixed string that can be used to detect the current runtime. Its value is always `Lagon/VERSION`, where `VERSION` is the current version of the Lagon Runtime.
 
 ---
 

--- a/packages/js-runtime/package.json
+++ b/packages/js-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lagon/js-runtime",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "description": "JavaScript Runtime",
   "private": true,
   "type": "module",

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -9,6 +9,7 @@ import './runtime/blob';
 import './runtime/global/console';
 import './runtime/global/process';
 import './runtime/global/crypto';
+import './runtime/global/navigator';
 import './runtime/http/URLSearchParams';
 import './runtime/http/URL';
 import './runtime/http/Headers';

--- a/packages/js-runtime/src/runtime/global/navigator.ts
+++ b/packages/js-runtime/src/runtime/global/navigator.ts
@@ -1,0 +1,12 @@
+// esbuild will inline the version as a const, and since both
+// runtime and js-runtime are versioned together, we can safely
+// import the version from the package.json instead of injecting
+// it from the Rust code.
+import { version } from '../../../package.json';
+
+(globalThis => {
+  globalThis.navigator = {
+    ...globalThis.navigator,
+    userAgent: `Lagon/${version}`,
+  };
+})(globalThis);


### PR DESCRIPTION
## About

Add the `navigator` global with a single field `userAgent` as [defined in WinterCG](https://proposal-common-min-api.deno.dev/#requirements-for-navigatoruseragent).

Also, set `@lagon/runtime` & `@lagon/js-runtime` as fixed packages in changeset config, to always keep the same version since they depend on each other.
