### PR TITLE
refactor(runtime): clean and better file architecture

### DIFF
--- a/packages/cli/src/commands/dev.rs
+++ b/packages/cli/src/commands/dev.rs
@@ -8,8 +8,8 @@ use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse, Server};
 use lagon_runtime::http::{Request, Response, RunResult, StreamResult};
-use lagon_runtime::isolate::{Isolate, IsolateOptions};
-use lagon_runtime::runtime::{Runtime, RuntimeOptions};
+use lagon_runtime::isolate::{options::IsolateOptions, Isolate};
+use lagon_runtime::runtime::{options::RuntimeOptions, Runtime};
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -138,8 +138,8 @@ async fn handle_request(
                             IsolateOptions::new(
                                 String::from_utf8(index).expect("Code is not UTF-8"),
                             )
-                            .with_metadata(Some((String::from(""), String::from(""))))
-                            .with_environment_variables(environment_variables),
+                            .metadata(Some((String::from(""), String::from(""))))
+                            .environment_variables(environment_variables),
                         );
 
                         isolate.run(request, tx).await;
@@ -241,7 +241,7 @@ pub async fn dev(
     let content = Arc::new(Mutex::new((index, assets)));
 
     let runtime =
-        Runtime::new(RuntimeOptions::default().with_allow_code_generation(allow_code_generation));
+        Runtime::new(RuntimeOptions::default().allow_code_generation(allow_code_generation));
     let addr = format!(
         "{}:{}",
         hostname.unwrap_or_else(|| "127.0.0.1".into()),

--- a/packages/runtime/src/isolate/callbacks.rs
+++ b/packages/runtime/src/isolate/callbacks.rs
@@ -1,0 +1,65 @@
+use crate::utils::{extract_v8_string, v8_string};
+
+use super::Isolate;
+
+pub extern "C" fn heap_limit_callback(
+    data: *mut std::ffi::c_void,
+    current_heap_limit: usize,
+    _initial_heap_limit: usize,
+) -> usize {
+    let isolate = unsafe { &mut *(data as *mut Isolate) };
+
+    isolate.heap_limit_reached();
+    // Avoid OOM killer by increasing the limit, since we kill
+    // the isolate above.
+    current_heap_limit * 2
+}
+
+pub extern "C" fn promise_reject_callback(message: v8::PromiseRejectMessage) {
+    let scope = &mut unsafe { v8::CallbackScope::new(&message) };
+    let promise = message.get_promise();
+    let promise = v8::Global::new(scope, promise);
+
+    let isolate = Isolate::state(scope);
+    let mut state = isolate.borrow_mut();
+
+    match message.get_event() {
+        v8::PromiseRejectEvent::PromiseRejectWithNoHandler => {
+            let content = message.get_value().map_or_else(
+                || "Unknown promise rejected error".to_owned(),
+                |value| {
+                    extract_v8_string(value, scope)
+                        .unwrap_or_else(|_| "Failed to extract promise reject message".to_owned())
+                },
+            );
+
+            state.rejected_promises.insert(promise, content);
+        }
+        v8::PromiseRejectEvent::PromiseHandlerAddedAfterReject => {
+            state.rejected_promises.remove(&promise);
+        }
+        _ => {}
+    }
+}
+
+// We don't allow imports at all, so we return None and throw an error
+// so it can be catched later. As the error message suggests, all code
+// should be bundled into a single file.
+pub fn resolve_module_callback<'a>(
+    context: v8::Local<'a, v8::Context>,
+    _: v8::Local<'a, v8::String>,
+    _: v8::Local<'a, v8::FixedArray>,
+    _: v8::Local<'a, v8::Module>,
+) -> Option<v8::Local<'a, v8::Module>> {
+    let scope = &mut unsafe { v8::CallbackScope::new(context) };
+
+    let message = v8_string(
+        scope,
+        "Can't import modules, everything should be bundled in a single file",
+    );
+
+    let exception = v8::Exception::error(scope, message);
+    scope.throw_exception(exception);
+
+    None
+}

