### PR TITLE
feat(dashboard,docs): add san-francisco-us-west & bangalore-ap-south regions

### DIFF
--- a/.changeset/witty-weeks-complain.md
+++ b/.changeset/witty-weeks-complain.md
@@ -1,0 +1,6 @@
+---
+'@lagon/dashboard': patch
+'@lagon/docs': patch
+---
+
+Add san-francisco-us-west and bangalore-ap-south regions

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -27,14 +27,18 @@ export const PRESIGNED_URL_EXPIRES_SECONDS = 60 * 60; // 1 hour
 export const REGIONS = {
   'ashburn-us-east': 'Ashburn (us-east)',
   'hillsboro-us-west': 'Hillsboro (us-west)',
+  'san-francisco-us-west': 'San Francisco (us-west)',
   'montreal-ca-east': 'Montreal (ca-east)',
   'london-eu-west': 'Londo (eu-west)',
   'paris-eu-west': 'Paris (eu-west)',
   'nuremberg-eu-central': 'Nuremberg (eu-central)',
   'helsinki-eu-north': 'Helsinki (eu-north)',
   'warsaw-eu-east': 'Warsaw (eu-east)',
+  'bangalore-ap-south': 'Bangalore (ap-south)',
   'singapore-ap-south': 'Singapore (ap-south)',
   'sydney-ap-south': 'Sydney (ap-south)',
+  'tokyo-ap-east': 'Tokyo (ap-east)',
+  'johannesburg-af-south': 'Johannesburg (af-south)',
 };
 
 export type Regions = keyof typeof REGIONS;

--- a/packages/docs/pages/cloud/regions.mdx
+++ b/packages/docs/pages/cloud/regions.mdx
@@ -1,4 +1,4 @@
-Lagon is currently deployed in 12 regions all around the world. We increase the number of regions regularly, and you can also [request a new Region here](https://tally.so/r/mDqAYN).
+Lagon is currently deployed in 14 regions all around the world. We increase the number of regions regularly, and you can also [request a new Region here](https://tally.so/r/mDqAYN).
 
 We use multiple hosting providers to prevent a single point of failure and provide resiliency in the case of an outage from one of our providers. Users are routed to the region that is geographically closest to them when they request a Function, using a mix of Anycast and GeoIP.
 
@@ -8,12 +8,14 @@ You can access the Region that is responding to the current requests using the [
 
 - Ashburn, Virginia (`ashburn-us-east`)
 - Hillsboro, Oregon (`hillsboro-us-west`)
+- San Francisco, California (`san-francisco-us-west`)
 - Montreal, Canada (`montreal-ca-east`)
 - London, United Kingdon (`london-eu-west`)
 - Paris, France (`paris-eu-west`)
 - Nuremberg, Germany (`nuremberg-eu-central`)
 - Helsinki, Finland (`helsinki-eu-north`)
 - Warsaw, Poland (`warsaw-eu-east`)
+- Bangalore, India (`bangalore-ap-south`)
 - Singapore (`singapore-ap-south`)
 - Sydney, Australia (`sydney-ap-south`)
 - Tokio, Japan (`tokio-ap-east`)


### PR DESCRIPTION
## About

Add two new regions for a total of 14:
- `san-francisco-us-west` (San Francisco, California)
- `bangalore-ap-south` (Bangalore, India)
