### PR TITLE
fix(runtime): use 16 bytes iv for AES-GCM

### DIFF
--- a/.changeset/nervous-cooks-promise.md
+++ b/.changeset/nervous-cooks-promise.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+AES-GCM uses 16 bytes iv instead of 12 bytes previously

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
 name = "lagon-runtime"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "aes-gcm",
  "anyhow",
  "flume",

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4.0"
 hmac = "0.12.1"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
+aes = "0.8.2"
 aes-gcm = "0.10.1"
 
 [dev-dependencies]

--- a/packages/runtime/src/crypto.rs
+++ b/packages/runtime/src/crypto.rs
@@ -1,3 +1,5 @@
+use aes::{cipher::typenum::U16, Aes256};
+use aes_gcm::AesGcm;
 use anyhow::{anyhow, Result};
 use hmac::Hmac;
 use sha2::{Sha256, Sha384, Sha512};
@@ -7,6 +9,7 @@ use crate::utils::{extract_v8_string, extract_v8_uint8array, v8_string};
 pub type HmacSha256 = Hmac<Sha256>;
 pub type HmacSha384 = Hmac<Sha384>;
 pub type HmacSha512 = Hmac<Sha512>;
+pub type Aes256Gcm = AesGcm<Aes256, U16>;
 
 pub enum Sha {
     Sha256,

--- a/packages/runtime/src/isolate/bindings/crypto/decrypt.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/decrypt.rs
@@ -1,10 +1,9 @@
 use crate::{
-    crypto::{extract_algorithm_object, extract_cryptokey_key_value, Algorithm},
+    crypto::{extract_algorithm_object, extract_cryptokey_key_value, Aes256Gcm, Algorithm},
     isolate::bindings::{BindingResult, PromiseResult},
     utils::extract_v8_uint8array,
 };
-use aes_gcm::{aead::Aead, Aes256Gcm};
-use aes_gcm::{KeyInit, Nonce};
+use aes_gcm::{aead::Aead, KeyInit, Nonce};
 use anyhow::Result;
 
 type Arg = (Algorithm, Vec<u8>, Vec<u8>);

--- a/packages/runtime/src/isolate/bindings/crypto/encrypt.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/encrypt.rs
@@ -1,9 +1,9 @@
 use crate::{
-    crypto::{extract_algorithm_object, extract_cryptokey_key_value, Algorithm},
+    crypto::{extract_algorithm_object, extract_cryptokey_key_value, Aes256Gcm, Algorithm},
     isolate::bindings::{BindingResult, PromiseResult},
     utils::extract_v8_uint8array,
 };
-use aes_gcm::{aead::Aead, Aes256Gcm};
+use aes_gcm::aead::Aead;
 use aes_gcm::{KeyInit, Nonce};
 use anyhow::Result;
 

--- a/packages/runtime/src/isolate/bindings/crypto/random_values.rs
+++ b/packages/runtime/src/isolate/bindings/crypto/random_values.rs
@@ -15,7 +15,6 @@ pub fn random_values_binding(
         buf[i] = rand::random();
     }
 
-    dbg!(&buf);
     let result = v8_uint8array(scope, buf);
 
     retval.set(result.into());

--- a/packages/runtime/tests/crypto.rs
+++ b/packages/runtime/tests/crypto.rs
@@ -255,7 +255,7 @@ async fn crypto_encrypt() {
         ['sign'],
     );
 
-    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-GCM', iv },
         key,
@@ -288,7 +288,7 @@ async fn crypto_decrypt() {
         ['sign'],
     );
 
-    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iv = crypto.getRandomValues(new Uint8Array(16));
     const ciphertext = await crypto.subtle.encrypt(
         { name: 'AES-GCM', iv },
         key,


### PR DESCRIPTION
## About

The AES-GCM algorithm should use 16 bytes iv, but used the default (from the crate) of 12 bytes before. This is required by the [W3C spec](https://w3c.github.io/webcrypto/#aes-cbc-operations): 

> If the [iv](https://w3c.github.io/webcrypto/#dfn-AesCbcParams-iv) member of normalizedAlgorithm does not have length 16 bytes, then [throw](https://webidl.spec.whatwg.org/#dfn-throw) an [OperationError](https://webidl.spec.whatwg.org/#operationerror).

Also remove a `dbg!` inside the random_value binding.