### PR TITLE
fix(runtime): borrow error when calling the same function twice

### DIFF
--- a/.changeset/popular-insects-dance.md
+++ b/.changeset/popular-insects-dance.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Fix runtime error when calling the same function twice

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -31,6 +31,31 @@ async fn execute_function() {
 }
 
 #[tokio::test]
+async fn execute_function_twice() {
+    setup();
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export function handler() {
+    return new Response('Hello world');
+}"
+        .into(),
+    ));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx.clone()).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
+
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
+}
+
+#[tokio::test]
 async fn environment_variables() {
     setup();
     let mut isolate = Isolate::new(

--- a/crates/runtime_isolate/src/lib.rs
+++ b/crates/runtime_isolate/src/lib.rs
@@ -169,8 +169,10 @@ impl Isolate {
         self.stream_status = StreamStatus::None;
         self.stream_response_sent = false;
 
-        let mut state = isolate_state.borrow_mut();
-        let global = state.global.0.clone();
+        let global = {
+            let state = isolate_state.borrow();
+            state.global.0.clone()
+        };
 
         let scope = &mut v8::HandleScope::with_context(&mut self.isolate, global.clone());
         let try_catch = &mut v8::TryCatch::new(scope);
@@ -180,8 +182,7 @@ impl Isolate {
             let resource_name = v8_string(try_catch, "isolate.js");
             let source_map_url = v8_string(try_catch, "");
 
-            state.lines = lines;
-            drop(state);
+            isolate_state.borrow_mut().lines = lines;
 
             let source = v8::script_compiler::Source::new(
                 code,


### PR DESCRIPTION
## About

Regression of #453 

The state was borrowed every time we called `evaluate` (first request + subsequent requests) but only dropped on first requests. This PR fixes this bug by not borrowing the state at first and mutably borrowing only on the first request (which is then dropped automatically)

## Tests

Added a new `execute_function_twice` test that runs a function twice. Without the fix, this test is failing.
