### PR TITLE
fix(js-runtime): timers id are always unique

### DIFF
--- a/.changeset/rich-tomatoes-protect.md
+++ b/.changeset/rich-tomatoes-protect.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+Fix timers id to always be unique

--- a/.changeset/thirty-dryers-thank.md
+++ b/.changeset/thirty-dryers-thank.md
@@ -1,0 +1,5 @@
+---
+'@lagon/js-runtime': patch
+---
+
+Add `self` to `globalThis`

--- a/packages/js-runtime/src/runtime/core.ts
+++ b/packages/js-runtime/src/runtime/core.ts
@@ -63,6 +63,10 @@
   const TEXT_ENCODER = new TextEncoder();
   const TEXT_DECODER = new TextDecoder();
 
+  // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/self
+  // @ts-expect-error Workers have a global `self` property, which we assign
+  // to `globalThis` because we don't implement all the Workers APIs
+  globalThis.self = globalThis;
   globalThis.__lagon__ = {
     isIterable,
     parseMultipart,

--- a/packages/js-runtime/src/runtime/global/timers.ts
+++ b/packages/js-runtime/src/runtime/global/timers.ts
@@ -8,19 +8,19 @@
   const timers = new Map<number, Timer>();
 
   const addTimer = (handler: () => void, timeout = 0, repeat: boolean) => {
-    counter++;
+    const id = counter++;
 
-    timers.set(counter, {
+    timers.set(id, {
       handler,
       repeat,
     });
 
     Lagon.sleep(timeout).then(() => {
-      const timer = timers.get(counter);
+      const timer = timers.get(id);
 
       if (timer) {
         timer.handler();
-        timers.delete(counter);
+        timers.delete(id);
 
         if (timer.repeat) {
           addTimer(timer.handler, timeout, repeat);
@@ -28,7 +28,7 @@
       }
     });
 
-    return counter;
+    return id;
   };
 
   // @ts-expect-error missing __promisify__

--- a/packages/js-runtime/src/runtime/http/Request.ts
+++ b/packages/js-runtime/src/runtime/http/Request.ts
@@ -3,7 +3,6 @@ import { RequestResponseBody } from './body';
 (globalThis => {
   globalThis.Request = class extends RequestResponseBody {
     readonly method: string;
-    readonly url: string;
     readonly cache: RequestCache;
     readonly credentials: RequestCredentials;
     readonly destination: RequestDestination;
@@ -15,14 +14,15 @@ import { RequestResponseBody } from './body';
     readonly referrerPolicy: ReferrerPolicy;
 
     private readonly init?: RequestInit;
+    private readonly input: RequestInfo | URL;
 
     constructor(input: RequestInfo | URL, init?: RequestInit) {
       super(init?.body, init?.headers);
 
       this.init = init;
+      this.input = input;
 
       this.method = init?.method || 'GET';
-      this.url = input.toString();
       this.cache = init?.cache || 'default';
       this.credentials = init?.credentials || 'same-origin';
       this.destination = 'worker';
@@ -32,6 +32,10 @@ import { RequestResponseBody } from './body';
       this.redirect = init?.redirect || 'follow';
       this.referrer = init?.referrer || '';
       this.referrerPolicy = init?.referrerPolicy || '';
+    }
+
+    get url(): string {
+      return this.input.toString();
     }
 
     get signal(): AbortSignal {


### PR DESCRIPTION
## About

Fix timers id to always be unique

Also, add `self` to `globalThis`

## Tests

Add a new test inside runtime that executes two `setTimeout` with different intervals and cancels the second one. It doesn't cancel the first one as it would before this fix.
