### PR TITLE
fix(cli): random segfault with `lagon dev`

### DIFF
--- a/.changeset/light-tomatoes-bake.md
+++ b/.changeset/light-tomatoes-bake.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix random segfault with `lagon dev`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-util",
  "urlencoding",
  "walkdir",
  "webbrowser",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -12,6 +12,7 @@ colored = "2.0.0"
 dirs = "4.0.0"
 webbrowser = "0.8.2"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7.4", features = ["rt"] }
 hyper = { version = "0.14", features = ["client", "server", "http1", "http2", "runtime", "stream"] }
 mime = "0.3.16"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## About

Fix random segfault errors when using `lagon dev`:

When calling into V8 to resolve Rust Futures to JS Promises while using another thread (from the HTTP server) than the previous one, V8 crashed:
```
[1]    6212 segmentation fault  cargo run -- dev test.ts
```

The full stacktrace:
```
(lldb) bt
* thread #8, name = 'tokio-runtime-worker', stop reason = EXC_BAD_ACCESS (code=1, address=0xf5d0)
  * frame #0: 0x00000001005fce24 lagon-cli`::main_thread_local_heap() at isolate.cc:5868:10 [opt]
    frame #1: 0x0000000100751eec lagon-cli`::BytecodeArrayIterator() at bytecode-array-iterator.cc:28:45 [opt]
    frame #2: 0x000000010051cdc8 lagon-cli`::BaselineCompiler() at baseline-compiler.cc:288:7 [opt]
    frame #3: 0x00000001005344f4 lagon-cli`::GenerateBaselineCode() at baseline.cc:64:30 [opt]
    frame #4: 0x000000010058fc8c lagon-cli`::CompileSharedWithBaseline() at compiler.cc:2655:10 [opt]
    frame #5: 0x0000000100590018 lagon-cli`::CompileBaseline() at compiler.cc:2681:8 [opt]
    frame #6: 0x000000010051afc8 lagon-cli`::CompileBatch() at baseline-batch-compiler.cc:320:5 [opt]
    frame #7: 0x00000001006107b4 lagon-cli`::OnInterruptTick() at tiering-manager.cc:434:44 [opt]
    frame #8: 0x0000000100a2e92c lagon-cli`::BytecodeBudgetInterruptWithStackCheck() at runtime-internal.cc:379:31 [opt]
    frame #9: 0x0000000100a2d03c lagon-cli`::Runtime_BytecodeBudgetInterruptWithStackCheck_Ignition() at runtime-internal.cc:396:1 [opt]
    frame #10: 0x000000010110ab2c lagon-cli`Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_NoBuiltinExit + 108
    frame #11: 0x00000001011d7354 lagon-cli`Builtins_JumpLoopWideHandler + 916
    frame #12: 0x0000000101080804 lagon-cli`Builtins_InterpreterEntryTrampoline + 292
    frame #13: 0x0000000101080804 lagon-cli`Builtins_InterpreterEntryTrampoline + 292
    frame #14: 0x0000000101161bf8 lagon-cli`Builtins_PromiseFulfillReactionJob + 56
    frame #15: 0x00000001010a9080 lagon-cli`Builtins_RunMicrotasks + 640
    frame #16: 0x000000010107eaa8 lagon-cli`Builtins_JSRunMicrotasksEntry + 168
    frame #17: 0x00000001005e5ad0 lagon-cli`::Invoke() at execution.cc:443:33 [opt]
    frame #18: 0x00000001005e6944 lagon-cli`::InvokeWithTryCatch() at execution.cc:488:20 [opt]
    frame #19: 0x00000001005e6b74 lagon-cli`::TryRunMicrotasks() at execution.cc:599:10 [opt]
    frame #20: 0x000000010060d968 lagon-cli`::RunMicrotasks() at microtask-queue.cc:172:22 [opt]
    frame #21: 0x000000010060d808 lagon-cli`::PerformCheckpointInternal() at microtask-queue.cc:126:3 [opt]
    frame #22: 0x0000000100600840 lagon-cli`::FireCallCompletedCallbackInternal() at isolate.cc:4909:44 [opt]
    frame #23: 0x00000001004fe87c lagon-cli`::Resolve() at api.cc:7838:1 [opt]
    frame #24: 0x0000000100492ca4 lagon-cli`::v8__Promise__Resolver__Resolve() at binding.cc:2243:51 [opt]
    frame #25: 0x0000000100420678 lagon-cli`lagon_runtime::isolate::Isolate::resolve_promises::hfea16367a6f0dec3 [inlined] v8::promise::_$LT$impl$u20$v8..data..PromiseResolver$GT$::resolve::h2ab42335ad09fbf8(self=0x000000010486f680, scope=0x0000000170c3dd88, value=Local<v8::data::Value> @ 0x0000000170c3e450) at promise.rs:149:13
```

This PR always spawns and executes isolates on the same thread using a pool of size 1.