### PR TITLE
fix(cli): only update the dev server when files are added/deleted/modified

### DIFF
--- a/.changeset/angry-keys-bake.md
+++ b/.changeset/angry-keys-bake.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Only update the dev server when files are added/deleted/modified

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-packages/docs/pages/contributing.md
+packages/docs/pages/contributing.mdx

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -13,7 +13,8 @@ use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
 use log::{
     set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record, SetLoggerError,
 };
-use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::event::ModifyKind;
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::fs;
@@ -71,7 +72,7 @@ fn parse_environment_variables(env: Option<PathBuf>) -> Result<HashMap<String, S
 }
 
 // This function is similar to packages/serverless/src/main.rs,
-// expect that we don't have multiple deployments and such multiple
+// except that we don't have multiple deployments and such multiple
 // threads to manage, and we don't manager logs and metrics.
 async fn handle_request(
     req: HyperRequest<Body>,
@@ -329,14 +330,28 @@ pub async fn dev(
     tokio::spawn(async move {
         let content = watcher_content.clone();
 
-        for _ in rx {
-            // Clear the screen and put the cursor at first row & first col of the screen.
-            print!("\x1B[2J\x1B[1;1H");
-            println!("{}", info("Found change, updating..."));
+        for event in rx.into_iter().flatten() {
+            let mut should_update = false;
 
-            let (index, assets) = bundle_function(&file, &client, &public_dir)?;
+            if let EventKind::Modify(modify) = event.kind {
+                if let ModifyKind::Data(_) = modify {
+                    should_update = true;
+                } else if let ModifyKind::Name(_) = modify {
+                    should_update = true;
+                }
+            } else if event.kind.is_create() || event.kind.is_modify() {
+                should_update = true;
+            }
 
-            *content.lock().await = (index, assets);
+            if should_update {
+                // Clear the screen and put the cursor at first row & first col of the screen.
+                // print!("\x1B[2J\x1B[1;1H");
+                println!("{}", info("Found change, updating..."));
+
+                let (index, assets) = bundle_function(&file, &client, &public_dir)?;
+
+                *content.lock().await = (index, assets);
+            }
         }
 
         Ok::<(), Error>(())

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -345,7 +345,7 @@ pub async fn dev(
 
             if should_update {
                 // Clear the screen and put the cursor at first row & first col of the screen.
-                // print!("\x1B[2J\x1B[1;1H");
+                print!("\x1B[2J\x1B[1;1H");
                 println!("{}", info("Found change, updating..."));
 
                 let (index, assets) = bundle_function(&file, &client, &public_dir)?;


### PR DESCRIPTION
## About

Previously, all events from [notify-rs](https://github.com/notify-rs/notify) assumed that the dev server should be reloaded. This includes metadata changes, that we want to ignore. Now, the dev server only updates when a file's content is modified / a file is added / a file is deleted.