### PR TITLE
fix(js-runtime): use non-null assertion operator in favor of ts-expect-error

### DIFF
--- a/packages/js-runtime/src/runtime/http/URL.ts
+++ b/packages/js-runtime/src/runtime/http/URL.ts
@@ -16,8 +16,7 @@
     public pathname = '';
     public port = '';
     public protocol = '';
-    // @ts-expect-error: TypeScript isn't smart enough to know this is always defined
-    public searchParams: URLSearchParams;
+    public searchParams!: URLSearchParams;
     public username = '';
 
     constructor(url: string | URL, base?: string | URL) {


### PR DESCRIPTION
Handbook: [Postfix !](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-)