### PR TITLE
feat(serverless,cli): allow ending a stream before sending the response

### DIFF
--- a/.changeset/dull-geckos-protect.md
+++ b/.changeset/dull-geckos-protect.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+Simplify streaming responses

--- a/.changeset/wicked-islands-exercise.md
+++ b/.changeset/wicked-islands-exercise.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Allow ending a stream before sending the response

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -173,23 +173,45 @@ async fn handle_request(
                     let bytes = Bytes::from(bytes);
                     stream_tx.send_async(Ok(bytes)).await.unwrap_or(());
                 }
-                StreamResult::Done => panic!("Got a stream done without data"),
+                StreamResult::Done => {
+                    println!(
+                        "{}",
+                        error("The stream was done before sending a response/data")
+                    );
+
+                    // Close the stream by sending empty bytes
+                    stream_tx.send_async(Ok(Bytes::new())).await.unwrap_or(());
+                }
             }
 
             tokio::spawn(async move {
+                let mut done = false;
+
                 while let Ok(result) = rx.recv_async().await {
                     match result {
                         RunResult::Stream(StreamResult::Start(response)) => {
                             response_tx.send_async(response).await.unwrap_or(());
                         }
                         RunResult::Stream(StreamResult::Data(bytes)) => {
+                            if done {
+                                println!("{}", error("Got data after stream was done"));
+
+                                // Close the stream by sending empty bytes
+                                stream_tx.send_async(Ok(Bytes::new())).await.unwrap_or(());
+                                break;
+                            }
+
                             let bytes = Bytes::from(bytes);
                             stream_tx.send_async(Ok(bytes)).await.unwrap_or(());
                         }
                         _ => {
-                            println!("{} {:?}", error("Unexpected stream result:"), result);
-                            // Close the stream by sending empty bytes if we receive anything
-                            // else than StreamResult (e.g errors)
+                            done = result == RunResult::Stream(StreamResult::Done);
+
+                            if !done {
+                                println!("{} {:?}", error("Unexpected stream result:"), result);
+                            }
+
+                            // Close the stream by sending empty bytes
                             stream_tx.send_async(Ok(Bytes::new())).await.unwrap_or(());
                         }
                     }


### PR DESCRIPTION
## About

It's possible to have a stream done before the response is sent. This was already "supported": meaning it was working fine, but wrongly assumed that it was an error.

This PR properly handle this data -> done -> start streaming flow, and also handle errors if we get data when the stream is already done.
Also simplify the js-runtime streaming handling, not sure why it used a new `ReadableStream` because it's 100% useless.