### PR TITLE
feat(runtime): add SHA1 to `CryptoSubtle#digest`

### DIFF
--- a/.changeset/thirty-spiders-glow.md
+++ b/.changeset/thirty-spiders-glow.md
@@ -1,0 +1,6 @@
+---
+'@lagon/docs': patch
+'@lagon/runtime': patch
+---
+
+Add SHA-1 to CryptoSubtle#digest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand",
+ "sha1",
  "sha2",
  "tokio",
  "tokio-util",

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -72,6 +72,7 @@ The standard `CryptoSubtle` object. [See the documentation on MDN](https://devel
 |         | `sign()`, `verify()` | `encrypt()`, `decrypt()` | `digest()` | `deriveBits()`, `deriveKey()` | `wrapKey()`, `unwrapKey()` |
 | ------- | -------------------- | ------------------------ | ---------- | ----------------------------- | -------------------------- |
 | HMAC    | ✅                   |                          |            |                               |                            |
+| SHA-1   |                      |                          | ✅         |                               |                            |
 | SHA-256 |                      |                          | ✅         |                               |                            |
 | SHA-384 |                      |                          | ✅         |                               |                            |
 | SHA-512 |                      |                          | ✅         |                               |                            |

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -18,6 +18,7 @@ log = { version = "0.4.17", features = ["std", "kv_unstable"] }
 lazy_static = "1.4.0"
 # Cryptography
 hmac = "0.12.1"
+sha1 = "0.10.5"
 sha2 = "0.10.6"
 aes-gcm = "0.10.1"
 

--- a/packages/runtime/src/isolate/bindings/crypto/digest.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/digest.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use sha1::Sha1;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
 use crate::{
@@ -24,6 +25,11 @@ pub async fn digest_binding(id: usize, arg: Arg) -> BindingResult {
     let data = arg.1;
 
     let result = match name.as_str() {
+        "SHA-1" => {
+            let mut hasher = Sha1::new();
+            hasher.update(data);
+            hasher.finalize().to_vec()
+        }
         "SHA-256" => {
             let mut hasher = Sha256::new();
             hasher.update(data);


### PR DESCRIPTION
## About

Closes #400
Relates to https://github.com/honojs/hono/issues/734#issuecomment-1359246312

Add SHA1 to the supported algorithms of `CryptoSubtle#digest`
