### PR TITLE
refactor(runtime): use a condvar to timeout isolates execution

### DIFF
--- a/.changeset/plenty-seahorses-hide.md
+++ b/.changeset/plenty-seahorses-hide.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Use a condvar to timeout isolates execution

--- a/crates/runtime/tests/fetch.rs
+++ b/crates/runtime/tests/fetch.rs
@@ -551,3 +551,22 @@ export async function handler() {{
     );
     assert!(rx.try_recv().is_err());
 }
+
+#[tokio::test]
+async fn fetch_https() {
+    setup();
+    let mut isolate = Isolate::new(IsolateOptions::new(
+        "export async function handler() {{
+    const status = (await fetch('https://google.com')).status;
+    return new Response(status);
+}}"
+        .into(),
+    ));
+    let (tx, rx) = flume::unbounded();
+    isolate.run(Request::default(), tx).await;
+
+    assert_eq!(
+        rx.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("200"))
+    );
+}


### PR DESCRIPTION
## About

Refactor the isolates timeout logic to use a [condvar](https://doc.rust-lang.org/stable/std/sync/struct.Condvar.html) using [`wait_timeout_while`](https://doc.rust-lang.org/stable/std/sync/struct.Condvar.html#method.wait_timeout_while). The thread waiting for the timeout is notified every time we run any pending promise, in order to stop counting the time.