--- a/packages/runtime/src/isolate/options.rs
+++ b/packages/runtime/src/isolate/options.rs
@@ -1,0 +1,103 @@
+use std::{collections::HashMap, rc::Rc};
+
+use crate::utils::v8_string;
+
+use super::IsolateStatistics;
+
+const JS_RUNTIME: &str = include_str!("../../runtime.js");
+
+pub type Metadata = Option<(String, String)>;
+type OnIsolateDropCallback = Box<dyn Fn(Rc<Metadata>)>;
+type OnIsolateStatisticsCallback = Box<dyn Fn(Rc<Metadata>, IsolateStatistics)>;
+
+pub struct IsolateOptions {
+    pub code: String,
+    pub environment_variables: Option<HashMap<String, String>>,
+    pub memory: usize,          // in MB (MegaBytes)
+    pub timeout: usize,         // in ms (MilliSeconds)
+    pub startup_timeout: usize, // is ms (MilliSeconds)
+    pub metadata: Rc<Metadata>,
+    pub on_drop: Option<OnIsolateDropCallback>,
+    pub on_statistics: Option<OnIsolateStatisticsCallback>,
+    // pub snapshot_blob: Option<Box<dyn Allocated<[u8]>>>,
+}
+
+impl IsolateOptions {
+    pub fn new(code: String) -> Self {
+        Self {
+            code,
+            environment_variables: None,
+            timeout: 50,
+            startup_timeout: 200,
+            memory: 128,
+            metadata: Rc::new(None),
+            on_drop: None,
+            on_statistics: None,
+            // snapshot_blob: None,
+        }
+    }
+
+    pub fn environment_variables(mut self, environment_variables: HashMap<String, String>) -> Self {
+        self.environment_variables = Some(environment_variables);
+        self
+    }
+
+    pub fn timeout(mut self, timeout: usize) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn startup_timeout(mut self, startup_timeout: usize) -> Self {
+        self.startup_timeout = startup_timeout;
+        self
+    }
+
+    pub fn memory(mut self, memory: usize) -> Self {
+        self.memory = memory;
+        self
+    }
+
+    pub fn metadata(mut self, metadata: Metadata) -> Self {
+        self.metadata = Rc::new(metadata);
+        self
+    }
+
+    pub fn on_drop_callback(mut self, on_drop: OnIsolateDropCallback) -> Self {
+        self.on_drop = Some(on_drop);
+        self
+    }
+
+    pub fn on_statistics_callback(mut self, on_statistics: OnIsolateStatisticsCallback) -> Self {
+        self.on_statistics = Some(on_statistics);
+        self
+    }
+
+    pub fn get_runtime_code<'a>(
+        &self,
+        scope: &mut v8::HandleScope<'a>,
+    ) -> v8::Local<'a, v8::String> {
+        let IsolateOptions {
+            code,
+            environment_variables,
+            ..
+        } = self;
+
+        let environment_variables = match environment_variables {
+            Some(environment_variables) => environment_variables
+                .iter()
+                .map(|(k, v)| format!("globalThis.process.env.{} = '{}'", k, v))
+                .collect::<Vec<String>>()
+                .join("\n"),
+            None => "".to_string(),
+        };
+
+        v8_string(
+            scope,
+            &format!(
+                r"{JS_RUNTIME}
+    {environment_variables}
+    {code}"
+            ),
+        )
+    }
+}

--- a/packages/runtime/src/runtime/options.rs
+++ b/packages/runtime/src/runtime/options.rs
@@ -1,0 +1,25 @@
+pub struct RuntimeOptions {
+    pub allow_code_generation: bool,
+    pub expose_gc: bool,
+}
+
+impl Default for RuntimeOptions {
+    fn default() -> Self {
+        Self {
+            allow_code_generation: true,
+            expose_gc: false,
+        }
+    }
+}
+
+impl RuntimeOptions {
+    pub fn allow_code_generation(mut self, allow_code_generation: bool) -> Self {
+        self.allow_code_generation = allow_code_generation;
+        self
+    }
+
+    pub fn expose_gc(mut self, expose_gc: bool) -> Self {
+        self.expose_gc = expose_gc;
+        self
+    }
+}

