### PR TITLE
feat(js-runtime): new `Blob` & `File` implementations

### DIFF
--- a/.changeset/silly-ligers-flash.md
+++ b/.changeset/silly-ligers-flash.md
@@ -1,0 +1,6 @@
+---
+'@lagon/docs': minor
+'@lagon/js-runtime': minor
+---
+
+Add Blob and File APIs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tools/wpt"]
 	path = tools/wpt
 	url = git@github.com:web-platform-tests/wpt.git
+	ignore = dirty

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -97,6 +97,14 @@ The standard `AbortController` object. [See the documentation on MDN](https://de
 
 The standard `AbortSignal` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
 
+### `Blob`
+
+The standard `Blob` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+
+### `File`
+
+The standard `File` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/File).
+
 ---
 
 ### Fetch

--- a/packages/js-runtime/package.json
+++ b/packages/js-runtime/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "abortcontroller-polyfill": "^1.7.5",
-    "blob-polyfill": "^7.0.20220408",
     "web-streams-polyfill": "^3.2.1"
   }
 }

--- a/packages/js-runtime/src/__tests__/blob.test.ts
+++ b/packages/js-runtime/src/__tests__/blob.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import '../runtime/blob';
+
+describe('blob', () => {
+  it('should blob', async () => {
+    const obj = { hello: 'world' };
+    const blob = new Blob([JSON.stringify(obj, null, 2)], {
+      type: 'application/json',
+    });
+
+    expect(blob.size).toEqual(22);
+    expect(blob.type).toEqual('application/json');
+  });
+});

--- a/packages/js-runtime/src/__tests__/blob.test.ts
+++ b/packages/js-runtime/src/__tests__/blob.test.ts
@@ -1,14 +1,112 @@
 import { describe, it, expect } from 'vitest';
-import '../runtime/blob';
+import '../';
 
