### PR TITLE
feat(runtime,js-runtime): timers APIs

### DIFF
--- a/.changeset/cuddly-mugs-play.md
+++ b/.changeset/cuddly-mugs-play.md
@@ -1,0 +1,7 @@
+---
+'@lagon/runtime': minor
+'@lagon/js-runtime': minor
+'@lagon/docs': patch
+---
+
+Add timers APIs (`setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`, `queueMicrotask`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derive_utils"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,6 +1405,8 @@ dependencies = [
  "hyper",
  "lagon-runtime-http",
  "lagon-runtime-isolate",
+ "log",
+ "serial_test",
  "tokio",
  "v8",
 ]
@@ -2678,6 +2692,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c789ec87f4687d022a2405cf46e0cd6284889f1839de292cadeb6c6019506f2"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64f9e531ce97c88b4778aad0ceee079216071cffec6ac9b904277f8f92e7fe3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -13,3 +13,5 @@ httptest = "0.15.4"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
 lagon-runtime-http = { path = "../runtime_http" }
 lagon-runtime-isolate = { path = "../runtime_isolate" }
+log = { version = "0.4.17", features = ["std", "kv_unstable", "kv_unstable_serde"] }
+serial_test = "0.10.0"

--- a/crates/runtime/tests/errors.rs
+++ b/crates/runtime/tests/errors.rs
@@ -153,7 +153,7 @@ async fn memory_reached() {
             .into(),
         )
         // Increase timeout for CI
-        .startup_timeout(1000)
+        .startup_timeout(10000)
         .memory(1),
     );
     let (tx, rx) = flume::unbounded();

--- a/crates/runtime/tests/timers.rs
+++ b/crates/runtime/tests/timers.rs
@@ -1,0 +1,244 @@
+use lagon_runtime::{options::RuntimeOptions, Runtime};
+use lagon_runtime_http::{Request, Response, RunResult};
+use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
+use serial_test::serial;
+use std::sync::Once;
+
+fn setup() {
+    static START: Once = Once::new();
+
+    START.call_once(|| {
+        Runtime::new(RuntimeOptions::default());
+    });
+}
+
+static mut RX: Option<flume::Receiver<String>> = None;
+
+fn setup_logger() -> flume::Receiver<String> {
+    static START: Once = Once::new();
+
+    START.call_once(|| {
+        let (tx, rx) = flume::unbounded();
+
+        struct Logger {
+            tx: flume::Sender<String>,
+        }
+
+        impl log::Log for Logger {
+            fn enabled(&self, _metadata: &log::Metadata) -> bool {
+                true
+            }
+            fn log(&self, record: &log::Record) {
+                self.tx.send(record.args().to_string()).unwrap();
+            }
+            fn flush(&self) {}
+        }
+
+        log::set_boxed_logger(Box::new(Logger { tx })).unwrap();
+        log::set_max_level(log::LevelFilter::Info);
+
+        unsafe { RX = Some(rx) };
+    });
+
+    unsafe { RX.clone() }.unwrap()
+}
+
+#[tokio::test]
+async fn set_timeout() {
+    setup();
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export async function handler() {
+    const test = await new Promise((resolve) => {
+        setTimeout(() => {
+            resolve('test');
+        }, 100);
+    });
+    return new Response(test);
+}"
+        .into(),
+    ));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("test"))
+    );
+    assert!(rx.recv_async().await.is_err());
+}
+
+#[tokio::test]
+#[serial]
+async fn set_timeout_not_blocking_response() {
+    setup();
+    let log_rx = setup_logger();
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
+    console.log('before')
+    setTimeout(() => {
+        console.log('done')
+    }, 100);
+    console.log('after')
+
+    return new Response('Hello!');
+}"
+            .into(),
+        )
+        .metadata(Some(("".to_owned(), "".to_owned()))),
+    );
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(log_rx.recv_async().await.unwrap(), "before".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "after".to_string());
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello!"))
+    );
+    assert!(rx.recv_async().await.is_err());
+    assert!(log_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn set_timeout_clear() {
+    setup();
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export async function handler() {
+    let id;
+    const test = await new Promise((resolve) => {
+        id = setTimeout(() => {
+            resolve('test');
+        }, 100);
+        clearTimeout(id);
+    });
+    return new Response(test);
+}"
+        .into(),
+    ));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(rx.recv_async().await.unwrap(), RunResult::Timeout);
+    assert!(rx.recv_async().await.is_err());
+}
+
+#[tokio::test]
+#[serial]
+async fn set_interval() {
+    let log_rx = setup_logger();
+    setup();
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
+    await new Promise(resolve => {
+        let count = 0;
+        const id = setInterval(() => {
+            count++;
+            console.log('interval', count);
+
+            if (count >= 3) {
+                clearInterval(id);
+                resolve();
+            }
+        }, 100);
+    });
+
+    console.log('res');
+    return new Response('Hello world');
+}"
+            .into(),
+        )
+        .metadata(Some(("".to_owned(), "".to_owned()))),
+    );
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(log_rx.recv_async().await.unwrap(), "interval 1".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "interval 2".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "interval 3".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "res".to_string());
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
+    assert!(rx.recv_async().await.is_err());
+}
+
+#[tokio::test]
+#[serial]
+async fn queue_microtask() {
+    let log_rx = setup_logger();
+    setup();
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
+    queueMicrotask(() => {
+        console.log('microtask');
+    });
+
+    console.log('before')
+
+    return new Response('Hello world');
+}"
+            .into(),
+        )
+        .metadata(Some(("".to_owned(), "".to_owned()))),
+    );
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(log_rx.recv_async().await.unwrap(), "before".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "microtask".to_string());
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
+    assert!(rx.recv_async().await.is_err());
+}
+
+#[tokio::test]
+#[serial]
+async fn timers_order() {
+    let log_rx = setup_logger();
+    setup();
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
+    queueMicrotask(() => {
+        console.log('microtask')
+    })
+
+    Promise.resolve().then(() => {
+        console.log('promise')
+    })
+
+    console.log('main');
+
+    await new Promise(resolve => setTimeout(() => {
+        console.log('timeout')
+        resolve()
+    }, 0))
+
+    console.log('main 2');
+
+    return new Response('Hello world');
+}"
+            .into(),
+        )
+        .metadata(Some(("".to_owned(), "".to_owned()))),
+    );
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(log_rx.recv_async().await.unwrap(), "main".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "microtask".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "promise".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "timeout".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "main 2".to_string());
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
+    assert!(rx.recv_async().await.is_err());
+}

