### PR TITLE
fix(js-runtime): `Response.error()` & `Response.redirect()` WPT conformance

### DIFF
--- a/.changeset/loud-clocks-tell.md
+++ b/.changeset/loud-clocks-tell.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+Fix implementation of `Response.error()` & `Response.redirect()`

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -74,6 +74,10 @@ declare global {
   interface Blob {
     readonly buffer: Uint8Array;
   }
+
+  interface Headers {
+    immutable: boolean;
+  }
 }
 
 export async function masterHandler(request: {

--- a/packages/js-runtime/src/runtime/http/Headers.ts
+++ b/packages/js-runtime/src/runtime/http/Headers.ts
@@ -1,6 +1,7 @@
 (globalThis => {
   globalThis.Headers = class {
     private readonly h: Map<string, string[]> = new Map();
+    immutable = false;
 
     constructor(init?: HeadersInit) {
       if (init === null) {
@@ -49,11 +50,19 @@
     }
 
     append(name: string, value: string) {
+      if (this.immutable) {
+        throw new TypeError('Headers are immutable');
+      }
+
       name = name.toLowerCase();
       this.addValue(name, value);
     }
 
     delete(name: string) {
+      if (this.immutable) {
+        throw new TypeError('Headers are immutable');
+      }
+
       name = name.toLowerCase();
       this.h.delete(name);
     }
@@ -81,6 +90,10 @@
     }
 
     set(name: string, value: string) {
+      if (this.immutable) {
+        throw new TypeError('Headers are immutable');
+      }
+
       name = name.toLowerCase();
       value = String(value);
       this.h.set(name, [value]);

--- a/packages/js-runtime/src/runtime/http/URL.ts
+++ b/packages/js-runtime/src/runtime/http/URL.ts
@@ -82,7 +82,6 @@
     }
 
     get href(): string {
-      // TODO: username and password
       const credentials = this.username + (this.password ? ':' + this.password : '');
 
       let href =

--- a/packages/wpt-runner/current-results.md
+++ b/packages/wpt-runner/current-results.md
@@ -473,8 +473,8 @@ TEST DONE 0 Can override Content-Type for Response with string body
 TEST DONE 0 Can override Content-Type for Response with ReadableStream body
 TEST DONE 1 Default Content-Type for Response with FormData body
 Running ../../tools/wpt/fetch/api/response/response-static-error.any.js
-TEST DONE 1 Check response returned by static method error()
-TEST DONE 1 the 'guard' of the Headers instance should be immutable
+TEST DONE 0 Check response returned by static method error()
+TEST DONE 0 the 'guard' of the Headers instance should be immutable
 Running ../../tools/wpt/fetch/api/response/response-static-json.any.js
 TEST DONE 0 Throws TypeError when calling static json() with a status of 204
 TEST DONE 0 Throws TypeError when calling static json() with a status of 205
@@ -490,17 +490,18 @@ TEST DONE 0 Check response returned by static json() with init {"headers":{"x-fo
 TEST DONE 0 Check static json() encodes JSON objects correctly
 TEST DONE 0 Check static json() propagates JSON serializer errors
 Running ../../tools/wpt/fetch/api/response/response-static-redirect.any.js
-TEST DONE 1 Check default redirect response
-TEST DONE 1 Check response returned by static method redirect(), status = 301
-TEST DONE 1 Check response returned by static method redirect(), status = 302
-TEST DONE 1 Check response returned by static method redirect(), status = 303
-TEST DONE 1 Check response returned by static method redirect(), status = 307
-TEST DONE 1 Check response returned by static method redirect(), status = 308
+http://test.url:1234/
+TEST DONE 0 Check default redirect response
+TEST DONE 0 Check response returned by static method redirect(), status = 301
+TEST DONE 0 Check response returned by static method redirect(), status = 302
+TEST DONE 0 Check response returned by static method redirect(), status = 303
+TEST DONE 0 Check response returned by static method redirect(), status = 307
+TEST DONE 0 Check response returned by static method redirect(), status = 308
 TEST DONE 1 Check error returned when giving invalid url to redirect()
-TEST DONE 1 Check error returned when giving invalid status to redirect(), status = 200
-TEST DONE 1 Check error returned when giving invalid status to redirect(), status = 309
-TEST DONE 1 Check error returned when giving invalid status to redirect(), status = 400
-TEST DONE 1 Check error returned when giving invalid status to redirect(), status = 500
+TEST DONE 0 Check error returned when giving invalid status to redirect(), status = 200
+TEST DONE 0 Check error returned when giving invalid status to redirect(), status = 309
+TEST DONE 0 Check error returned when giving invalid status to redirect(), status = 400
+TEST DONE 0 Check error returned when giving invalid status to redirect(), status = 500
 Running ../../tools/wpt/fetch/api/response/response-stream-bad-chunk.any.js
 TEST DONE 1 ReadableStream with non-Uint8Array chunk passed to Response.arrayBuffer() causes TypeError
 TEST DONE 1 ReadableStream with non-Uint8Array chunk passed to Response.blob() causes TypeError
@@ -1497,5 +1498,5 @@ TEST DONE 0 Blob.text() different charset param with non-ascii input
 TEST DONE 1 Blob.text() invalid utf-8 input
 TEST DONE 1 Blob.text() concurrent reads
 
-1402 tests, 349 passed, 1047 failed
- -> 24% conformance
+1402 tests, 361 passed, 1035 failed
+ -> 25% conformance

--- a/packages/wpt-runner/current-results.md
+++ b/packages/wpt-runner/current-results.md
@@ -490,7 +490,6 @@ TEST DONE 0 Check response returned by static json() with init {"headers":{"x-fo
 TEST DONE 0 Check static json() encodes JSON objects correctly
 TEST DONE 0 Check static json() propagates JSON serializer errors
 Running ../../tools/wpt/fetch/api/response/response-static-redirect.any.js
-http://test.url:1234/
 TEST DONE 0 Check default redirect response
 TEST DONE 0 Check response returned by static method redirect(), status = 301
 TEST DONE 0 Check response returned by static method redirect(), status = 302


### PR DESCRIPTION
## About

From:
```
1402 tests, 349 passed, 1047 failed
 -> 24% conformance
```

To:
```
1402 tests, 361 passed, 1035 failed
 -> 25% conformance
```


The only failing WPT test is `Check error returned when giving invalid url to redirect()`, which should be fixed automatically when our `URL` implementation throw errors on malformatted URLs.