-describe('blob', () => {
-  it('should blob', async () => {
-    const obj = { hello: 'world' };
-    const blob = new Blob([JSON.stringify(obj, null, 2)], {
-      type: 'application/json',
-    });
+describe('Blob', () => {
+  it('should allow empty blobs', () => {
+    const blob = new Blob();
+    expect(blob.size).toEqual(0);
+    expect(blob.type).toEqual('');
+  });
 
-    expect(blob.size).toEqual(22);
-    expect(blob.type).toEqual('application/json');
+  it('should set the type', () => {
+    const blob = new Blob([], { type: 'text/plain' });
+    expect(blob.size).toEqual(0);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should init with string', () => {
+    const blob = new Blob(['hello'], { type: 'text/plain' });
+    expect(blob.size).toEqual(5);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should init with multiple strings', () => {
+    const blob = new Blob(['hello', 'world'], { type: 'text/plain' });
+    expect(blob.size).toEqual(10);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should init with Blob', () => {
+    const blob = new Blob([new Blob(['hello'])], { type: 'text/plain' });
+    expect(blob.size).toEqual(5);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should init with multiple Blobs', () => {
+    const blob = new Blob([new Blob(['hello']), new Blob(['world'])], { type: 'text/plain' });
+    expect(blob.size).toEqual(10);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should init with ArrayBuffer', () => {
+    const blob = new Blob([new ArrayBuffer(5)], { type: 'text/plain' });
+    expect(blob.size).toEqual(5);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should init with different types', () => {
+    const blob = new Blob(['hello', new ArrayBuffer(5), new Blob(['world'])], { type: 'text/plain' });
+    expect(blob.size).toEqual(15);
+    expect(blob.type).toEqual('text/plain');
+  });
+
+  it('should transform to ArrayBuffer', async () => {
+    const blob = new Blob(['hello']);
+    const buffer = await blob.arrayBuffer();
+    expect(buffer).toBeInstanceOf(ArrayBuffer);
+    expect(buffer.byteLength).toEqual(5);
+    expect(buffer).toEqual(new TextEncoder().encode('hello').buffer);
+  });
+
+  it('should slice', async () => {
+    const blob = new Blob(['hello world']);
+    const sliced = blob.slice(6);
+    expect(sliced.size).toEqual(5);
+    expect(await sliced.text()).toEqual('world');
+  });
+
+  it('should slice with start', async () => {
+    const blob = new Blob(['hello world']);
+    const sliced = blob.slice(6, 11);
+    expect(sliced.size).toEqual(5);
+    expect(await sliced.text()).toEqual('world');
+  });
+
+  it('should slice with start and end', async () => {
+    const blob = new Blob(['hello world']);
+    const sliced = blob.slice(0, 5);
+    expect(sliced.size).toEqual(5);
+    expect(await sliced.text()).toEqual('hello');
+  });
+
+  it('should slice with negative start', async () => {
+    const blob = new Blob(['hello world']);
+    const sliced = blob.slice(-5);
+    expect(sliced.size).toEqual(5);
+    expect(await sliced.text()).toEqual('world');
+  });
+
+  it('should slice with negative start and end', async () => {
+    const blob = new Blob(['hello world']);
+    const sliced = blob.slice(-5, -1);
+    expect(sliced.size).toEqual(4);
+    expect(await sliced.text()).toEqual('worl');
+  });
+
+  it('should transform to text', async () => {
+    const blob = new Blob(['hello']);
+    const text = await blob.text();
+    expect(text).toEqual('hello');
+  });
+
+  it('should transform to ReadableStream', async () => {
+    const blob = new Blob(['hello']);
+    const stream = blob.stream();
+    const reader = stream.getReader();
+    const { done, value } = await reader.read();
+    expect(done).toEqual(false);
+    expect(value).toEqual(new TextEncoder().encode('hello'));
+    const { done: done2 } = await reader.read();
+    expect(done2).toEqual(true);
   });
 });

--- a/packages/js-runtime/src/__tests__/file.test.ts
+++ b/packages/js-runtime/src/__tests__/file.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import '../';
+
+describe('File', () => {
+  it('should be an instanceof Blob', () => {
+    const file = new File([], 'file.txt');
+    expect(file).toBeInstanceOf(Blob);
+  });
+
+  it('should allow empty files', () => {
+    const file = new File([], 'file.txt');
+    expect(file.size).toEqual(0);
+    expect(file.type).toEqual('');
+    expect(file.name).toEqual('file.txt');
+    expect(file.lastModified).toBeGreaterThan(0);
+  });
+
+  it('should set the type', () => {
+    const file = new File([], 'file.txt', { type: 'text/plain' });
+    expect(file.size).toEqual(0);
+    expect(file.type).toEqual('text/plain');
+    expect(file.name).toEqual('file.txt');
+    expect(file.lastModified).toBeGreaterThan(0);
+  });
+
+  it('should init with string', () => {
+    const file = new File(['hello'], 'file.txt', { type: 'text/plain' });
+    expect(file.size).toEqual(5);
+    expect(file.type).toEqual('text/plain');
+    expect(file.name).toEqual('file.txt');
+    expect(file.lastModified).toBeGreaterThan(0);
+  });
+
+  it('should set lastModified', () => {
+    const file = new File([], 'file.txt', { lastModified: 123 });
+    expect(file.size).toEqual(0);
+    expect(file.type).toEqual('');
+    expect(file.name).toEqual('file.txt');
+    expect(file.lastModified).toEqual(123);
+  });
+});

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -6,6 +6,7 @@ import './runtime/core';
 import './runtime/streams';
 import './runtime/abort';
 import './runtime/blob';
+import './runtime/file';
 import './runtime/global/console';
 import './runtime/global/process';
 import './runtime/global/crypto';
@@ -68,6 +69,10 @@ declare global {
 
   interface Response {
     readonly isStream: boolean;
+  }
+
+  interface Blob {
+    readonly buffer: Uint8Array;
   }
 }
 

--- a/packages/js-runtime/src/runtime/blob.ts
+++ b/packages/js-runtime/src/runtime/blob.ts
@@ -12,7 +12,7 @@
         const chunks = blobParts.map(blobPart => {
           if (typeof blobPart === 'string') {
             return globalThis.__lagon__.TEXT_ENCODER.encode(blobPart);
-          } else if (blobPart instanceof ArrayBuffer) {
+          } else if (blobPart instanceof ArrayBuffer || blobPart instanceof Uint8Array) {
             return new Uint8Array(blobPart);
           } else if (blobPart instanceof Blob) {
             return blobPart.buffer as Uint8Array;
@@ -34,6 +34,7 @@
         this.buffer = buffer;
       } else {
         this.size = 0;
+        this.buffer = new Uint8Array(0);
       }
 
       this.type = options?.type || '';
@@ -43,7 +44,17 @@
       return Promise.resolve(this.buffer.buffer);
     }
 
-    slice(start?: number, end?: number, contentType?: string): Blob {}
+    slice(start?: number, end?: number, contentType?: string): Blob {
+      let type = contentType;
+
+      if (type === undefined) {
+        type = this.type;
+      } else if (type === null) {
+        type = 'null';
+      }
+
+      return new Blob([this.buffer.slice(start, end)], { type });
+    }
 
     stream(): ReadableStream<Uint8Array> {
       return new ReadableStream({

--- a/packages/js-runtime/src/runtime/blob.ts
+++ b/packages/js-runtime/src/runtime/blob.ts
@@ -1,6 +1,3 @@
-// // @ts-expect-error blob-polyfill isn't typed
-// import { Blob } from 'blob-polyfill';
-
 (globalThis => {
   globalThis.Blob = class {
     readonly size: number;

--- a/packages/js-runtime/src/runtime/blob.ts
+++ b/packages/js-runtime/src/runtime/blob.ts
@@ -1,6 +1,61 @@
-// @ts-expect-error blob-polyfill isn't typed
-import { Blob } from 'blob-polyfill';
+// // @ts-expect-error blob-polyfill isn't typed
+// import { Blob } from 'blob-polyfill';
 
 (globalThis => {
-  globalThis.Blob = Blob;
+  globalThis.Blob = class {
+    readonly size: number;
+    readonly type: string;
+    readonly buffer: Uint8Array;
+
+    constructor(blobParts?: BlobPart[], options?: BlobPropertyBag) {
+      if (blobParts) {
+        const chunks = blobParts.map(blobPart => {
+          if (typeof blobPart === 'string') {
+            return globalThis.__lagon__.TEXT_ENCODER.encode(blobPart);
+          } else if (blobPart instanceof ArrayBuffer) {
+            return new Uint8Array(blobPart);
+          } else if (blobPart instanceof Blob) {
+            return blobPart.buffer as Uint8Array;
+          } else {
+            return new Uint8Array(0);
+          }
+        });
+
+        const totalSize = chunks.reduce((acc, chunk) => acc + chunk.byteLength, 0);
+        const buffer = new Uint8Array(totalSize);
+        let offset = 0;
+
+        for (const chunk of chunks) {
+          buffer.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+
+        this.size = buffer.byteLength;
+        this.buffer = buffer;
+      } else {
+        this.size = 0;
+      }
+
+      this.type = options?.type || '';
+    }
+
+    arrayBuffer(): Promise<ArrayBuffer> {
+      return Promise.resolve(this.buffer.buffer);
+    }
+
+    slice(start?: number, end?: number, contentType?: string): Blob {}
+
+    stream(): ReadableStream<Uint8Array> {
+      return new ReadableStream({
+        pull: async controller => {
+          controller.enqueue(this.buffer);
+          controller.close();
+        },
+      });
+    }
+
+    text(): Promise<string> {
+      return Promise.resolve(globalThis.__lagon__.TEXT_DECODER.decode(this.buffer));
+    }
+  };
 })(globalThis);

--- a/packages/js-runtime/src/runtime/file.ts
+++ b/packages/js-runtime/src/runtime/file.ts
@@ -1,19 +1,43 @@
 (globalThis => {
-  globalThis.File = class extends Blob {};
+  globalThis.File = class extends Blob {
+    readonly lastModified: number;
+    readonly name: string;
+    readonly webkitRelativePath: string;
 
+    constructor(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag) {
+      super(fileBits, options);
+
+      this.lastModified = options?.lastModified || Date.now();
+      this.name = fileName;
+      this.webkitRelativePath = '';
+    }
+  };
+
+  // TODO: properly implement FileReader. It should extends Event
+  // @ts-expect-errore to fix
   globalThis.FileReader = class {
+    // @ts-expect-errore to fix
     readonly DONE: number;
+    // @ts-expect-errore to fix
     readonly EMPTY: number;
+    // @ts-expect-errore to fix
     readonly LOADING: number;
 
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     constructor() {}
 
+    // @ts-expect-errore to fix
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     onerror(): ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null {}
+    // @ts-expect-errore to fix
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     onload(): ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null {}
 
     readAsText(blob: Blob, encoding?: string) {
       blob.text().then(text => {
+        // @ts-expect-errore to fix
         this.result = text;
+        // @ts-expect-errore to fix
         this.onload(this);
       });
     }

--- a/packages/js-runtime/src/runtime/file.ts
+++ b/packages/js-runtime/src/runtime/file.ts
@@ -1,0 +1,21 @@
+(globalThis => {
+  globalThis.File = class extends Blob {};
+
+  globalThis.FileReader = class {
+    readonly DONE: number;
+    readonly EMPTY: number;
+    readonly LOADING: number;
+
+    constructor() {}
+
+    onerror(): ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null {}
+    onload(): ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null {}
+
+    readAsText(blob: Blob, encoding?: string) {
+      blob.text().then(text => {
+        this.result = text;
+        this.onload(this);
+      });
+    }
+  };
+})(globalThis);

--- a/packages/js-runtime/tsconfig.json
+++ b/packages/js-runtime/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2022", "WebWorker", "Webworker.Iterable"],
+    "lib": [
+      "ES2022",
+      "WebWorker",
+      "Webworker.Iterable"
+    ],
     "types": [], // Exclude node types
     "module": "ESNext",
     "moduleResolution": "Node",
@@ -13,5 +17,7 @@
     "incremental": true,
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
   },
-  "exclude": ["./dist/**/*"],
+  "exclude": [
+    "./dist/**/*"
+  ],
 }

--- a/packages/runtime/src/runtime/mod.rs
+++ b/packages/runtime/src/runtime/mod.rs
@@ -10,6 +10,8 @@ struct IcuData([u8; 10454784]);
 static JS_RUNTIME: &str = include_str!("../../runtime.js");
 static ICU_DATA: IcuData = IcuData(*include_bytes!("../../icudtl.dat"));
 
+const FLAGS: [&str; 0] = [];
+
 lazy_static! {
     pub static ref POOL: LocalPoolHandle = LocalPoolHandle::new(1);
 }
@@ -17,11 +19,17 @@ lazy_static! {
 #[derive(Default)]
 pub struct RuntimeOptions {
     allow_code_generation: bool,
+    expose_gc: bool,
 }
 
 impl RuntimeOptions {
     pub fn with_allow_code_generation(mut self, allow_code_generation: bool) -> Self {
         self.allow_code_generation = allow_code_generation;
+        self
+    }
+
+    pub fn with_expose_gc(mut self, expose_gc: bool) -> Self {
+        self.expose_gc = expose_gc;
         self
     }
 }
@@ -34,10 +42,18 @@ impl Runtime {
         // https://github.com/denoland/deno/blob/a55b194638bcaace38917703b7d9233fb1989d44/core/runtime.rs#L223
         v8::icu::set_common_data_71(&ICU_DATA.0).expect("Failed to load ICU data");
 
+        let mut flags = FLAGS.join(" ");
+
         // Disable code generation from `eval` / `new Function`
         if !options.allow_code_generation {
-            V8::set_flags_from_string("--disallow-code-generation-from-strings");
+            flags += " --disallow-code-generation-from-strings";
         }
+
+        if options.expose_gc {
+            flags += " --expose-gc";
+        }
+
+        V8::set_flags_from_string(&flags);
 
         let platform = v8::new_default_platform(0, false).make_shared();
         V8::initialize_platform(platform);

--- a/packages/wpt-runner/src/main.rs
+++ b/packages/wpt-runner/src/main.rs
@@ -12,6 +12,7 @@ use lagon_runtime::{
 };
 
 const ENCODING_TABLE: &str = include_str!("../../../tools/wpt/encoding/resources/encodings.js");
+const SUPPORT_BLOB: &str = include_str!("../../../tools/wpt/FileAPI/support/Blob.js");
 
 lazy_static! {
     static ref RESULT: Mutex<(usize, usize, usize)> = Mutex::new((0, 0, 0));
@@ -54,7 +55,7 @@ fn init_logger() -> Result<(), SetLoggerError> {
     Ok(())
 }
 
-const SKIP_TESTS: [&str; 17] = [
+const SKIP_TESTS: [&str; 15] = [
     // request
     "request-cache-default-conditional.any.js",
     "request-cache-no-cache.any.js",
@@ -73,9 +74,6 @@ const SKIP_TESTS: [&str; 17] = [
     "unsupported-encodings.any.js",
     "api-invalid-label.any.js",
     "replacement-encodings.any.js",
-    // blob
-    "Blob-slice.any.js",
-    "Blob-constructor.any.js",
 ];
 
 async fn run_test(path: &Path) {
@@ -104,10 +102,11 @@ async fn run_test(path: &Path) {
 export function handler() {{
     {}
     {ENCODING_TABLE}
+    {SUPPORT_BLOB}
     {code}
     return new Response()
 }}",
-        TEST_HARNESS.as_str()
+        TEST_HARNESS.as_str(),
     )
     .replace("self.", "globalThis.");
 
@@ -134,7 +133,7 @@ async fn test_directory(path: &Path) {
 
 #[tokio::main]
 async fn main() {
-    let runtime = Runtime::new(RuntimeOptions::default());
+    let runtime = Runtime::new(RuntimeOptions::default().with_expose_gc(true));
     init_logger().expect("Failed to initialize logger");
 
     if let Some(path) = env::args().nth(1) {

--- a/packages/wpt-runner/src/main.rs
+++ b/packages/wpt-runner/src/main.rs
@@ -54,7 +54,7 @@ fn init_logger() -> Result<(), SetLoggerError> {
     Ok(())
 }
 
-const SKIP_TESTS: [&str; 15] = [
+const SKIP_TESTS: [&str; 17] = [
     // request
     "request-cache-default-conditional.any.js",
     "request-cache-no-cache.any.js",
@@ -73,6 +73,9 @@ const SKIP_TESTS: [&str; 15] = [
     "unsupported-encodings.any.js",
     "api-invalid-label.any.js",
     "replacement-encodings.any.js",
+    // blob
+    "Blob-slice.any.js",
+    "Blob-constructor.any.js",
 ];
 
 async fn run_test(path: &Path) {
@@ -152,6 +155,7 @@ async fn main() {
         // Enable when CompressionStream/DecompressionStream are implemented
         // test_directory(Path::new("../../tools/wpt/compression")).await;
         test_directory(Path::new("../../tools/wpt/encoding")).await;
+        test_directory(Path::new("../../tools/wpt/FileAPI/blob")).await;
     }
 
     let result = RESULT.lock().unwrap();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,11 +277,9 @@ importers:
   packages/js-runtime:
     specifiers:
       abortcontroller-polyfill: ^1.7.5
-      blob-polyfill: ^7.0.20220408
       web-streams-polyfill: ^3.2.1
     dependencies:
       abortcontroller-polyfill: 1.7.5
-      blob-polyfill: 7.0.20220408
       web-streams-polyfill: 3.2.1
 
   packages/runtime:
@@ -9059,10 +9057,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
     dev: true
-
-  /blob-polyfill/7.0.20220408:
-    resolution: {integrity: sha512-oD8Ydw+5lNoqq+en24iuPt1QixdPpe/nUF8azTHnviCZYu9zUC+TwdzIp5orpblJosNlgNbVmmAb//c6d6ImUQ==}
-    dev: false
 
   /bluebird/3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'vitest/config';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   test: {
     silent: true,
   },
-  plugins: [tsconfigPaths()],
 });


### PR DESCRIPTION
## About

The current `Blob` implementation (from [blob-polyfill](https://www.npmjs.com/package/blob-polyfill)) causes issues because it uses `document`. The CI didn't catch the bug before: https://github.com/lagonapp/lagon/pull/253#issuecomment-1356360719, maybe due to a wrong caching mechanism.

Initial WPT results:

<img width="600" alt="Screenshot 2022-12-22 at 09 26 40" src="https://user-images.githubusercontent.com/43268759/209090890-4238a480-65dc-4b47-b99b-b6f456fbec23.png">
