### PR TITLE
feat(js-runtime): add `Event` & `EventTarget` APIs

### DIFF
--- a/.changeset/many-beans-itch.md
+++ b/.changeset/many-beans-itch.md
@@ -1,0 +1,6 @@
+---
+'@lagon/docs': patch
+'@lagon/js-runtime': patch
+---
+
+Add `Event` & `EventTarget` APIs

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "@changesets/changelog-github": "^0.4.6",
     "@changesets/cli": "^2.23.1",
     "@types/mock-fs": "^4.13.1",
-    "@typescript-eslint/eslint-plugin": "^5.26.0",
-    "@typescript-eslint/parser": "^5.26.0",
+    "@typescript-eslint/eslint-plugin": "^5.47.1",
+    "@typescript-eslint/parser": "^5.47.1",
+    "@typescript-eslint/typescript-estree": "^5.47.1",
     "c8": "^7.12.0",
     "esbuild": "^0.16.0",
     "eslint": "^8.16.0",
@@ -40,7 +41,7 @@
     "prettier": "^2.6.2",
     "tsup": "^6.0.1",
     "turbo": "^1.5.2",
-    "typescript": "^4.6.4",
+    "typescript": "^4.9.4",
     "vitest": "^0.25.0"
   }
 }

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -106,6 +106,18 @@ The standard `Blob` object. [See the documentation on MDN](https://developer.moz
 
 The standard `File` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/File).
 
+### `Event`
+
+The standard `Event` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Event).
+
+### `EventTarget`
+
+The standard `EventTarget` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget).
+
+### `CustomEvent`
+
+The standard `CustomEvent` object. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent).
+
 ---
 
 ### Fetch

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -3,6 +3,7 @@ import './runtime/encoding/TextEncoder';
 import './runtime/encoding/TextDecoder';
 import './runtime/encoding/base64';
 import './runtime/core';
+import './runtime/event';
 import './runtime/streams';
 import './runtime/abort';
 import './runtime/blob';

