### PR TITLE
perf(runtime): store timeouts as `Duration`

### DIFF
--- a/.changeset/clever-pigs-sit.md
+++ b/.changeset/clever-pigs-sit.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Increase timeout of isolate for `dev` command

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -113,6 +113,8 @@ async fn handle_request(
                             IsolateOptions::new(
                                 String::from_utf8(index).expect("Code is not UTF-8"),
                             )
+                            .timeout(Duration::from_secs(1))
+                            .startup_timeout(Duration::from_secs(2))
                             .metadata(Some((String::from(""), String::from(""))))
                             .environment_variables(environment_variables),
                         );

--- a/crates/runtime/tests/errors.rs
+++ b/crates/runtime/tests/errors.rs
@@ -2,7 +2,7 @@ use httptest::bytes::Bytes;
 use lagon_runtime::{options::RuntimeOptions, Runtime};
 use lagon_runtime_http::{Method, Request, RunResult};
 use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
-use std::sync::Once;
+use std::{sync::Once, time::Duration};
 
 fn setup() {
     static START: Once = Once::new();
@@ -153,7 +153,7 @@ async fn memory_reached() {
             .into(),
         )
         // Increase timeout for CI
-        .startup_timeout(10000)
+        .startup_timeout(Duration::from_millis(10000))
         .memory(1),
     );
     let (tx, rx) = flume::unbounded();

--- a/crates/runtime_isolate/src/lib.rs
+++ b/crates/runtime_isolate/src/lib.rs
@@ -462,8 +462,8 @@ impl Isolate {
         // Script parsing may take a long time, so we use the startup_timeout
         // when the isolate has not been used yet.
         let timeout = match self.handler.is_none() && self.compilation_error.is_none() {
-            true => Duration::from_millis(self.options.startup_timeout as u64),
-            false => Duration::from_millis(self.options.timeout as u64),
+            true => self.options.startup_timeout,
+            false => self.options.timeout,
         };
         let (termination_tx, termination_rx) = flume::bounded(1);
 

--- a/crates/runtime_isolate/src/options.rs
+++ b/crates/runtime_isolate/src/options.rs
@@ -1,5 +1,5 @@
 use lagon_runtime_v8_utils::v8_string;
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, rc::Rc, time::Duration};
 
 use super::IsolateStatistics;
 
@@ -12,9 +12,9 @@ type OnIsolateStatisticsCallback = Box<dyn Fn(Rc<Metadata>, IsolateStatistics)>;
 pub struct IsolateOptions {
     pub code: String,
     pub environment_variables: Option<HashMap<String, String>>,
-    pub memory: usize,          // in MB (MegaBytes)
-    pub timeout: usize,         // in ms (MilliSeconds)
-    pub startup_timeout: usize, // is ms (MilliSeconds)
+    pub memory: usize, // in MB (MegaBytes)
+    pub timeout: Duration,
+    pub startup_timeout: Duration,
     pub metadata: Rc<Metadata>,
     pub on_drop: Option<OnIsolateDropCallback>,
     pub on_statistics: Option<OnIsolateStatisticsCallback>,
@@ -28,8 +28,8 @@ impl IsolateOptions {
         Self {
             code,
             environment_variables: None,
-            timeout: 50,
-            startup_timeout: 200,
+            timeout: Duration::from_millis(50),
+            startup_timeout: Duration::from_millis(200),
             memory: 128,
             metadata: Rc::new(None),
             on_drop: None,
@@ -43,12 +43,12 @@ impl IsolateOptions {
         self
     }
 
-    pub fn timeout(mut self, timeout: usize) -> Self {
+    pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
     }
 
-    pub fn startup_timeout(mut self, startup_timeout: usize) -> Self {
+    pub fn startup_timeout(mut self, startup_timeout: Duration) -> Self {
         self.startup_timeout = startup_timeout;
         self
     }

--- a/crates/serverless/src/cronjob.rs
+++ b/crates/serverless/src/cronjob.rs
@@ -4,7 +4,7 @@ use lagon_runtime_isolate::{options::IsolateOptions, Isolate, CONSOLE_SOURCE};
 use lagon_runtime_utils::Deployment;
 use log::{error, info, warn};
 use metrics::{decrement_gauge, histogram, increment_gauge};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio_cron_scheduler::{Job, JobScheduler};
 use uuid::Uuid;
 
@@ -58,8 +58,8 @@ impl Cronjob {
                         let options = IsolateOptions::new(code)
                             .environment_variables(deployment.environment_variables.clone())
                             .memory(deployment.memory)
-                            .timeout(deployment.timeout)
-                            .startup_timeout(deployment.startup_timeout)
+                            .timeout(Duration::from_millis(deployment.timeout as u64))
+                            .startup_timeout(Duration::from_millis(deployment.startup_timeout as u64))
                             .metadata(Some((deployment.id.clone(), deployment.function_id.clone())))
                             .on_drop_callback(Box::new(|metadata| {
                                 if let Some(metadata) = metadata.as_ref().as_ref() {

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -32,10 +32,8 @@ use std::convert::Infallible;
 use std::env;
 use std::net::SocketAddr;
 use std::path::Path;
-#[cfg(not(debug_assertions))]
-use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock};
 use tokio_util::task::LocalPoolHandle;
 
@@ -220,8 +218,8 @@ async fn handle_request(
                                 deployment.environment_variables.clone(),
                             )
                             .memory(deployment.memory)
-                            .timeout(deployment.timeout)
-                            .startup_timeout(deployment.startup_timeout)
+                            .timeout(Duration::from_millis(deployment.timeout as u64))
+                            .startup_timeout(Duration::from_millis(deployment.startup_timeout as u64))
                             .metadata(Some((deployment.id.clone(), deployment.function_id.clone())))
                             .on_drop_callback(Box::new(|metadata| {
                                 if let Some(metadata) = metadata.as_ref().as_ref() {


### PR DESCRIPTION
## About

Store timeouts as `Duration` inside `IsolateOptions` to avoid creating new `Duration` instances every time the isolate is run.
Also increase isolate timeout for `dev` command of the CLI.