### PR TITLE
fix(dashboard): CPU time stats to return average > 0

### DIFF
--- a/.changeset/rude-ducks-listen.md
+++ b/.changeset/rude-ducks-listen.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Fix CPU time stats to return average > 0

--- a/packages/dashboard/lib/trpc/statsRouter.ts
+++ b/packages/dashboard/lib/trpc/statsRouter.ts
@@ -125,7 +125,10 @@ export const statsRouter = (t: T) =>
             `sum(increase(lagon_isolate_requests{function="${input.functionId}"}[${step}s]))`,
             input.timeframe,
           ),
-          prometheus(`avg(lagon_isolate_cpu_time{function="${input.functionId}",quantile="0.99"})`, input.timeframe),
+          prometheus(
+            `avg(lagon_isolate_cpu_time{function="${input.functionId}",quantile="0.99"} > 0)`,
+            input.timeframe,
+          ),
           prometheus(`sum(increase(lagon_bytes_in{function="${input.functionId}"}[${step}s]))`, input.timeframe),
           prometheus(`sum(increase(lagon_bytes_out{function="${input.functionId}"}[${step}s]))`, input.timeframe),
         ]);


### PR DESCRIPTION
## About

Return the average of the CPU time for records > 0.