--- a/packages/runtime/src/runtime/options.rs
+++ b/packages/runtime/src/runtime/options.rs
@@ -1,15 +1,7 @@
+#[derive(Default)]
 pub struct RuntimeOptions {
     pub allow_code_generation: bool,
     pub expose_gc: bool,
-}
-
-impl Default for RuntimeOptions {
-    fn default() -> Self {
-        Self {
-            allow_code_generation: true,
-            expose_gc: false,
-        }
-    }
 }
 
 impl RuntimeOptions {

--- a/packages/runtime/tests/allow_codegen.rs
+++ b/packages/runtime/tests/allow_codegen.rs
@@ -2,15 +2,15 @@ use std::sync::Once;
 
 use lagon_runtime::{
     http::{Request, Response, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {
     static START: Once = Once::new();
 
     START.call_once(|| {
-        Runtime::new(RuntimeOptions::default().with_allow_code_generation(true));
+        Runtime::new(RuntimeOptions::default().allow_code_generation(true));
     });
 }
 

--- a/packages/runtime/tests/crypto.rs
+++ b/packages/runtime/tests/crypto.rs
@@ -2,8 +2,8 @@ use std::sync::Once;
 
 use lagon_runtime::{
     http::{Request, Response, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {

--- a/packages/runtime/tests/disallow_codegen.rs
+++ b/packages/runtime/tests/disallow_codegen.rs
@@ -2,8 +2,8 @@ use std::sync::Once;
 
 use lagon_runtime::{
     http::{Request, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {

--- a/packages/runtime/tests/errors.rs
+++ b/packages/runtime/tests/errors.rs
@@ -3,8 +3,8 @@ use std::sync::Once;
 use hyper::body::Bytes;
 use lagon_runtime::{
     http::{Method, Request, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {
@@ -155,8 +155,8 @@ async fn memory_reached() {
             .into(),
         )
         // Increase timeout for CI
-        .with_startup_timeout(1000)
-        .with_memory(1),
+        .startup_timeout(1000)
+        .memory(1),
     );
     let (tx, rx) = flume::unbounded();
     isolate

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -3,8 +3,8 @@ use std::sync::Once;
 use httptest::{matchers::*, responders::*, Expectation, Server};
 use lagon_runtime::{
     http::{Request, Response, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {

--- a/packages/runtime/tests/promises.rs
+++ b/packages/runtime/tests/promises.rs
@@ -6,8 +6,8 @@ use hyper::{
 };
 use lagon_runtime::{
     http::{Request, Response, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {

--- a/packages/runtime/tests/runtime.rs
+++ b/packages/runtime/tests/runtime.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, sync::Once};
 use hyper::body::Bytes;
 use lagon_runtime::{
     http::{Method, Request, Response, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {
@@ -43,7 +43,7 @@ async fn environment_variables() {
 }"
             .into(),
         )
-        .with_environment_variables(
+        .environment_variables(
             vec![("TEST".into(), "Hello world".into())]
                 .into_iter()
                 .collect(),

--- a/packages/runtime/tests/streams.rs
+++ b/packages/runtime/tests/streams.rs
@@ -4,8 +4,8 @@ use httptest::{matchers::*, responders::*, Expectation, Server};
 use hyper::body::Bytes;
 use lagon_runtime::{
     http::{Request, Response, RunResult, StreamResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 fn setup() {

--- a/packages/serverless/src/main.rs
+++ b/packages/serverless/src/main.rs
@@ -8,8 +8,8 @@ use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse, Server};
 use lagon_runtime::http::{Request, RunResult, StreamResult};
-use lagon_runtime::isolate::{Isolate, IsolateOptions};
-use lagon_runtime::runtime::{Runtime, RuntimeOptions};
+use lagon_runtime::isolate::{options::IsolateOptions, Isolate};
+use lagon_runtime::runtime::{options::RuntimeOptions, Runtime};
 use lazy_static::lazy_static;
 use log::{as_debug, error, info, warn};
 use metrics::{counter, decrement_gauge, histogram, increment_counter, increment_gauge};
@@ -202,14 +202,14 @@ async fn handle_request(
                             "".into()
                         });
                         let options = IsolateOptions::new(code)
-                            .with_environment_variables(
+                            .environment_variables(
                                 deployment.environment_variables.clone(),
                             )
-                            .with_memory(deployment.memory)
-                            .with_timeout(deployment.timeout)
-                            .with_startup_timeout(deployment.startup_timeout)
-                            .with_metadata(Some((deployment.id.clone(), deployment.function_id.clone())))
-                            .with_on_drop_callback(Box::new(|metadata| {
+                            .memory(deployment.memory)
+                            .timeout(deployment.timeout)
+                            .startup_timeout(deployment.startup_timeout)
+                            .metadata(Some((deployment.id.clone(), deployment.function_id.clone())))
+                            .on_drop_callback(Box::new(|metadata| {
                                 if let Some(metadata) = metadata.as_ref().as_ref() {
 
 
@@ -223,7 +223,7 @@ async fn handle_request(
                                     info!(deployment = metadata.0, function = metadata.1; "Dropping isolate");
                                 }
                             }))
-                            .with_on_statistics_callback(Box::new(|metadata, statistics| {
+                            .on_statistics_callback(Box::new(|metadata, statistics| {
                                 if let Some(metadata) = metadata.as_ref().as_ref() {
                                     let labels = [
                                         ("deployment", metadata.0.clone()),

--- a/packages/wpt-runner/src/main.rs
+++ b/packages/wpt-runner/src/main.rs
@@ -12,8 +12,8 @@ use std::{
 
 use lagon_runtime::{
     http::{Request, RunResult},
-    isolate::{Isolate, IsolateOptions},
-    runtime::{Runtime, RuntimeOptions},
+    isolate::{options::IsolateOptions, Isolate},
+    runtime::{options::RuntimeOptions, Runtime},
 };
 
 // From tools/wpt/encoding/resources/encodings.js, we only support utf-8
@@ -145,7 +145,7 @@ export function handler() {{
     .replace("self.", "globalThis.");
 
     let mut isolate = Isolate::new(
-        IsolateOptions::new(code).with_metadata(Some((String::from(""), String::from("")))),
+        IsolateOptions::new(code).metadata(Some((String::from(""), String::from("")))),
     );
 
     let (tx, rx) = flume::unbounded();
@@ -172,7 +172,7 @@ async fn test_directory(path: &Path) {
 
 #[tokio::main]
 async fn main() {
-    let runtime = Runtime::new(RuntimeOptions::default().with_expose_gc(true));
+    let runtime = Runtime::new(RuntimeOptions::default().expose_gc(true));
     init_logger().expect("Failed to initialize logger");
 
     if let Some(path) = env::args().nth(1) {


### PR DESCRIPTION
## About

- Move option structs to separate files
- Remove `with_` prefix in builders' methods in options
- Move callbacks to a separate file
