### PR TITLE
feat(runtime): follow redirects in `fetch()`

### DIFF
--- a/.changeset/short-foxes-care.md
+++ b/.changeset/short-foxes-care.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Follow redirects in `fetch`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1390,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "anyhow",
+ "async-recursion",
  "flume",
  "futures",
  "hmac",

--- a/packages/runtime/Cargo.toml
+++ b/packages/runtime/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
 rand = "0.8.5"
 log = { version = "0.4.17", features = ["std", "kv_unstable"] }
 lazy_static = "1.4.0"
+async-recursion = "1.0.0"
 # Cryptography
 hmac = "0.12.1"
 sha1 = "0.10.5"

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -234,7 +234,11 @@ async fn response_status() {
     let server = Server::run();
     server.expect(
         Expectation::matching(request::method_path("GET", "/"))
-            .respond_with(status_code(302).body("Moved")),
+            .respond_with(status_code(302).append_header("location", "/moved")),
+    );
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/moved"))
+            .respond_with(status_code(200).body("Moved")),
     );
     let url = server.url("/");
 
@@ -251,7 +255,7 @@ async fn response_status() {
 
     assert_eq!(
         rx.recv_async().await.unwrap(),
-        RunResult::Response(Response::from("Moved: 302"))
+        RunResult::Response(Response::from("Moved: 200"))
     );
 }
 

--- a/packages/runtime/tests/fetch.rs
+++ b/packages/runtime/tests/fetch.rs
@@ -388,3 +388,122 @@ async fn abort_signal() {
         RunResult::Response(Response::from("Aborted"))
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn redirect() {
+    setup();
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(301).append_header("Location", "https://google.com")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const status = (await fetch('{url}')).status;
+    return new Response(status);
+}}"
+    )));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("200"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn redirect_relative_url() {
+    setup();
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(301).append_header("Location", "/redirected")),
+    );
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/redirected"))
+            .respond_with(status_code(200)),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const status = (await fetch('{url}')).status;
+    return new Response(status);
+}}"
+    )));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("200"))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn redirect_without_location_header() {
+    setup();
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/")).respond_with(status_code(301)),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const status = (await fetch('{url}')).status;
+    return new Response(status);
+}}"
+    )));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Error("Error: Got a redirect without Location header".into())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn redirect_loop() {
+    setup();
+    let server = Server::run();
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/"))
+            .respond_with(status_code(301).append_header("location", "/a")),
+    );
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/a"))
+            .respond_with(status_code(301).append_header("location", "/b")),
+    );
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/b"))
+            .respond_with(status_code(301).append_header("location", "/c")),
+    );
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/c"))
+            .respond_with(status_code(301).append_header("location", "/d")),
+    );
+    server.expect(
+        Expectation::matching(request::method_path("GET", "/d"))
+            .respond_with(status_code(301).append_header("location", "/e")),
+    );
+    let url = server.url("/");
+
+    let mut isolate = Isolate::new(IsolateOptions::new(format!(
+        "export async function handler() {{
+    const status = (await fetch('{url}')).status;
+    return new Response(status);
+}}"
+    )));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Error("Error: Too many redirects".into())
+    );
+}


### PR DESCRIPTION
## About

Closes #445

Follow redirects in `fetch()` calls for both absolute and relative URLs. There is a hard limit of 5 redirects before throwing a "redirect loop" error.