### PR TITLE
fix(serverless): always drop isolates on the same thread as created

### DIFF
--- a/.changeset/pretty-eagles-reply.md
+++ b/.changeset/pretty-eagles-reply.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Always drop isolates on the same thread as created

--- a/crates/serverless/src/deployments/cache.rs
+++ b/crates/serverless/src/deployments/cache.rs
@@ -5,17 +5,15 @@ use std::{
     time::{Duration, Instant},
 };
 
-use log::{error, info};
 use tokio::sync::RwLock;
 use tokio_util::task::LocalPoolHandle;
 
-use crate::ISOLATES;
+use super::pubsub::clear_deployments_cache;
 
-const CACHE_TASK_INTERVAL: Duration = Duration::from_secs(60);
+const CACHE_TASK_INTERVAL: Duration = Duration::from_secs(1);
 
 pub fn run_cache_clear_task(
     last_requests: Arc<RwLock<HashMap<String, Instant>>>,
-    thread_ids: Arc<RwLock<HashMap<String, usize>>>,
     pool: LocalPoolHandle,
 ) {
     let isolates_cache_seconds = Duration::from_secs(
@@ -30,55 +28,30 @@ pub fn run_cache_clear_task(
             tokio::time::sleep(CACHE_TASK_INTERVAL).await;
 
             let now = Instant::now();
-            let mut isolates_to_clear = Vec::new();
+            let mut hostnames_to_clear = Vec::new();
             let last_requests_reader = last_requests.read().await;
 
             for (hostname, last_request) in last_requests_reader.iter() {
                 if now.duration_since(*last_request) > isolates_cache_seconds {
-                    isolates_to_clear.push(hostname.clone());
+                    hostnames_to_clear.push(hostname.clone());
                 }
             }
 
-            if isolates_to_clear.is_empty() {
+            if hostnames_to_clear.is_empty() {
                 continue;
             }
 
             // Drop the read lock because we now acquire a write lock
             drop(last_requests_reader);
 
+            // Clear everything
             let mut last_requests = last_requests.write().await;
-            let thread_ids = thread_ids.read().await;
 
-            for hostname in isolates_to_clear {
-                if let Some(thread_id) = thread_ids.get(&hostname) {
-                    last_requests.remove(&hostname);
-
-                    let thread_id = *thread_id;
-
-                    // The isolate is implicitely dropped when the block after `remove()` ends
-                    //
-                    // An isolate must be dropped (which will call `exit()` and terminate the
-                    // execution) in the same thread as it was created in
-                    match pool.spawn_pinned_by_idx(move || async move {
-                        let mut thread_isolates = ISOLATES.write().await;
-                        let thread_isolates = thread_isolates.get_mut(&thread_id).unwrap();
-
-                        if let Some(isolate) = thread_isolates.remove(&hostname) {
-                            let metadata = isolate.get_metadata();
-
-                            if let Some((deployment, ..)) = metadata.as_ref() {
-                                info!(deployment = deployment; "Clearing deployment from cache due to expiration");
-                            }
-                        }
-                    }, thread_id)
-                        .await {
-                            Ok(_) => {},
-                            Err(err) => {
-                                error!("Failed to clear deployment from cache: {}", err);
-                            }
-                        };
-                }
+            for hostname in &hostnames_to_clear {
+                last_requests.remove(hostname);
             }
+
+            clear_deployments_cache(hostnames_to_clear, &pool, "expiration").await;
         }
     });
 }

--- a/crates/serverless/src/deployments/pubsub.rs
+++ b/crates/serverless/src/deployments/pubsub.rs
@@ -1,30 +1,73 @@
 use std::{collections::HashMap, env, sync::Arc};
 
 use anyhow::Result;
-use log::{error, warn};
+use log::{error, info, warn};
 use metrics::increment_counter;
 use s3::Bucket;
 use serde_json::Value;
 use tokio::{sync::RwLock, task::JoinHandle};
+use tokio_util::task::LocalPoolHandle;
 
-use crate::{ISOLATES, REGION};
+use crate::{ISOLATES, POOL_SIZE, REGION};
 
 use super::{filesystem::rm_deployment, Deployment};
 
-async fn clear_deployments_cache(domains: &Vec<String>) {
-    let mut isolates = ISOLATES.write().await;
-    isolates
-        .iter_mut()
-        .for_each(|(_thread_id, thread_isolates)| {
-            for domain in domains {
-                thread_isolates.remove(domain);
+// The isolate is implicitely dropped when the block after `remove()` ends
+//
+// An isolate must be dropped (which will call `exit()` and terminate the
+// execution) in the same thread as it was created in
+pub async fn clear_deployments_cache(
+    hostnames: Vec<String>,
+    pool: &LocalPoolHandle,
+    reason: &'static str,
+) {
+    for thread_id in 0..POOL_SIZE {
+        let hostnames = hostnames.clone();
+
+        // Spawn early the task and loop the hostnames inside, instead
+        // of looping outside and spawning hostnames * threads tasks
+        match pool
+            .spawn_pinned_by_idx(
+                move || async move {
+                    let mut thread_isolates = ISOLATES.write().await;
+
+                    for hostname in hostnames {
+                        // We might not have yet created the isolates map for this thread
+                        if let Some(thread_isolates) = thread_isolates.get_mut(&thread_id) {
+                            if let Some(isolate) = thread_isolates.remove(&hostname) {
+                                let metadata = isolate.get_metadata();
+
+                                if let Some((deployment, function)) = metadata.as_ref() {
+                                    info!(
+                                        deployment = deployment,
+                                        function = function,
+                                        hostname = hostname;
+                                        "Clearing deployment from cache due to {}",
+                                        reason
+                                    );
+                                }
+                            } else {
+                                warn!(hostname = hostname; "Could not clear deployment from cache");
+                            }
+                        }
+                    }
+                },
+                thread_id,
+            )
+            .await
+        {
+            Ok(_) => {}
+            Err(err) => {
+                error!("Failed to clear deployments from cache: {}", err);
             }
-        })
+        };
+    }
 }
 
 pub fn listen_pub_sub(
     bucket: Bucket,
     deployments: Arc<RwLock<HashMap<String, Arc<Deployment>>>>,
+    pool: LocalPoolHandle,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
         let url = env::var("REDIS_URL").expect("REDIS_URL must be set");
@@ -90,7 +133,7 @@ pub fn listen_pub_sub(
                                 deployments.insert(domain.clone(), Arc::new(deployment.clone()));
                             }
 
-                            clear_deployments_cache(&domains).await;
+                            clear_deployments_cache(domains, &pool, "deployment").await;
                         }
                         Err(error) => {
                             increment_counter!(
@@ -125,7 +168,7 @@ pub fn listen_pub_sub(
                                 deployments.remove(domain);
                             }
 
-                            clear_deployments_cache(&domains).await;
+                            clear_deployments_cache(domains, &pool, "undeployment").await;
                         }
                         Err(error) => {
                             increment_counter!(
@@ -169,7 +212,7 @@ pub fn listen_pub_sub(
                         deployments.insert(domain.clone(), Arc::new(deployment.clone()));
                     }
 
-                    clear_deployments_cache(&domains).await;
+                    clear_deployments_cache(domains, &pool, "promotion").await;
                 }
                 _ => warn!("Unknown channel: {}", channel),
             };


### PR DESCRIPTION
## About

Following #483 

The logic to drop isolates on the same thread as they were created was missing for pub/sub events (deployments, undeployments, promotions). This PR moves this logic to a function used both in the cache clear task and in the pub/sub events handling.