### PR TITLE
perf(runtime,serverless): use an `Rc` for isolates metadata instead of cloning

### DIFF
--- a/.changeset/dull-flies-compare.md
+++ b/.changeset/dull-flies-compare.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+---
+
+Use an Rc for isolates metadata instead of cloning

--- a/packages/runtime/src/isolate/bindings/console.rs
+++ b/packages/runtime/src/isolate/bindings/console.rs
@@ -14,7 +14,7 @@ pub fn console_binding(
     let state = Isolate::state(scope);
     let state = state.borrow();
 
-    if let Some((deployment, function)) = &state.metadata {
+    if let Some((deployment, function)) = &state.metadata.as_ref() {
         let deployment = deployment.as_str();
         let function = function.as_str();
 

--- a/packages/serverless/src/deployments/cache.rs
+++ b/packages/serverless/src/deployments/cache.rs
@@ -51,11 +51,11 @@ pub fn run_cache_clear_task(last_requests: Arc<RwLock<HashMap<String, Instant>>>
                     last_requests.remove(&hostname);
 
                     if let Some(isolate) = isolates.remove(&hostname) {
-                        let (deployment, ..) = isolate
-                            .get_metadata()
-                            .unwrap_or_else(|| ("Unknown".to_owned(), "".to_owned()));
+                        let metadata = isolate.get_metadata();
 
-                        info!(deployment = deployment; "Clearing deployment from cache due to expiration");
+                        if let Some((deployment, ..)) = metadata.as_ref() {
+                            info!(deployment = deployment; "Clearing deployment from cache due to expiration");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## About

Wrap the `metadata` of an isolate inside an `Rc` to avoid cloning the tuple many times.