--- a/crates/runtime/tests/timers.rs
+++ b/crates/runtime/tests/timers.rs
@@ -67,7 +67,7 @@ async fn set_timeout() {
     assert!(rx.recv_async().await.is_err());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn set_timeout_not_blocking_response() {
     setup();
@@ -129,7 +129,7 @@ async fn set_timeout_clear() {
     assert!(rx.recv_async().await.is_err());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn set_interval() {
     let log_rx = setup_logger();

--- a/crates/runtime/tests/timers.rs
+++ b/crates/runtime/tests/timers.rs
@@ -108,8 +108,11 @@ async fn set_timeout_clear() {
     let id;
     const test = await new Promise((resolve) => {
         id = setTimeout(() => {
-            resolve('test');
+            resolve('first');
         }, 100);
+        setTimeout(() => {
+            resolve('second');
+        }, 200);
         clearTimeout(id);
     });
     return new Response(test);
@@ -119,7 +122,10 @@ async fn set_timeout_clear() {
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
-    assert_eq!(rx.recv_async().await.unwrap(), RunResult::Timeout);
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("second"))
+    );
     assert!(rx.recv_async().await.is_err());
 }
 

--- a/crates/runtime_isolate/src/bindings/crypto/random_values.rs
+++ b/crates/runtime_isolate/src/bindings/crypto/random_values.rs
@@ -7,6 +7,7 @@ pub fn random_values_binding(
     mut retval: v8::ReturnValue,
 ) {
     let value = args.get(0);
+    // TODO: check if value is a TypedArray
     let chunk = unsafe { v8::Local::<v8::TypedArray>::cast(value) };
     let mut buf = vec![0; chunk.byte_length()];
     chunk.copy_contents(&mut buf);

--- a/crates/runtime_isolate/src/bindings/crypto/random_values.rs
+++ b/crates/runtime_isolate/src/bindings/crypto/random_values.rs
@@ -1,5 +1,5 @@
 use lagon_runtime_crypto::methods::random_values;
-use lagon_runtime_v8_utils::v8_uint8array;
+use lagon_runtime_v8_utils::{v8_exception, v8_uint8array};
 
 pub fn random_values_binding(
     scope: &mut v8::HandleScope,
@@ -7,7 +7,12 @@ pub fn random_values_binding(
     mut retval: v8::ReturnValue,
 ) {
     let value = args.get(0);
-    // TODO: check if value is a TypedArray
+
+    if !value.is_typed_array() {
+        let exception = v8_exception(scope, "Parameter 1 is not of type 'TypedArray'");
+        scope.throw_exception(exception);
+    }
+
     let chunk = unsafe { v8::Local::<v8::TypedArray>::cast(value) };
     let mut buf = vec![0; chunk.byte_length()];
     chunk.copy_contents(&mut buf);

--- a/crates/runtime_isolate/src/bindings/queue_microtask.rs
+++ b/crates/runtime_isolate/src/bindings/queue_microtask.rs
@@ -1,0 +1,11 @@
+pub fn queue_microtask_binding(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut _retval: v8::ReturnValue,
+) {
+    let value = args.get(0);
+    // TODO: check if value is a function
+    let function = unsafe { v8::Local::<v8::Function>::cast(value) };
+
+    scope.enqueue_microtask(function);
+}

--- a/crates/runtime_isolate/src/bindings/queue_microtask.rs
+++ b/crates/runtime_isolate/src/bindings/queue_microtask.rs
@@ -1,11 +1,17 @@
+use lagon_runtime_v8_utils::v8_exception;
+
 pub fn queue_microtask_binding(
     scope: &mut v8::HandleScope,
     args: v8::FunctionCallbackArguments,
     mut _retval: v8::ReturnValue,
 ) {
     let value = args.get(0);
-    // TODO: check if value is a function
-    let function = unsafe { v8::Local::<v8::Function>::cast(value) };
 
+    if !value.is_function() {
+        let exception = v8_exception(scope, "Parameter 1 is not of type 'Function'");
+        scope.throw_exception(exception);
+    }
+
+    let function = unsafe { v8::Local::<v8::Function>::cast(value) };
     scope.enqueue_microtask(function);
 }

--- a/crates/runtime_isolate/src/bindings/sleep.rs
+++ b/crates/runtime_isolate/src/bindings/sleep.rs
@@ -1,0 +1,33 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use hyper::{client::HttpConnector, Body, Client};
+use hyper_tls::HttpsConnector;
+use lazy_static::lazy_static;
+
+use crate::bindings::PromiseResult;
+
+use super::BindingResult;
+
+lazy_static! {
+    static ref CLIENT: Client<HttpsConnector<HttpConnector>> =
+        Client::builder().build::<_, Body>(HttpsConnector::new());
+}
+
+type Arg = u64;
+
+pub fn sleep_init(scope: &mut v8::HandleScope, args: v8::FunctionCallbackArguments) -> Result<Arg> {
+    match args.get(0).to_int32(scope) {
+        Some(delay) => Ok(delay.value() as u64),
+        None => Err(anyhow!("Invalid delay")),
+    }
+}
+
+pub async fn sleep_binding(id: usize, arg: Arg) -> BindingResult {
+    tokio::time::sleep(Duration::from_millis(arg)).await;
+
+    BindingResult {
+        id,
+        result: PromiseResult::Undefined,
+    }
+}

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -25,7 +25,10 @@ pub fn extract_v8_headers_object(
     value: v8::Local<v8::Value>,
     scope: &mut v8::HandleScope,
 ) -> Result<Option<HashMap<String, String>>> {
-    // TODO: check if value is a Map
+    if !value.is_map() {
+        return Err(anyhow!("Value is not of type 'Map'"));
+    }
+
     let map = unsafe { v8::Local::<v8::Map>::cast(value) };
 
     if map.size() > 0 {
@@ -57,7 +60,10 @@ pub fn extract_v8_headers_object(
 }
 
 pub fn extract_v8_uint8array(value: v8::Local<v8::Value>) -> Result<Vec<u8>> {
-    // TODO: check if value is a Uint8Array
+    if !value.is_uint8_array() {
+        return Err(anyhow!("Value is not of type 'Uint8Array'"));
+    }
+
     let chunk = unsafe { v8::Local::<v8::Uint8Array>::cast(value) };
     let mut buf = vec![0; chunk.byte_length()];
     chunk.copy_contents(&mut buf);
@@ -107,4 +113,9 @@ pub fn v8_headers_object<'a>(
 
 pub fn v8_boolean<'a>(scope: &mut v8::HandleScope<'a>, value: bool) -> v8::Local<'a, v8::Boolean> {
     v8::Boolean::new(scope, value)
+}
+
+pub fn v8_exception<'a>(scope: &mut v8::HandleScope<'a>, value: &str) -> v8::Local<'a, v8::Value> {
+    let message = v8_string(scope, value);
+    v8::Exception::type_error(scope, message)
 }

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -25,6 +25,7 @@ pub fn extract_v8_headers_object(
     value: v8::Local<v8::Value>,
     scope: &mut v8::HandleScope,
 ) -> Result<Option<HashMap<String, String>>> {
+    // TODO: check if value is a Map
     let map = unsafe { v8::Local::<v8::Map>::cast(value) };
 
     if map.size() > 0 {
@@ -56,6 +57,7 @@ pub fn extract_v8_headers_object(
 }
 
 pub fn extract_v8_uint8array(value: v8::Local<v8::Value>) -> Result<Vec<u8>> {
+    // TODO: check if value is a Uint8Array
     let chunk = unsafe { v8::Local::<v8::Uint8Array>::cast(value) };
     let mut buf = vec![0; chunk.byte_length()];
     chunk.copy_contents(&mut buf);

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -186,3 +186,23 @@ The standard `atob` method. [See the documentation on MDN](https://developer.moz
 ### `btoa()`
 
 The standard `btoa` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/btoa).
+
+### `setInterval()`
+
+The standard `setInterval` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/setInterval).
+
+### `setTimeout()`
+
+The standard `setTimeout` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout).
+
+### `clearInterval()`
+
+The standard `clearInterval` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/clearInterval).
+
+### `clearTimeout()`
+
+The standard `clearTimeout` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout).
+
+### `queueMicrotask()`
+
+The standard `queueMicrotask` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask).

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -12,6 +12,7 @@ import './runtime/global/console';
 import './runtime/global/process';
 import './runtime/global/crypto';
 import './runtime/global/navigator';
+import './runtime/global/timers';
 import './runtime/http/URLSearchParams';
 import './runtime/http/URL';
 import './runtime/http/Headers';
@@ -59,6 +60,8 @@ declare global {
       key: CryptoKey,
       data: BufferSource,
     ) => Promise<ArrayBuffer>;
+    sleep: (ms: number) => Promise<void>;
+    queueMicrotask: (callback: () => void) => void;
   };
   var __lagon__: {
     isIterable: (value: unknown) => value is ArrayBuffer;

--- a/packages/js-runtime/src/runtime/global/timers.ts
+++ b/packages/js-runtime/src/runtime/global/timers.ts
@@ -1,0 +1,51 @@
+(globalThis => {
+  type Timer = {
+    handler: () => void;
+    repeat: boolean;
+  };
+
+  let counter = 0;
+  const timers = new Map<number, Timer>();
+
+  const addTimer = (handler: () => void, timeout = 0, repeat: boolean) => {
+    counter++;
+
+    timers.set(counter, {
+      handler,
+      repeat,
+    });
+
+    Lagon.sleep(timeout).then(() => {
+      const timer = timers.get(counter);
+
+      if (timer) {
+        timer.handler();
+        timers.delete(counter);
+
+        if (timer.repeat) {
+          addTimer(timer.handler, timeout, repeat);
+        }
+      }
+    });
+
+    return counter;
+  };
+
+  // @ts-expect-error missing __promisify__
+  globalThis.setTimeout = (handler, timeout) => addTimer(handler, timeout, false);
+
+  globalThis.clearTimeout = id => {
+    timers.delete(id as number);
+  };
+
+  // @ts-expect-error missing __promisify__
+  globalThis.setInterval = (handler, timeout) => addTimer(handler, timeout, true);
+
+  globalThis.clearInterval = id => {
+    timers.delete(id as number);
+  };
+
+  globalThis.queueMicrotask = callback => {
+    Lagon.queueMicrotask(callback);
+  };
+})(globalThis);


### PR DESCRIPTION
## About

Add timers APIs (`setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`, `queueMicrotask`).

Both `setTimeout` and `setInterval` uses a new `Lagon.sleep(ms)` method, that sleeps the future for the given duration.