### PR TITLE
feat(runtime,ui): limit the number of `fetch()` calls per execution

### DIFF
--- a/.changeset/perfect-ladybugs-mate.md
+++ b/.changeset/perfect-ladybugs-mate.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime': patch
+'@lagon/docs': patch
+---
+
+Limit the number of `fetch()` calls to 20 per execution

--- a/crates/runtime_isolate/src/lib.rs
+++ b/crates/runtime_isolate/src/lib.rs
@@ -36,7 +36,7 @@ const TIMEOUT_LOOP_DELAY: Duration = Duration::from_millis(1);
 struct Global(v8::Global<v8::Context>);
 
 #[derive(Debug)]
-struct IsolateState {
+pub struct IsolateState {
     global: Global,
     promises: FuturesUnordered<Pin<Box<dyn Future<Output = BindingResult>>>>,
     js_promises: HashMap<usize, v8::Global<v8::PromiseResolver>>,
@@ -45,6 +45,7 @@ struct IsolateState {
     metadata: Rc<Metadata>,
     rejected_promises: HashMap<v8::Global<v8::Promise>, String>,
     lines: usize,
+    fetch_calls: usize,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -116,6 +117,7 @@ impl Isolate {
                 metadata: Rc::clone(&options.metadata),
                 rejected_promises: HashMap::new(),
                 lines: 0,
+                fetch_calls: 0,
             }
         };
 
@@ -237,6 +239,7 @@ impl Isolate {
             let mut state = isolate_state.borrow_mut();
             state.handler_result = None;
             state.rejected_promises.clear();
+            state.fetch_calls = 0;
         }
 
         match handler.call(try_catch, global.into(), &[request.into()]) {

--- a/packages/docs/pages/cloud/limits.mdx
+++ b/packages/docs/pages/cloud/limits.mdx
@@ -21,20 +21,20 @@ Each Function name must be unique. The name must be at least 3 and up to 64 char
 
 Below are the limits for each plan:
 
-|                       | Personal      | Pro           | Enterprise |
-| --------------------- | ------------- | ------------- | ---------- |
-| Free requests/month   | 3,000,000     | 5,000,000     | Custom     |
-| Code size             | 10MB          | 10MB          | Custom     |
-| Assets                | 100           | 100           | Custom     |
-| Assets size           | 10MB          | 10MB          | Custom     |
-| Memory                | 128MB         | 128MB         | Up to 1GB  |
-| CPU time/request      | 10ms          | 50ms          | Up to 1s   |
-| CPU startup time      | 100ms         | 200ms         | Up to 1s   |
-| Custom domains        | 10            | 10            | Custom     |
-| Environment variables | 100           | 100           | Custom     |
-| Env. var. key length  | 64 characters | 64 characters | Custom     |
-| Env. var. value size  | 5KB           | 5KB           | Custom     |
+|                        | Personal      | Pro           | Enterprise |
+| ---------------------- | ------------- | ------------- | ---------- |
+| Free requests/month    | 3,000,000     | 5,000,000     | Custom     |
+| Code size              | 10MB          | 10MB          | Custom     |
+| Assets                 | 100           | 100           | Custom     |
+| Assets size            | 10MB          | 10MB          | Custom     |
+| Memory                 | 128MB         | 128MB         | Up to 1GB  |
+| CPU time/request       | 10ms          | 50ms          | Up to 1s   |
+| CPU startup time       | 100ms         | 200ms         | Up to 1s   |
+| Custom domains         | 10            | 10            | Custom     |
+| Environment variables  | 100           | 100           | Custom     |
+| Env. var. key length   | 64 characters | 64 characters | Custom     |
+| Env. var. value size   | 5KB           | 5KB           | Custom     |
+| `fetch()` calls        | 20            | 20            | Custom     |
+| `fetch()` redirections | 5             | 5             | Custom     |
 
 The CPU time limit only counts the time spent executing your code. For example, that means the time spent waiting for a response from a `fetch` call is not counted.
-
-The CPU startup time


### PR DESCRIPTION
## About

This PR complements the limit of redirections for `fetch()`, by allowing up to 20 `fetch()` calls (without redirections) per execution.

Also add a test that ensures that an error is thrown if we go beyond this limit, but that it still works in subsequent requests.
And add the `fetch()` limits to the docs.