### PR TITLE
chore: reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
-**/node_modules
-**/target
-**/.env
+node_modules/
+packages/*/node_modules/
+packages/*/.turbo/
+crates/*/.turbo/
+target/
+wpt/
+dist/
+.env
+.eslintcache
+crates/serverless/deployments/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,32 @@
-FROM node:19.4.0-buster-slim as runtime
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
 
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM node:19.4.0-bullseye-slim as js-runtime
 WORKDIR /app
 COPY ./packages/js-runtime/src/ ./src
 COPY ./packages/js-runtime/package.json ./
-
 RUN npm install --global esbuild
 RUN npm install
 RUN npm run build
 
-FROM rust:1.66-buster as builder
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+COPY --from=js-runtime /app/dist/index.js /app/crates/js-runtime/dist
+RUN cargo build --release --bin lagon-serverless
 
+FROM debian:bullseye-slim AS runtime
 WORKDIR /app
-COPY . ./
+RUN apt-get update -y \
+    && apt-get install -y ca-certificates \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/lagon-serverless /usr/local/bin
 
-WORKDIR /app/crates/serverless
-COPY --from=runtime /app/dist/index.js /app/crates/js-runtime/dist/
-RUN cargo build --release
-
-FROM rust:1.66-slim-buster
-
-RUN apt-get install -y ca-certificates
-COPY --from=builder /app/target/release/lagon-serverless /usr/local/bin/lagon-serverless
-
-# Serverless
-EXPOSE 4000
-# Prometheus
-EXPOSE 9000
-
-CMD ["lagon-serverless"]
+ENTRYPOINT ["/usr/local/bin/lagon-serverless"]


### PR DESCRIPTION
## About

Reduce Docker image size:
- Smaller runtime image (`debian:bullseye-slim` instead of `rust:slim-buster`)
- Use [cargo chef](https://github.com/LukeMathWalker/cargo-chef) to speed up docker builds
- Update node image to `bullseye-slim`

From **317MB** to **55.2MB**, so a 82% decrease!