### PR TITLE
fix(serverless): use the system root CA to connect to MySQL

### DIFF
--- a/.changeset/moody-guests-tan.md
+++ b/.changeset/moody-guests-tan.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Use the system root CA to connect to MySQL

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -21,10 +21,14 @@ use mysql::{OptsBuilder, SslOpts};
 use rand::prelude::*;
 use s3::creds::Credentials;
 use s3::Bucket;
+#[cfg(not(debug_assertions))]
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::env;
 use std::net::SocketAddr;
+#[cfg(not(debug_assertions))]
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -371,9 +375,9 @@ async fn main() -> Result<()> {
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
     #[cfg(not(debug_assertions))]
-    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(
-        SslOpts::default().with_danger_accept_invalid_certs(true),
-    ));
+    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
+        Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
+    )));
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN cargo build --release
 
 FROM rust:1.66-slim-buster
 
+RUN apt-get install -y ca-certificates
 COPY --from=builder /app/target/release/lagon-serverless /usr/local/bin/lagon-serverless
 
 # Serverless


### PR DESCRIPTION
## About

Use the system root CA to connect to MySQL, instead of allowing insecure connections with an invalid certificate.

See https://planetscale.com/docs/concepts/secure-connections#ca-root-configuration
