### PR TITLE
feat(cli): improve contrast of the colors

### DIFF
--- a/.changeset/heavy-llamas-arrive.md
+++ b/.changeset/heavy-llamas-arrive.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Improve contrast of the colors

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -85,7 +85,7 @@ async fn handle_request(
 
     println!(
         "{} {} {}",
-        format!("{}", Local::now().time()).black(),
+        format!("{}", Local::now().time()).bright_black(),
         req.method().to_string().blue(),
         url
     );
@@ -283,7 +283,11 @@ pub async fn dev(
     }
 
     println!();
-    println!(" {} http://{}", "➤".black(), format!("{addr}").blue());
+    println!(
+        " {} {}",
+        "➤".bright_black(),
+        format!("http://{addr}").blue()
+    );
     println!();
 
     init_logger()?;

--- a/crates/cli/src/commands/ls.rs
+++ b/crates/cli/src/commands/ls.rs
@@ -68,20 +68,20 @@ pub async fn ls(file: PathBuf) -> Result<()> {
                             "{} {} {}{}, {}{}",
                             "•".green(),
                             deployment.id,
-                            "(".black(),
-                            deployment.created_at.black(),
+                            "(".bright_black(),
+                            deployment.created_at.bright_black(),
                             "production".green(),
-                            ")".black()
+                            ")".bright_black()
                         );
                     } else {
                         println!(
                             "{} {} {}{}, {}{}",
                             "•".blue(),
                             deployment.id,
-                            "(".black(),
-                            deployment.created_at.black(),
+                            "(".bright_black(),
+                            deployment.created_at.bright_black(),
                             "preview".blue(),
-                            ")".black()
+                            ")".bright_black()
                         );
                     }
                 }

--- a/crates/cli/src/utils/console.rs
+++ b/crates/cli/src/utils/console.rs
@@ -6,15 +6,15 @@ pub fn info(message: &str) -> String {
 }
 
 pub fn input(message: &str) -> String {
-    format!(" {} {}", "↳".black(), message.black())
+    format!(" {} {}", "↳".bright_black(), message.bright_black())
 }
 
 pub fn debug(message: &str) -> String {
-    message.black().to_string()
+    message.bright_black().to_string()
 }
 
 pub fn debug_success(message: &str) -> String {
-    format!("{} {}", "✓".green(), message.black())
+    format!("{} {}", "✓".green(), message.bright_black())
 }
 
 pub fn success(message: &str) -> String {

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -324,7 +324,11 @@ pub async fn create_deployment(
     println!();
     println!("{}", success("Function deployed!"));
     println!();
-    println!(" {} {}", "➤".black(), response.result.data.url.blue());
+    println!(
+        " {} {}",
+        "➤".bright_black(),
+        response.result.data.url.blue()
+    );
     println!();
 
     Ok(())

--- a/crates/wpt-runner/src/main.rs
+++ b/crates/wpt-runner/src/main.rs
@@ -69,7 +69,7 @@ impl Log for SimpleLogger {
             } else if content.starts_with("TEST START") {
                 RESULT.lock().unwrap().0 += 1;
             } else {
-                println!("{}", content.black());
+                println!("{}", content.bright_black());
             }
         }
     }


### PR DESCRIPTION
## About

Improve the contrast of the colors by using `bright_black` instead of `black`:

Before:
<img width="618" alt="Screenshot 2023-02-13 at 18 02 59" src="https://user-images.githubusercontent.com/43268759/218523376-d7560eeb-a2e5-41e1-868c-66cf1a98eafd.png">

After:
<img width="639" alt="Screenshot 2023-02-13 at 18 01 53" src="https://user-images.githubusercontent.com/43268759/218523117-3498df56-e7e3-4d0b-9c21-552d8a15f800.png">
