### PR TITLE
refactor(cli,runtime,serverless): clean unwrap() usage

### DIFF
--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use crate::utils::{
     bundle_function, debug, print_progress, success, validate_code_file, validate_public_dir,
@@ -31,9 +31,11 @@ pub fn build(file: PathBuf, client: Option<PathBuf>, public_dir: Option<PathBuf>
         let message = format!("Writting {}...", path);
         let end_progress = print_progress(&message);
 
-        let dir = PathBuf::from(".lagon")
-            .join("public")
-            .join(PathBuf::from(&path).parent().unwrap());
+        let dir = PathBuf::from(".lagon").join("public").join(
+            PathBuf::from(&path)
+                .parent()
+                .ok_or_else(|| anyhow!("Could not find parent of {}", path))?,
+        );
         fs::create_dir_all(dir)?;
         fs::write(format!(".lagon/public/{}", path), content)?;
 

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -100,19 +100,23 @@ async fn handle_request(
     }) {
         println!("              {}", input("Asset found"));
 
-        let extension = Path::new(asset.0).extension().unwrap().to_str().unwrap();
-        let content_type = match extension {
-            "js" => "application/javascript",
-            "css" => "text/css",
-            "html" => "text/html",
-            "png" => "image/png",
-            "jpg" => "image/jpeg",
-            "jpeg" => "image/jpeg",
-            "svg" => "image/svg+xml",
-            "json" => "application/json",
-            "txt" => "text/plain",
-            _ => "text/plain",
-        };
+        let content_type =
+            Path::new(asset.0)
+                .extension()
+                .map_or("application/octet-stream", |extension| {
+                    match extension.to_str().unwrap_or("") {
+                        "js" => "application/javascript",
+                        "css" => "text/css",
+                        "html" => "text/html",
+                        "png" => "image/png",
+                        "jpg" => "image/jpeg",
+                        "jpeg" => "image/jpeg",
+                        "svg" => "image/svg+xml",
+                        "json" => "application/json",
+                        "txt" => "text/plain",
+                        _ => "application/octet-stream",
+                    }
+                });
 
         let mut headers = HashMap::new();
         headers.insert("content-type".into(), content_type.into());

--- a/crates/runtime_crypto/src/methods/decrypt.rs
+++ b/crates/runtime_crypto/src/methods/decrypt.rs
@@ -6,9 +6,13 @@ use crate::{Aes256Gcm, Algorithm};
 pub fn decrypt(algorithm: Algorithm, key_value: Vec<u8>, data: Vec<u8>) -> Result<Vec<u8>> {
     match algorithm {
         Algorithm::AesGcm(iv) => {
-            let cipher = Aes256Gcm::new_from_slice(&key_value).unwrap();
+            let cipher = Aes256Gcm::new_from_slice(&key_value)?;
             let nonce = Nonce::from_slice(&iv);
-            Ok(cipher.decrypt(nonce, data.as_ref()).unwrap())
+
+            match cipher.decrypt(nonce, data.as_ref()) {
+                Ok(result) => Ok(result),
+                Err(_) => Err(anyhow!("Decryption failed")),
+            }
         }
         _ => Err(anyhow!("Algorithm not supported")),
     }

--- a/crates/runtime_crypto/src/methods/encrypt.rs
+++ b/crates/runtime_crypto/src/methods/encrypt.rs
@@ -6,9 +6,13 @@ use crate::{Aes256Gcm, Algorithm};
 pub fn encrypt(algorithm: Algorithm, key_value: Vec<u8>, data: Vec<u8>) -> Result<Vec<u8>> {
     match algorithm {
         Algorithm::AesGcm(iv) => {
-            let cipher = Aes256Gcm::new_from_slice(&key_value).unwrap();
+            let cipher = Aes256Gcm::new_from_slice(&key_value)?;
             let nonce = Nonce::from_slice(&iv);
-            Ok(cipher.encrypt(nonce, data.as_ref()).unwrap())
+
+            match cipher.encrypt(nonce, data.as_ref()) {
+                Ok(result) => Ok(result),
+                Err(_) => Err(anyhow!("Encryption failed")),
+            }
         }
         _ => Err(anyhow!("Algorithm not supported")),
     }

--- a/crates/runtime_crypto/src/methods/sign.rs
+++ b/crates/runtime_crypto/src/methods/sign.rs
@@ -6,7 +6,7 @@ use crate::{Algorithm, HmacSha256};
 pub fn sign(algorithm: Algorithm, key_value: Vec<u8>, data: Vec<u8>) -> Result<Vec<u8>> {
     match algorithm {
         Algorithm::Hmac => {
-            let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
+            let mut mac = HmacSha256::new_from_slice(&key_value)?;
             mac.update(&data);
             Ok(mac.finalize().into_bytes().to_vec())
         }

--- a/crates/runtime_crypto/src/methods/verify.rs
+++ b/crates/runtime_crypto/src/methods/verify.rs
@@ -11,7 +11,7 @@ pub fn verify(
 ) -> Result<bool> {
     match algorithm {
         Algorithm::Hmac => {
-            let mut mac = HmacSha256::new_from_slice(&key_value).unwrap();
+            let mut mac = HmacSha256::new_from_slice(&key_value)?;
             mac.update(&data);
             Ok(mac.verify_slice(&signature).is_ok())
         }

--- a/crates/runtime_isolate/src/bindings/fetch.rs
+++ b/crates/runtime_isolate/src/bindings/fetch.rs
@@ -51,7 +51,7 @@ async fn make_request(
 
     if response.status().is_redirection() {
         let mut redirect_url = match response.headers().get("location") {
-            Some(location) => location.to_str().unwrap().to_string(),
+            Some(location) => location.to_str()?.to_string(),
             None => return Err(anyhow!("Got a redirect without Location header")),
         };
 

--- a/crates/runtime_isolate/src/callbacks.rs
+++ b/crates/runtime_isolate/src/callbacks.rs
@@ -28,8 +28,11 @@ pub extern "C" fn promise_reject_callback(message: v8::PromiseRejectMessage) {
     match message.get_event() {
         v8::PromiseRejectEvent::PromiseRejectWithNoHandler => {
             let try_catch = &mut v8::TryCatch::new(scope);
-            let exception_message =
-                get_exception_message(try_catch, message.get_value().unwrap(), state.lines);
+
+            let exception_message = match message.get_value() {
+                Some(exception) => get_exception_message(try_catch, exception, state.lines),
+                None => "Unknown error".to_string(),
+            };
 
             state.rejected_promises.insert(promise, exception_message);
         }

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -42,13 +42,11 @@ pub fn extract_v8_headers_object(
 
             let key = headers_keys
                 .get_index(scope, index)
-                .unwrap()
-                .to_rust_string_lossy(scope);
+                .map_or_else(|| "".to_string(), |key| key.to_rust_string_lossy(scope));
             index += 1;
             let value = headers_keys
                 .get_index(scope, index)
-                .unwrap()
-                .to_rust_string_lossy(scope);
+                .map_or_else(|| "".to_string(), |value| value.to_rust_string_lossy(scope));
 
             headers.insert(key, value);
         }

--- a/crates/serverless/src/deployments/assets.rs
+++ b/crates/serverless/src/deployments/assets.rs
@@ -12,19 +12,21 @@ pub fn handle_asset(deployment: &Deployment, asset: &String) -> Result<Response>
         .join(asset);
     let body = fs::read(path)?;
 
-    let extension = Path::new(asset).extension().unwrap().to_str().unwrap();
-    let content_type = match extension {
-        "js" => "application/javascript",
-        "css" => "text/css",
-        "html" => "text/html",
-        "png" => "image/png",
-        "jpg" => "image/jpeg",
-        "jpeg" => "image/jpeg",
-        "svg" => "image/svg+xml",
-        "json" => "application/json",
-        "txt" => "text/plain",
-        _ => "text/plain",
-    };
+    let content_type = Path::new(asset).extension().map_or(
+        "application/octet-stream",
+        |extension| match extension.to_str().unwrap_or("") {
+            "js" => "application/javascript",
+            "css" => "text/css",
+            "html" => "text/html",
+            "png" => "image/png",
+            "jpg" => "image/jpeg",
+            "jpeg" => "image/jpeg",
+            "svg" => "image/svg+xml",
+            "json" => "application/json",
+            "txt" => "text/plain",
+            _ => "application/octet-stream",
+        },
+    );
 
     let mut headers = HashMap::new();
     headers.insert("content-type".into(), content_type.into());

--- a/crates/serverless/src/deployments/filesystem.rs
+++ b/crates/serverless/src/deployments/filesystem.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::{env, fs, path::Path};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use log::info;
 
 use super::Deployment;
@@ -47,9 +47,11 @@ pub fn write_deployment_asset(deployment_id: &str, asset: &str, buf: &[u8]) -> R
     let asset = asset.replace("public/", "");
     let asset = asset.as_str();
 
-    let dir = PathBuf::from("deployments")
-        .join(deployment_id)
-        .join(PathBuf::from(asset).parent().unwrap());
+    let dir = PathBuf::from("deployments").join(deployment_id).join(
+        PathBuf::from(asset)
+            .parent()
+            .ok_or_else(|| anyhow!("Could not get parent of {}", asset))?,
+    );
     fs::create_dir_all(dir)?;
 
     let mut file =


### PR DESCRIPTION
## About

Remove most of `unwrap()` in the codebase to properly handle errors.