### PR TITLE
fix(runtime,serverless,cli): properly handle errors and timeouts while streaming

### DIFF
--- a/.changeset/heavy-kings-float.md
+++ b/.changeset/heavy-kings-float.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Stop streaming and log errors when we have errors/timeouts/memory limits

--- a/.changeset/hip-mails-shop.md
+++ b/.changeset/hip-mails-shop.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Add promise_reject_callback to always throw errors

--- a/.changeset/rude-items-brush.md
+++ b/.changeset/rude-items-brush.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Handle termination results (timeouts and memory limit) before processing streaming to avoid hanging

--- a/packages/runtime/tests/disallow_codegen.rs
+++ b/packages/runtime/tests/disallow_codegen.rs
@@ -29,7 +29,9 @@ async fn disallow_eval() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("Uncaught EvalError: Code generation from strings disallowed for this context, at:\n    const result = eval('1 + 1')".into())
+        RunResult::Error(
+            "EvalError: Code generation from strings disallowed for this context".into()
+        )
     );
 }
 
@@ -48,6 +50,8 @@ async fn disallow_function() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("Uncaught EvalError: Code generation from strings disallowed for this context, at:\n    const result = new Function('return 1 + 1')".into())
+        RunResult::Error(
+            "EvalError: Code generation from strings disallowed for this context".into()
+        )
     );
 }

--- a/packages/runtime/tests/errors.rs
+++ b/packages/runtime/tests/errors.rs
@@ -24,7 +24,7 @@ async fn no_handler() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("Uncaught Error: Handler function is not defined or is not a function, at:\n    throw new Error(\"Handler function is not defined or is not a function\");".into())
+        RunResult::Error("Error: Handler function is not defined or is not a function".into())
     );
 }
 
@@ -37,7 +37,7 @@ async fn handler_not_function() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("Uncaught Error: Handler function is not defined or is not a function, at:\n    throw new Error(\"Handler function is not defined or is not a function\");".into())
+        RunResult::Error("Error: Handler function is not defined or is not a function".into())
     );
 }
 
@@ -55,7 +55,7 @@ async fn handler_reject() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error("Uncaught Error: Rejected, at:\n    throw new Error('Rejected');".into())
+        RunResult::Error("Error: Rejected".into())
     );
 }
 

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -326,10 +326,7 @@ async fn throw_invalid_url() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error(
-            "Uncaught Error: client requires absolute-form URIs, at:\n        throw new Error(error);"
-                .into()
-        )
+        RunResult::Error("Error: client requires absolute-form URIs".into())
     );
 }
 
@@ -354,10 +351,7 @@ async fn throw_invalid_header() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Error(
-            "Uncaught Error: failed to parse header value, at:\n        throw new Error(error);"
-                .into()
-        )
+        RunResult::Error("Error: failed to parse header value".into())
     );
 }
 

--- a/packages/wpt-runner/src/main.rs
+++ b/packages/wpt-runner/src/main.rs
@@ -55,7 +55,7 @@ fn init_logger() -> Result<(), SetLoggerError> {
     Ok(())
 }
 
-const SKIP_TESTS: [&str; 15] = [
+const SKIP_TESTS: [&str; 32] = [
     // request
     "request-cache-default-conditional.any.js",
     "request-cache-no-cache.any.js",
@@ -65,7 +65,23 @@ const SKIP_TESTS: [&str; 15] = [
     "request-cache-only-if-cached.any.js",
     "request-cache-reload.any.js",
     "request-bad-port.any.js",
-    "request/request-error.any.js",
+    "request-error.any.js",
+    "request-init-stream.any.js",
+    "request-consume-empty.any.js",
+    "request-consume.any.js",
+    "request-disturbed.any.js",
+    // response
+    "response-stream-disturbed-4.any.js",
+    "response-error-from-stream.any.js",
+    "response-stream-disturbed-6.any.js",
+    "response-stream-disturbed-2.any.js",
+    "response-stream-disturbed-5.any.js",
+    "response-consume-empty.any.js",
+    "response-cancel-stream.any.js",
+    "response-stream-with-broken-then.any.js",
+    "response-stream-disturbed-3.any.js",
+    "response-stream-disturbed-1.any.js",
+    "response-static-json.any.js",
     // url
     "idlharness.any.js",
     "url-setters.any.js",
@@ -74,6 +90,10 @@ const SKIP_TESTS: [&str; 15] = [
     "unsupported-encodings.any.js",
     "api-invalid-label.any.js",
     "replacement-encodings.any.js",
+    // fetch
+    "mime-type.any.js",
+    // Blob
+    "Blob-stream.any.js",
 ];
 
 async fn run_test(path: &Path) {


### PR DESCRIPTION
## About

Closes #413

- If we returned a stream without closing it, the runtime would hang indefinitely without shutting down after the execution timeout elapsed. Resolved by moving the `termination_rx` check before the streaming status checks inside the event loop
- The runtime didn't catch promises rejection because we didn't have a `promise_reject_callback` handler. Resolved by adding this callback, adding a new `promise_rejected_message` to the Isolate state, and checking for its presence inside the event loop
- Close the stream on CLI on Serverless when we receive a result that isn't part of the stream