### PR TITLE
fix(cli): define `process.env.NODE_ENV` to `"production"` & bundle in ESNext

### DIFF
--- a/.changeset/ten-hats-sell.md
+++ b/.changeset/ten-hats-sell.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Bundle in ESNext

--- a/.changeset/tricky-cups-decide.md
+++ b/.changeset/tricky-cups-decide.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Define process.env.NODE_ENV as "production"

--- a/packages/cli/src/utils/deployments.rs
+++ b/packages/cli/src/utils/deployments.rs
@@ -75,10 +75,12 @@ pub fn delete_function_config(file: &Path) -> Result<()> {
 fn esbuild(file: &PathBuf) -> Result<Vec<u8>> {
     let result = Command::new("esbuild")
         .arg(file)
+        .arg("--define:process.env.NODE_ENV=\"production\"")
         .arg("--bundle")
         .arg("--format=esm")
-        .arg("--target=es2020")
+        .arg("--target=esnext")
         .arg("--platform=browser")
+        .arg("--conditions=lagon")
         .arg("--loader:.wasm=binary")
         .output()?;
 


### PR DESCRIPTION
## About

- Bundle in ESNext instead of ES2020
- Add support for `exports` key of `lagon` using `--conditions`
- Define `process.env.NODE_ENV` to `"production"` so ESBuild can tree shake libraries like React