### PR TITLE
fix(cli): ESBuild path on Windows

### DIFF
--- a/.changeset/wild-boats-shout.md
+++ b/.changeset/wild-boats-shout.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix ESBuild path on Windows


### PR DESCRIPTION
## About

Globally installed packages via NPM are not runnable as-is, we need to use the full path to the `esbuild.cmd` executable.