--- a/packages/js-runtime/src/runtime/blob.ts
+++ b/packages/js-runtime/src/runtime/blob.ts
@@ -1,4 +1,5 @@
 (globalThis => {
+  // @ts-expect-error missing `prototype` property
   globalThis.Blob = class {
     readonly size: number;
     readonly type: string;

--- a/packages/js-runtime/src/runtime/event.ts
+++ b/packages/js-runtime/src/runtime/event.ts
@@ -1,0 +1,170 @@
+(globalThis => {
+  type Listener = {
+    callback: EventListenerOrEventListenerObject | null;
+    options?: AddEventListenerOptions | boolean;
+  };
+
+  globalThis.EventTarget = class {
+    private listeners: Map<string, Listener[]> = new Map();
+
+    addEventListener(
+      type: string,
+      callback: EventListenerOrEventListenerObject | null,
+      options?: AddEventListenerOptions | boolean,
+    ) {
+      if (typeof options === 'object' && options?.signal === null) {
+        throw new TypeError('signal is null');
+      }
+
+      const listeners = this.listeners.get(type) ?? [];
+      const exists = listeners.find(current => current.callback === callback);
+
+      if (!exists) {
+        this.listeners.set(
+          type,
+          listeners.concat({
+            callback,
+            options,
+          }),
+        );
+      }
+    }
+
+    dispatchEvent(event: Event): boolean {
+      const { type, cancelable } = event;
+
+      for (const { callback, options } of this.listeners.get(type) ?? []) {
+        const initialPreventDefault = event.preventDefault;
+        const passive = typeof options === 'object' && !!options.passive;
+
+        if (passive) {
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          event.preventDefault = () => {};
+        }
+
+        if (typeof options === 'object' && (options.once || options.signal?.aborted)) {
+          this.removeEventListener(type, callback, options);
+
+          if (options.signal?.aborted) {
+            continue;
+          }
+        }
+
+        if (typeof callback === 'function') {
+          callback(event);
+        } else {
+          callback?.handleEvent(event);
+        }
+
+        if (passive) {
+          event.preventDefault = initialPreventDefault;
+        }
+
+        if (cancelable && event.defaultPrevented && !passive) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    removeEventListener(
+      type: string,
+      callback: EventListenerOrEventListenerObject | null,
+      options?: EventListenerOptions | boolean,
+    ) {
+      const listeners = this.listeners.get(type) ?? [];
+      this.listeners.set(
+        type,
+        listeners.filter(listener => listener.callback !== callback && listener.options !== options),
+      );
+    }
+  };
+
+  // TODO: remove this @ts-ignore, not sure why it complains about
+  // NONE, CAPTURING_PHASE, AT_TARGET, BUBBLING_PHASE
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  globalThis.Event = class {
+    readonly bubbles: boolean;
+    cancelBubble: boolean;
+    readonly cancelable: boolean;
+    readonly composed: boolean;
+    readonly currentTarget: EventTarget | null;
+    readonly defaultPrevented: boolean;
+    readonly eventPhase: number;
+    readonly isTrusted: boolean;
+    returnValue: boolean;
+    readonly srcElement: EventTarget | null;
+    readonly target: EventTarget | null;
+    readonly timeStamp: DOMHighResTimeStamp;
+    readonly type: string;
+
+    // https://dom.spec.whatwg.org/#dom-event-eventphase
+    static readonly NONE = 0;
+    static readonly CAPTURING_PHASE = 1;
+    static readonly AT_TARGET: 2;
+    static readonly BUBBLING_PHASE = 3;
+
+    constructor(type: string, eventInitDict?: EventInit) {
+      if (type === undefined) {
+        throw new TypeError('Event requires at least one argument');
+      }
+
+      this.type = type;
+      this.bubbles = eventInitDict?.bubbles ?? false;
+      this.cancelable = eventInitDict?.cancelable ?? false;
+      this.composed = eventInitDict?.composed ?? false;
+
+      this.cancelBubble = false;
+      this.currentTarget = null;
+      this.defaultPrevented = false;
+      this.eventPhase = 0;
+      this.isTrusted = false;
+      this.returnValue = true;
+      this.srcElement = null;
+      this.target = null;
+      this.timeStamp = Date.now();
+    }
+
+    composedPath(): EventTarget[] {
+      return [];
+    }
+
+    initEvent(type: string, bubbles?: boolean, cancelable?: boolean) {
+      // @ts-expect-error we assign to a readonly property
+      this.type = type;
+      // @ts-expect-error we assign to a readonly property
+      this.bubbles = bubbles ?? false;
+      // @ts-expect-error we assign to a readonly property
+      this.cancelable = cancelable ?? false;
+    }
+
+    preventDefault() {
+      // @ts-expect-error we assign to a readonly property
+      this.defaultPrevented = true;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    stopImmediatePropagation() {}
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    stopPropagation() {}
+  };
+
+  globalThis.CustomEvent = class<T> extends Event {
+    readonly detail: T;
+
+    constructor(type: string, eventInitDict?: CustomEventInit<T>) {
+      super(type, eventInitDict);
+
+      this.detail = eventInitDict?.detail ?? (null as T);
+    }
+
+    initCustomEvent(type: string, bubbles?: boolean, cancelable?: boolean, detail?: T) {
+      this.initEvent(type, bubbles, cancelable);
+      // @ts-expect-error we assign to a readonly property
+      this.detail = detail ?? (null as T);
+    }
+  };
+})(globalThis);

--- a/packages/js-runtime/src/runtime/streams.ts
+++ b/packages/js-runtime/src/runtime/streams.ts
@@ -8,12 +8,14 @@ import {
 } from 'web-streams-polyfill';
 
 (globalThis => {
+  // @ts-expect-error type slightly differs
   globalThis.ReadableStream = ReadableStream;
   // @ts-expect-error type slightly differs
   globalThis.ReadableStreamBYOBReader = ReadableStreamBYOBReader;
   // @ts-expect-error type slightly differs
   globalThis.ReadableStreamDefaultReader = ReadableStreamDefaultReader;
   globalThis.TransformStream = TransformStream;
+  // @ts-expect-error type slightly differs
   globalThis.WritableStream = WritableStream;
   // @ts-expect-error type slightly differs
   globalThis.WritableStreamDefaultWriter = WritableStreamDefaultWriter;

--- a/packages/wpt-runner/current-results.md
+++ b/packages/wpt-runner/current-results.md
@@ -1496,6 +1496,58 @@ TEST DONE 0 Blob.text() different charset param in type option
 TEST DONE 0 Blob.text() different charset param with non-ascii input
 TEST DONE 1 Blob.text() invalid utf-8 input
 TEST DONE 1 Blob.text() concurrent reads
+Running ../../tools/wpt/dom/events/AddEventListenerOptions-once.any.js
+TEST DONE 0 Once listener should be invoked only once
+TEST DONE 0 Once listener should be invoked only once even if the event is nested
+TEST DONE 0 Once listener should be added / removed like normal listeners
+TEST DONE 0 Multiple once listeners should be invoked even if the stopImmediatePropagation is set
+Running ../../tools/wpt/dom/events/AddEventListenerOptions-passive.any.js
+TEST DONE 1 Supports passive option on addEventListener only
+TEST DONE 0 preventDefault should be ignored if-and-only-if the passive option is true
+TEST DONE 1 returnValue should be ignored if-and-only-if the passive option is true
+TEST DONE 0 passive behavior of one listener should be unaffected by the presence of other listeners
+TEST DONE 1 Equivalence of option values
+Running ../../tools/wpt/dom/events/AddEventListenerOptions-signal.any.js
+1
+2
+2
+2
+TEST DONE 0 Passing an AbortSignal to addEventListener options should allow removing a listener
+TEST DONE 0 Passing an AbortSignal to addEventListener does not prevent removeEventListener
+TEST DONE 0 Passing an AbortSignal to addEventListener works with the once flag
+TEST DONE 0 Removing a once listener works with a passed signal
+TEST DONE 0 Passing an AbortSignal to multiple listeners
+TEST DONE 0 Passing an AbortSignal to addEventListener works with the capture flag
+TEST DONE 0 Aborting from a listener does not call future listeners
+TEST DONE 0 Adding then aborting a listener in another listener does not call it
+TEST DONE 0 Aborting from a nested listener should remove it
+TEST DONE 0 Passing null as the signal should throw
+TEST DONE 0 Passing null as the signal should throw (listener is also null)
+Running ../../tools/wpt/dom/events/Event-constructors.any.js
+TEST DONE 0 Untitled
+TEST DONE 0 Untitled 1
+TEST DONE 1 Untitled 2
+TEST DONE 0 Untitled 3
+TEST DONE 0 Untitled 4
+TEST DONE 0 Untitled 5
+TEST DONE 0 Untitled 6
+TEST DONE 0 Untitled 7
+TEST DONE 0 Untitled 8
+TEST DONE 0 Untitled 9
+TEST DONE 0 Untitled 10
+TEST DONE 0 Untitled 11
+TEST DONE 0 Untitled 12
+TEST DONE 0 Untitled 13
+Running ../../tools/wpt/dom/events/Event-isTrusted.any.js
+TEST DONE 1 Untitled
+Running ../../tools/wpt/dom/events/EventTarget-add-remove-listener.any.js
+TEST DONE 0 Removing an event listener without explicit capture arg should succeed
+Running ../../tools/wpt/dom/events/EventTarget-addEventListener.any.js
+TEST DONE 0 Adding a null event listener should succeed
+Running ../../tools/wpt/dom/events/EventTarget-constructible.any.js
+TEST DONE 0 A constructed EventTarget can be used as expected
+TEST DONE 0 EventTarget can be subclassed
+Skipping ../../tools/wpt/dom/events/EventTarget-removeEventListener.any.js
 
-1402 tests, 361 passed, 1035 failed
- -> 25% conformance
+1441 tests, 395 passed, 1040 failed
+ -> 27% conformance

--- a/packages/wpt-runner/current-results.md
+++ b/packages/wpt-runner/current-results.md
@@ -1508,10 +1508,6 @@ TEST DONE 1 returnValue should be ignored if-and-only-if the passive option is t
 TEST DONE 0 passive behavior of one listener should be unaffected by the presence of other listeners
 TEST DONE 1 Equivalence of option values
 Running ../../tools/wpt/dom/events/AddEventListenerOptions-signal.any.js
-1
-2
-2
-2
 TEST DONE 0 Passing an AbortSignal to addEventListener options should allow removing a listener
 TEST DONE 0 Passing an AbortSignal to addEventListener does not prevent removeEventListener
 TEST DONE 0 Passing an AbortSignal to addEventListener works with the once flag

--- a/packages/wpt-runner/src/main.rs
+++ b/packages/wpt-runner/src/main.rs
@@ -83,7 +83,7 @@ fn init_logger() -> Result<(), SetLoggerError> {
     Ok(())
 }
 
-const SKIP_TESTS: [&str; 14] = [
+const SKIP_TESTS: [&str; 15] = [
     // request
     "request-error.any.js",         // "badRequestArgTests is not defined"
     "request-init-stream.any.js",   // "request.body.getReader is not a function"
@@ -102,6 +102,8 @@ const SKIP_TESTS: [&str; 14] = [
     "iso-2022-jp-decoder.any.js",          // we only support utf-8
     "encodeInto.any.js",                   // TextEncoder#encodeInto isn't implemented yet
     "textdecoder-fatal-single-byte.any.js", // have a random number of tests?
+    // event
+    "EventTarget-removeEventListener.any.js", // removeEventListener does not exists on the global object
 ];
 
 async fn run_test(path: &Path) {
@@ -192,6 +194,7 @@ async fn main() {
         // test_directory(Path::new("../../tools/wpt/compression")).await;
         test_directory(Path::new("../../tools/wpt/encoding")).await;
         test_directory(Path::new("../../tools/wpt/FileAPI/blob")).await;
+        test_directory(Path::new("../../tools/wpt/dom/events")).await;
     }
 
     let result = RESULT.lock().unwrap();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,9 @@ importers:
       '@changesets/changelog-github': ^0.4.6
       '@changesets/cli': ^2.23.1
       '@types/mock-fs': ^4.13.1
-      '@typescript-eslint/eslint-plugin': ^5.26.0
-      '@typescript-eslint/parser': ^5.26.0
+      '@typescript-eslint/eslint-plugin': ^5.47.1
+      '@typescript-eslint/parser': ^5.47.1
+      '@typescript-eslint/typescript-estree': ^5.47.1
       c8: ^7.12.0
       esbuild: ^0.16.0
       eslint: ^8.16.0
@@ -20,14 +21,15 @@ importers:
       prettier: ^2.6.2
       tsup: ^6.0.1
       turbo: ^1.5.2
-      typescript: ^4.6.4
+      typescript: ^4.9.4
       vitest: ^0.25.0
     devDependencies:
       '@changesets/changelog-github': 0.4.6
       '@changesets/cli': 2.23.1
       '@types/mock-fs': 4.13.1
-      '@typescript-eslint/eslint-plugin': 5.30.5_6zdoc3rn4mpiddqwhppni2mnnm
-      '@typescript-eslint/parser': 5.30.5_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/eslint-plugin': 5.47.1_bvkihrwpflcvz4tzbvhhoeequa
+      '@typescript-eslint/parser': 5.47.1_k4b6qcmrsydkglujhfzi6kw7lm
+      '@typescript-eslint/typescript-estree': 5.47.1_typescript@4.9.4
       c8: 7.12.0
       esbuild: 0.16.5
       eslint: 8.19.0
@@ -37,10 +39,10 @@ importers:
       lint-staged: 13.0.3
       mock-fs: 5.1.4
       prettier: 2.7.1
-      tsup: 6.1.3_typescript@4.7.4
-      turbo: 1.5.2
-      typescript: 4.7.4
-      vitest: 0.25.3
+      tsup: 6.5.0_typescript@4.9.4
+      turbo: 1.6.3
+      typescript: 4.9.4
+      vitest: 0.25.8
 
   examples/astro:
     specifiers:
@@ -8708,6 +8710,10 @@ packages:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
     dev: true
 
+  /@types/semver/7.3.13:
+    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
+
   /@types/source-list-map/0.1.2:
     resolution: {integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==}
     dev: true
@@ -8775,8 +8781,8 @@ packages:
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.30.5_6zdoc3rn4mpiddqwhppni2mnnm:
-    resolution: {integrity: sha512-lftkqRoBvc28VFXEoRgyZuztyVUQ04JvUnATSPtIRFAccbXTWL6DEtXGYMcbg998kXw1NLUJm7rTQ9eUt+q6Ig==}
+  /@typescript-eslint/eslint-plugin/5.47.1_bvkihrwpflcvz4tzbvhhoeequa:
+    resolution: {integrity: sha512-r4RZ2Jl9kcQN7K/dcOT+J7NAimbiis4sSM9spvWimsBvDegMhKLA5vri2jG19PmIPbDjPeWzfUPQ2hjEzA4Nmg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -8786,18 +8792,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.30.5_4x5o4skxv6sl53vpwefgt23khm
-      '@typescript-eslint/scope-manager': 5.30.5
-      '@typescript-eslint/type-utils': 5.30.5_4x5o4skxv6sl53vpwefgt23khm
-      '@typescript-eslint/utils': 5.30.5_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/parser': 5.47.1_k4b6qcmrsydkglujhfzi6kw7lm
+      '@typescript-eslint/scope-manager': 5.47.1
+      '@typescript-eslint/type-utils': 5.47.1_k4b6qcmrsydkglujhfzi6kw7lm
+      '@typescript-eslint/utils': 5.47.1_k4b6qcmrsydkglujhfzi6kw7lm
       debug: 4.3.4
       eslint: 8.19.0
-      functional-red-black-tree: 1.0.1
       ignore: 5.2.0
+      natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8813,26 +8819,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/parser/5.30.5_4x5o4skxv6sl53vpwefgt23khm:
-    resolution: {integrity: sha512-zj251pcPXI8GO9NDKWWmygP6+UjwWmrdf9qMW/L/uQJBM/0XbU2inxe5io/234y/RCvwpKEYjZ6c1YrXERkK4Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.30.5
-      '@typescript-eslint/types': 5.30.5
-      '@typescript-eslint/typescript-estree': 5.30.5_typescript@4.7.4
-      debug: 4.3.4
-      eslint: 8.19.0
-      typescript: 4.7.4
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@typescript-eslint/parser/5.44.0_4x5o4skxv6sl53vpwefgt23khm:
@@ -8855,6 +8841,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser/5.47.1_k4b6qcmrsydkglujhfzi6kw7lm:
+    resolution: {integrity: sha512-9Vb+KIv29r6GPu4EboWOnQM7T+UjpjXvjCPhNORlgm40a9Ia9bvaPJswvtae1gip2QEeVeGh6YquqAzEgoRAlw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.47.1
+      '@typescript-eslint/types': 5.47.1
+      '@typescript-eslint/typescript-estree': 5.47.1_typescript@4.9.4
+      debug: 4.3.4
+      eslint: 8.19.0
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager/5.30.5:
     resolution: {integrity: sha512-NJ6F+YHHFT/30isRe2UTmIGGAiXKckCyMnIV58cE3JkHmaD6e5zyEYm5hBDv0Wbin+IC0T1FWJpD3YqHUG/Ydg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8871,8 +8877,16 @@ packages:
       '@typescript-eslint/visitor-keys': 5.44.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.30.5_4x5o4skxv6sl53vpwefgt23khm:
-    resolution: {integrity: sha512-k9+ejlv1GgwN1nN7XjVtyCgE0BTzhzT1YsQF0rv4Vfj2U9xnslBgMYYvcEYAFVdvhuEscELJsB7lDkN7WusErw==}
+  /@typescript-eslint/scope-manager/5.47.1:
+    resolution: {integrity: sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.47.1
+      '@typescript-eslint/visitor-keys': 5.47.1
+    dev: true
+
+  /@typescript-eslint/type-utils/5.47.1_k4b6qcmrsydkglujhfzi6kw7lm:
+    resolution: {integrity: sha512-/UKOeo8ee80A7/GJA427oIrBi/Gd4osk/3auBUg4Rn9EahFpevVV1mUK8hjyQD5lHPqX397x6CwOk5WGh1E/1w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -8881,11 +8895,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.30.5_4x5o4skxv6sl53vpwefgt23khm
+      '@typescript-eslint/typescript-estree': 5.47.1_typescript@4.9.4
+      '@typescript-eslint/utils': 5.47.1_k4b6qcmrsydkglujhfzi6kw7lm
       debug: 4.3.4
       eslint: 8.19.0
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8897,6 +8912,11 @@ packages:
 
   /@typescript-eslint/types/5.44.0:
     resolution: {integrity: sha512-Tp+zDnHmGk4qKR1l+Y1rBvpjpm5tGXX339eAlRBDg+kgZkz9Bw+pqi4dyseOZMsGuSH69fYfPJCBKBrbPCxYFQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types/5.47.1:
+    resolution: {integrity: sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -8942,6 +8962,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.47.1_typescript@4.9.4:
+    resolution: {integrity: sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.47.1
+      '@typescript-eslint/visitor-keys': 5.47.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.9.4
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils/5.30.5_4x5o4skxv6sl53vpwefgt23khm:
     resolution: {integrity: sha512-o4SSUH9IkuA7AYIfAvatldovurqTAHrfzPApOZvdUq01hHojZojCFXx06D/aFpKCgWbMPRdJBWAC3sWp3itwTA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8960,6 +9001,26 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.47.1_k4b6qcmrsydkglujhfzi6kw7lm:
+    resolution: {integrity: sha512-l90SdwqfmkuIVaREZ2ykEfCezepCLxzWMo5gVfcJsJCaT4jHT+QjgSkYhs5BMQmWqE9k3AtIfk4g211z/sTMVw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.47.1
+      '@typescript-eslint/types': 5.47.1
+      '@typescript-eslint/typescript-estree': 5.47.1_typescript@4.9.4
+      eslint: 8.19.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.19.0
+      semver: 7.3.7
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.30.5:
     resolution: {integrity: sha512-D+xtGo9HUMELzWIUqcQc0p2PO4NyvTrgIOK/VnSH083+8sq0tiLozNRKuLarwHYGRuA6TVBQSuuLwJUDWd3aaA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8973,6 +9034,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.44.0
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.47.1:
+    resolution: {integrity: sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.47.1
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -10574,13 +10643,13 @@ packages:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
     dev: true
 
-  /bundle-require/3.0.4_esbuild@0.14.48:
-    resolution: {integrity: sha512-VXG6epB1yrLAvWVQpl92qF347/UXmncQj7J3U8kZEbdVZ1ZkQyr4hYeL/9RvcE8vVVdp53dY78Fd/3pqfRqI1A==}
+  /bundle-require/3.1.2_esbuild@0.15.15:
+    resolution: {integrity: sha512-Of6l6JBAxiyQ5axFxUM6dYeP/W7X2Sozeo/4EYB9sJhL+dqL7TKjg+shwxp6jlu/6ZSERfsYtIpSJ1/x3XkAEA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.13'
     dependencies:
-      esbuild: 0.14.48
+      esbuild: 0.15.15
       load-tsconfig: 0.2.3
     dev: true
 
@@ -10611,11 +10680,6 @@ packages:
       v8-to-istanbul: 9.0.1
       yargs: 16.2.0
       yargs-parser: 20.2.9
-    dev: true
-
-  /cac/6.7.12:
-    resolution: {integrity: sha512-rM7E2ygtMkJqD9c7WnFU6fruFcN3xe4FM5yUmgxhZzIKJk4uHl9U/fhwdajGFQbQuv43FAUo1Fe8gX/oIKDeSA==}
-    engines: {node: '>=8'}
     dev: true
 
   /cac/6.7.14:
@@ -10798,13 +10862,13 @@ packages:
   /ccount/2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  /chai/4.3.6:
-    resolution: {integrity: sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==}
+  /chai/4.3.7:
+    resolution: {integrity: sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
       check-error: 1.0.2
-      deep-eql: 3.0.1
+      deep-eql: 4.1.3
       get-func-name: 2.0.0
       loupe: 2.3.4
       pathval: 1.1.1
@@ -11723,9 +11787,9 @@ packages:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
 
-  /deep-eql/3.0.1:
-    resolution: {integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==}
-    engines: {node: '>=0.12'}
+  /deep-eql/4.1.3:
+    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
     dependencies:
       type-detect: 4.0.8
     dev: true
@@ -14081,7 +14145,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
+      fast-glob: 3.2.12
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
@@ -16871,6 +16935,10 @@ packages:
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /natural-compare-lite/1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare/1.4.0:
@@ -20297,8 +20365,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-literal/0.4.2:
-    resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
+  /strip-literal/1.0.0:
+    resolution: {integrity: sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==}
     dependencies:
       acorn: 8.8.1
     dev: true
@@ -20892,8 +20960,8 @@ packages:
       esbuild: 0.14.48
     dev: true
 
-  /tsup/6.1.3_typescript@4.7.4:
-    resolution: {integrity: sha512-eRpBnbfpDFng+EJNTQ90N7QAf4HAGGC7O3buHIjroKWK7D1ibk9/YnR/3cS8HsMU5T+6Oi+cnF+yU5WmCnB//Q==}
+  /tsup/6.5.0_typescript@4.9.4:
+    resolution: {integrity: sha512-36u82r7rYqRHFkD15R20Cd4ercPkbYmuvRkz3Q1LCm5BsiFNUgpo36zbjVhCOgvjyxNBWNKHsaD5Rl8SykfzNA==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
@@ -20908,21 +20976,21 @@ packages:
       typescript:
         optional: true
     dependencies:
-      bundle-require: 3.0.4_esbuild@0.14.48
-      cac: 6.7.12
+      bundle-require: 3.1.2_esbuild@0.15.15
+      cac: 6.7.14
       chokidar: 3.5.3
       debug: 4.3.4
-      esbuild: 0.14.48
+      esbuild: 0.15.15
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
       postcss-load-config: 3.1.4
       resolve-from: 5.0.0
-      rollup: 2.75.7
+      rollup: 3.8.1
       source-map: 0.8.0-beta.0
       sucrase: 3.23.0
       tree-kill: 1.2.2
-      typescript: 4.7.4
+      typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -20936,6 +21004,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.7.4
+    dev: true
+
+  /tsutils/3.21.0_typescript@4.9.4:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.9.4
     dev: true
 
   /tty-browserify/0.0.0:
@@ -20956,65 +21034,65 @@ packages:
       yargs: 17.5.1
     dev: true
 
-  /turbo-darwin-64/1.5.2:
-    resolution: {integrity: sha512-NFOHgYKsuhuF6KRiUM3GzLx1wNTerFcZbIGhANsmeaOo48zSpOhNaKpRsS+DbLuBcxF6WZFwF4qngtduKGZqUw==}
+  /turbo-darwin-64/1.6.3:
+    resolution: {integrity: sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.5.2:
-    resolution: {integrity: sha512-mrd7TIFT+U+mblJtKX2ZIDh5NZ6qIG5rc/I2T+PFL1qIZvuRAOCs1JLCUB4m+IusNOYIzYKQWbupX4JWzPfm0w==}
+  /turbo-darwin-arm64/1.6.3:
+    resolution: {integrity: sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.5.2:
-    resolution: {integrity: sha512-KjQzYLxgPyDBD8Uye+Tst0rYmJkjbqWl1l5QwuZaVtSmyss+U3hF7Nd9Dk93EhXXEEKIhzXfdqOVcW2+zKAPrA==}
+  /turbo-linux-64/1.6.3:
+    resolution: {integrity: sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.5.2:
-    resolution: {integrity: sha512-cbcRTt9hJMK7aLHSpk4hHjekm5A5fVL71NSgNxvaRKI47qXJTc4aAeWSpHBWSe4KNKhMg/DyJ8D3aTfnnqx4rA==}
+  /turbo-linux-arm64/1.6.3:
+    resolution: {integrity: sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.5.2:
-    resolution: {integrity: sha512-ntLpZ86wJCVEHdwTrz4JWZ12+LkiWt0teEcXpxlmL6hKHMEmHcf2v5rnEPbVFqo5TMkuXRUgfXSZ2SZ0meJzPg==}
+  /turbo-windows-64/1.6.3:
+    resolution: {integrity: sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.5.2:
-    resolution: {integrity: sha512-ghCC2MjC1obxv/wPXM9H7JklnxNtxNlZ6HjnDHNOg3LSUF2NCPd6X52uOXb9JtEpIq+bL3EhtDCth9Z61nWpuA==}
+  /turbo-windows-arm64/1.6.3:
+    resolution: {integrity: sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.5.2:
-    resolution: {integrity: sha512-id1q+kFjFhuwmrP4E0EWrPTKsJ5HDZtFkFF7XNwZl/Q0idVTwq+4feg3Xn96AyXXDNca50lafhjIUxrq3Q2cIA==}
+  /turbo/1.6.3:
+    resolution: {integrity: sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.5.2
-      turbo-darwin-arm64: 1.5.2
-      turbo-linux-64: 1.5.2
-      turbo-linux-arm64: 1.5.2
-      turbo-windows-64: 1.5.2
-      turbo-windows-arm64: 1.5.2
+      turbo-darwin-64: 1.6.3
+      turbo-darwin-arm64: 1.6.3
+      turbo-linux-64: 1.6.3
+      turbo-linux-arm64: 1.6.3
+      turbo-windows-64: 1.6.3
+      turbo-windows-arm64: 1.6.3
     dev: true
 
   /type-check/0.3.2:
@@ -21706,40 +21784,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite/3.2.5_@types+node@18.11.9:
-    resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.11.9
-      esbuild: 0.15.15
-      postcss: 8.4.20
-      resolve: 1.22.1
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /vite/4.0.3:
     resolution: {integrity: sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -21773,6 +21817,40 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vite/4.0.3_@types+node@18.11.18:
+    resolution: {integrity: sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.11.18
+      esbuild: 0.16.5
+      postcss: 8.4.20
+      resolve: 1.22.1
+      rollup: 3.8.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /vitefu/0.2.2_vite@3.2.5:
     resolution: {integrity: sha512-8CKEIWPm4B4DUDN+h+hVJa9pyNi7rzc5MYmbxhs1wcMakueGFNWB5/DL30USm9qU3xUPnL4/rrLEAwwFiD1tag==}
     peerDependencies:
@@ -21784,8 +21862,8 @@ packages:
       vite: 3.2.5
     dev: true
 
-  /vitest/0.25.3:
-    resolution: {integrity: sha512-/UzHfXIKsELZhL7OaM2xFlRF8HRZgAHtPctacvNK8H4vOcbJJAMEgbWNGSAK7Y9b1NBe5SeM7VTuz2RsTHFJJA==}
+  /vitest/0.25.8:
+    resolution: {integrity: sha512-X75TApG2wZTJn299E/TIYevr4E9/nBo1sUtZzn0Ci5oK8qnpZAZyhwg0qCeMSakGIWtc6oRwcQFyFfW14aOFWg==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -21808,18 +21886,18 @@ packages:
     dependencies:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.11.9
+      '@types/node': 18.11.18
       acorn: 8.8.1
       acorn-walk: 8.2.0
-      chai: 4.3.6
+      chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.2
       source-map: 0.6.1
-      strip-literal: 0.4.2
+      strip-literal: 1.0.0
       tinybench: 2.3.1
       tinypool: 0.3.0
       tinyspy: 1.0.2
-      vite: 3.2.5_@types+node@18.11.9
+      vite: 4.0.3_@types+node@18.11.18
     transitivePeerDependencies:
       - less
       - sass


### PR DESCRIPTION
## About

Closes #415 

Add `Event` & `EventTarget` APIs, as required by WinterCG. Also add `CustomEvent` API to make WPT tests pass:

```
39 tests, 34 passed, 5 failed
 -> 87% conformance
```

Most of the failing tests are due to unimplemented methods and fields, that are still tested by WPT (`returnValue`, `initEvent()`)