### PR TITLE
fix: improve `LayoutTitle` and `FunctionLinks`

### DIFF
--- a/packages/dashboard/lib/components/FunctionLinks.tsx
+++ b/packages/dashboard/lib/components/FunctionLinks.tsx
@@ -1,20 +1,22 @@
 import { getCurrentDomain, getFullCurrentDomain, getFullDomain } from 'lib/utils';
 import { Link } from '@lagon/ui';
+import { MouseEventHandler } from 'react';
 
 type FunctionLinksProps = {
   func?: {
     name: string;
     domains: string[];
   };
+  onClick?: MouseEventHandler<HTMLDivElement> | undefined;
 };
 
-const FunctionLinks = ({ func }: FunctionLinksProps) => {
+const FunctionLinks = ({ func, onClick }: FunctionLinksProps) => {
   if (!func) {
     return null;
   }
 
   return (
-    <div className="flex gap-4 overflow-x-scroll md:overflow-x-auto">
+    <div onClick={onClick} className="flex gap-4 overflow-x-scroll md:overflow-x-auto">
       <Link href={getFullCurrentDomain(func)} target="_blank">
         {getCurrentDomain(func)}
       </Link>

--- a/packages/dashboard/lib/components/FunctionLinks.tsx
+++ b/packages/dashboard/lib/components/FunctionLinks.tsx
@@ -7,7 +7,7 @@ type FunctionLinksProps = {
     name: string;
     domains: string[];
   };
-  onClick?: MouseEventHandler<HTMLDivElement> | undefined;
+  onClick?: MouseEventHandler<HTMLDivElement>;
 };
 
 const FunctionLinks = ({ func, onClick }: FunctionLinksProps) => {

--- a/packages/dashboard/lib/components/LayoutTitle.tsx
+++ b/packages/dashboard/lib/components/LayoutTitle.tsx
@@ -10,7 +10,7 @@ type LayoutTitleProps = {
 
 const LayoutTitle = ({ title, titleStatus, rightItem, children }: LayoutTitleProps) => {
   return (
-    <div className="mx-auto px-4 md:max-w-4xl">
+    <div className="mx-auto px-4 md:max-w-4xl pb-12">
       <div className="flex justify-between items-center pt-10 mb-4">
         <Text size="2xl">
           {titleStatus ? <Dot status={titleStatus} /> : null}

--- a/packages/dashboard/lib/pages/functions/FunctionsList.tsx
+++ b/packages/dashboard/lib/pages/functions/FunctionsList.tsx
@@ -18,6 +18,10 @@ const FunctionsList = () => {
     [push],
   );
 
+  const handleLinkClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    event.stopPropagation();
+  };
+
   return (
     <div className="flex gap-4 flex-col">
       {functions?.length === 0 ? <EmptyState title={t('empty.title')} description={t('empty.description')} /> : null}
@@ -28,7 +32,7 @@ const FunctionsList = () => {
               <Dot status="success" />
               {func.name}
             </Text>
-            <FunctionLinks func={func} />
+            <FunctionLinks onClick={handleLinkClick} func={func} />
           </div>
           <Text size="sm">
             {t('list.lastUpdate')}&nbsp;


### PR DESCRIPTION
## About

Hi, really excited with this project and willing to contribute a lot.

- This PR does two little things:
   1. Add bottom padding in `LayoutTitle` component: [3b97df4](https://github.com/lagonapp/lagon/commit/3b97df48a1ef8d1d646e25c226ba3abd74b0b8e0)
  
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/65691613/210690303-a829b7b0-347e-4824-b5e4-d5a81f85079a.png">

   2. Prevent open functions' page on link click: [480d60b4](https://github.com/lagonapp/lagon/commit/480d60b4cc2d973017275eb3aa44a06e18955afa)

Currently, if you click the deployment link via functions list card (eg: `something-something.lagon.app`), it will open the deployment in new tab, but the original tab will open the deployment details. This PR fix this using `event.stopPropagation()`. [ref](https://stackoverflow.com/a/54075528)
