### PR TITLE
feat(runtime,serverless): add V8 heap snapshots

### DIFF
--- a/.changeset/early-wombats-ring.md
+++ b/.changeset/early-wombats-ring.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime': patch
+'@lagon/js-runtime': patch
+---
+
+Split sync and async bindings into LagonSync/LagonAsync

--- a/.changeset/healthy-rice-fly.md
+++ b/.changeset/healthy-rice-fly.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+---
+
+Add option to load V8 heap snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ storybook-static/
 .DS_Store
 .env
 tsconfig.tsbuildinfo
+snapshot.bin

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -14,3 +14,7 @@ lagon-runtime-http = { path = "../runtime_http" }
 lagon-runtime-isolate = { path = "../runtime_isolate" }
 log = { version = "0.4.17", features = ["std", "kv_unstable", "kv_unstable_serde"] }
 serial_test = "1.0.0"
+
+[features]
+default = []
+ignore-snapshot = ["lagon-runtime-isolate/ignore-snapshot"]

--- a/crates/runtime/package.json
+++ b/crates/runtime/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "cargo build",
-    "test": "cargo test",
+    "test": "cargo test && cargo test --features ignore-snapshot",
     "lint": "cargo clippy -- -Dwarnings --no-deps"
   }
 }

--- a/crates/runtime/tests/crypto.rs
+++ b/crates/runtime/tests/crypto.rs
@@ -14,14 +14,17 @@ fn setup() {
 #[tokio::test]
 async fn crypto_random_uuid() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const uuid = crypto.randomUUID();
     const secondUuid = crypto.randomUUID();
     return new Response(`${typeof uuid} ${uuid.length} ${uuid === secondUuid}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -34,14 +37,17 @@ async fn crypto_random_uuid() {
 #[tokio::test]
 async fn crypto_get_random_values() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const typedArray = new Uint8Array([0, 8, 2]);
     const result = crypto.getRandomValues(typedArray);
     return new Response(`${result == typedArray} ${typedArray.length} ${result.length}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -54,13 +60,16 @@ async fn crypto_get_random_values() {
 #[tokio::test]
 async fn crypto_get_random_values_throw_not_typedarray() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const result = crypto.getRandomValues(true);
     return new Response(`${result == typedArray} ${typedArray.length} ${result.length}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -76,8 +85,9 @@ async fn crypto_get_random_values_throw_not_typedarray() {
 #[tokio::test]
 async fn crypto_key_value() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const { keyValue } = await crypto.subtle.importKey(
         'raw',
         new TextEncoder().encode('secret'),
@@ -88,8 +98,10 @@ async fn crypto_key_value() {
 
     return new Response(`${typeof keyValue} ${keyValue.length}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -102,8 +114,9 @@ async fn crypto_key_value() {
 #[tokio::test]
 async fn crypto_unique_key_value() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const { keyValue: first } = await crypto.subtle.importKey(
         'raw',
         new TextEncoder().encode('secret'),
@@ -121,8 +134,10 @@ async fn crypto_unique_key_value() {
 
     return new Response(first == second);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -135,8 +150,9 @@ async fn crypto_unique_key_value() {
 #[tokio::test]
 async fn crypto_sign() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
         new TextEncoder().encode('secret'),
@@ -151,8 +167,10 @@ async fn crypto_sign() {
 
     return new Response(`${signed instanceof Uint8Array} ${signed.length}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -165,8 +183,9 @@ async fn crypto_sign() {
 #[tokio::test]
 async fn crypto_verify() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
         new TextEncoder().encode('secret'),
@@ -185,8 +204,10 @@ async fn crypto_verify() {
 
     return new Response(verified);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -199,14 +220,17 @@ async fn crypto_verify() {
 #[tokio::test]
 async fn crypto_digest_sha1() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const digest = await crypto.subtle.digest('SHA-1', new TextEncoder().encode('hello, world'));
 
     return new Response(`${digest.length} ${digest}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -221,14 +245,17 @@ async fn crypto_digest_sha1() {
 #[tokio::test]
 async fn crypto_digest_string() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('hello, world'));
 
     return new Response(`${digest.length} ${digest}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -248,7 +275,7 @@ async fn crypto_digest_object() {
     return new Response(`${digest.length} ${digest}`);
 }"
         .into(),
-    ));
+    ).snapshot_blob(include_bytes!("../../serverless/snapshot.bin")));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -261,8 +288,9 @@ async fn crypto_digest_object() {
 #[tokio::test]
 async fn crypto_encrypt() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
         new TextEncoder().encode('secret'),
@@ -280,8 +308,10 @@ async fn crypto_encrypt() {
 
     return new Response(`${ciphertext instanceof Uint8Array} ${ciphertext.length}`);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -294,8 +324,9 @@ async fn crypto_encrypt() {
 #[tokio::test]
 async fn crypto_decrypt() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
         new TextEncoder().encode('secret'),
@@ -319,8 +350,10 @@ async fn crypto_decrypt() {
 
     return new Response(text);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/disallow_codegen.rs
+++ b/crates/runtime/tests/disallow_codegen.rs
@@ -14,13 +14,16 @@ fn setup() {
 #[tokio::test]
 async fn disallow_eval() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const result = eval('1 + 1')
     return new Response(result)
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -35,13 +38,16 @@ async fn disallow_eval() {
 #[tokio::test]
 async fn disallow_function() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const result = new Function('return 1 + 1')
     return new Response(result())
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/errors.rs
+++ b/crates/runtime/tests/errors.rs
@@ -15,7 +15,10 @@ fn setup() {
 #[tokio::test]
 async fn no_handler() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new("console.log('Hello')".into()));
+    let mut isolate = Isolate::new(
+        IsolateOptions::new("console.log('Hello')".into())
+            .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -30,7 +33,10 @@ async fn no_handler() {
 #[tokio::test]
 async fn handler_not_function() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new("export const handler = 'Hello'".into()));
+    let mut isolate = Isolate::new(
+        IsolateOptions::new("export const handler = 'Hello'".into())
+            .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -45,12 +51,15 @@ async fn handler_not_function() {
 #[tokio::test]
 async fn handler_reject() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     throw new Error('Rejected');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -63,12 +72,15 @@ async fn handler_reject() {
 #[tokio::test]
 async fn compilation_error() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     this syntax is invalid
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -81,14 +93,17 @@ async fn compilation_error() {
 #[tokio::test]
 async fn import_errors() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "import test from 'test';
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "import test from 'test';
 
 export function handler() {
     return new Response('hello world');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -104,13 +119,16 @@ export function handler() {
 #[tokio::test]
 async fn execution_timeout_reached() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     while(true) {}
     return new Response('Should not be reached');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -120,13 +138,16 @@ async fn execution_timeout_reached() {
 #[tokio::test]
 async fn init_timeout_reached() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "while(true) {}
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "while(true) {}
 export function handler() {
     return new Response('Should not be reached');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -152,6 +173,7 @@ async fn memory_reached() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         // Increase timeout for CI
         .startup_timeout(Duration::from_millis(10000))
         .memory(1),
@@ -175,8 +197,9 @@ async fn memory_reached() {
 #[tokio::test]
 async fn stacktrace() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "function test(a) {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "function test(a) {
     return a() / 1;
 }
 
@@ -187,8 +210,10 @@ function first(a) {
 export function handler() {
     return new Response(first('a'));
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/fetch.rs
+++ b/crates/runtime/tests/fetch.rs
@@ -22,12 +22,15 @@ async fn basic_fetch() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}').then(res => res.text());
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -47,15 +50,18 @@ async fn request_method() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'POST'
     }}).then(res => res.text());
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -75,15 +81,18 @@ async fn request_method_fallback() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'UNKNOWN'
     }}).then(res => res.text());
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -106,8 +115,9 @@ async fn request_headers() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}', {{
         headers: {{
             'x-token': 'hello'
@@ -116,7 +126,9 @@ async fn request_headers() {
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -139,8 +151,9 @@ async fn request_headers_class() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}', {{
         headers: new Headers({{
             'x-token': 'hello'
@@ -149,7 +162,9 @@ async fn request_headers_class() {
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -172,8 +187,9 @@ async fn request_body() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'POST',
         body: 'Hello!'
@@ -181,7 +197,9 @@ async fn request_body() {
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -201,8 +219,9 @@ async fn response_headers() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const response = await fetch('{url}');
     const body = [];
 
@@ -215,7 +234,9 @@ async fn response_headers() {
 
     return new Response(body.sort((a, b) => a.localeCompare(b)).join(' '));
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -239,14 +260,17 @@ async fn response_status() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.text();
 
     return new Response(`${{body}}: ${{response.status}}`);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -266,14 +290,17 @@ async fn response_json() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.json();
 
     return new Response(`${{typeof body}} ${{JSON.stringify(body)}}`);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -293,14 +320,17 @@ async fn response_array_buffer() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.arrayBuffer();
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -313,15 +343,18 @@ async fn response_array_buffer() {
 #[tokio::test]
 async fn throw_invalid_url() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const response = await fetch('doesnotexist');
     const body = await response.text();
 
     return new Response(body);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -334,8 +367,9 @@ async fn throw_invalid_url() {
 #[tokio::test]
 async fn throw_invalid_header() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const response = await fetch('http://localhost:5555/', {
         headers: {
             'foo': 'bar\\r\\n'
@@ -345,8 +379,10 @@ async fn throw_invalid_header() {
 
     return new Response(body);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -366,8 +402,9 @@ async fn abort_signal() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const controller = new AbortController();
     const signal = controller.signal;
 
@@ -380,7 +417,9 @@ async fn abort_signal() {
 
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -400,12 +439,15 @@ async fn redirect() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -429,12 +471,15 @@ async fn redirect_relative_url() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -453,12 +498,15 @@ async fn redirect_without_location_header() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -494,12 +542,15 @@ async fn redirect_loop() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -520,8 +571,9 @@ async fn limit_fetch_calls() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "let pass = false;
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "let pass = false;
 export async function handler() {{
     if (!pass) {{
         pass = true
@@ -533,7 +585,9 @@ export async function handler() {{
     await fetch('{url}');
     return new Response('ok')
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx.clone()).await;
 
@@ -555,13 +609,16 @@ export async function handler() {{
 #[tokio::test]
 async fn fetch_https() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {{
     const status = (await fetch('https://google.com')).status;
     return new Response(status);
 }}"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/promises.rs
+++ b/crates/runtime/tests/promises.rs
@@ -15,12 +15,15 @@ fn setup() {
 #[tokio::test]
 async fn execute_async_handler() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     return new Response('Async handler');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -40,12 +43,15 @@ async fn execute_promise() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export async function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export async function handler() {{
     const body = await fetch('{url}').then((res) => res.text());
     return new Response(body);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -15,12 +15,15 @@ fn setup() {
 #[tokio::test]
 async fn execute_function() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response('Hello world');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -33,12 +36,15 @@ async fn execute_function() {
 #[tokio::test]
 async fn execute_function_twice() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response('Hello world');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx.clone()).await;
 
@@ -65,6 +71,7 @@ async fn environment_variables() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         .environment_variables(
             vec![("TEST".into(), "Hello world".into())]
                 .into_iter()
@@ -83,12 +90,15 @@ async fn environment_variables() {
 #[tokio::test]
 async fn get_body() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler(request) {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler(request) {
     return new Response(request.body);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate
         .run(
@@ -111,12 +121,15 @@ async fn get_body() {
 #[tokio::test]
 async fn get_input() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler(request) {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler(request) {
     return new Response(request.url);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate
         .run(
@@ -139,12 +152,15 @@ async fn get_input() {
 #[tokio::test]
 async fn get_method() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler(request) {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler(request) {
     return new Response(request.method);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate
         .run(
@@ -167,12 +183,15 @@ async fn get_method() {
 #[tokio::test]
 async fn get_headers() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler(request) {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler(request) {
     return new Response(request.headers.get('x-auth'));
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
 
     let mut headers = HashMap::new();
     headers.insert("x-auth".into(), "token".into());
@@ -199,8 +218,9 @@ async fn get_headers() {
 #[tokio::test]
 async fn return_headers() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response('Hello world', {
         headers: {
             'Content-Type': 'text/html',
@@ -208,8 +228,10 @@ async fn return_headers() {
         }
     });
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
 
     let mut headers = HashMap::new();
     headers.insert("content-type".into(), "text/html".into());
@@ -231,8 +253,9 @@ async fn return_headers() {
 #[tokio::test]
 async fn return_headers_from_headers_api() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response('Hello world', {
         headers: new Headers({
             'Content-Type': 'text/html',
@@ -240,8 +263,10 @@ async fn return_headers_from_headers_api() {
         })
     });
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
 
     let mut headers = HashMap::new();
     headers.insert("content-type".into(), "text/html".into());
@@ -263,14 +288,17 @@ async fn return_headers_from_headers_api() {
 #[tokio::test]
 async fn return_status() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response('Moved permanently', {
         status: 302,
     });
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -287,14 +315,17 @@ async fn return_status() {
 #[tokio::test]
 async fn return_uint8array() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     // TextEncoder#encode returns a Uint8Array
     const body = new TextEncoder().encode('Hello world');
     return new Response(body);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -307,8 +338,9 @@ async fn return_uint8array() {
 #[tokio::test]
 async fn console_log() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const types = ['log', 'info', 'debug', 'error', 'warn'];
 
     types.forEach(type => {
@@ -317,8 +349,10 @@ async fn console_log() {
 
     return new Response('');
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -331,12 +365,15 @@ async fn console_log() {
 #[tokio::test]
 async fn atob() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response(atob('SGVsbG8='));
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -349,12 +386,15 @@ async fn atob() {
 #[tokio::test]
 async fn btoa() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response(btoa('Hello'));
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/streams.rs
+++ b/crates/runtime/tests/streams.rs
@@ -15,8 +15,9 @@ fn setup() {
 #[tokio::test]
 async fn sync_streaming() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response(
         new ReadableStream({
             pull(controller) {
@@ -26,8 +27,10 @@ async fn sync_streaming() {
         }),
     );
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -51,8 +54,9 @@ async fn sync_streaming() {
 #[tokio::test]
 async fn queue_multiple() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     let count = 0;
     return new Response(
         new ReadableStream({
@@ -68,8 +72,10 @@ async fn queue_multiple() {
         }),
     );
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -96,8 +102,9 @@ async fn queue_multiple() {
 #[tokio::test]
 async fn custom_response() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response(
         new ReadableStream({
             pull(controller) {
@@ -113,8 +120,10 @@ async fn custom_response() {
         },
     );
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -142,8 +151,9 @@ async fn custom_response() {
 #[tokio::test]
 async fn start_and_pull() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     return new Response(
         new ReadableStream({
             start(controller) {
@@ -156,8 +166,10 @@ async fn start_and_pull() {
         }),
     );
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -194,8 +206,9 @@ async fn response_before_write() {
     );
     let url = server.url("/");
 
-    let mut isolate = Isolate::new(IsolateOptions::new(format!(
-        "export function handler() {{
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(format!(
+            "export function handler() {{
     const transformStream = new TransformStream({{
         start(controller) {{
             controller.enqueue(new TextEncoder().encode('Loading...'));
@@ -214,7 +227,9 @@ async fn response_before_write() {
 
     return new Response(readableStream);
 }}"
-    )));
+        ))
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -244,14 +259,17 @@ async fn response_before_write() {
 #[tokio::test]
 async fn timeout_infinite_streaming() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const { readable } = new TransformStream()
 
     return new Response(readable);
 }"
-        .to_owned(),
-    ));
+            .to_owned(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -267,8 +285,9 @@ async fn timeout_infinite_streaming() {
 #[tokio::test]
 async fn promise_reject_callback() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export function handler() {
     const { readable } = new TransformStream()
 
     async function trigger() {
@@ -279,8 +298,10 @@ async fn promise_reject_callback() {
 
     return new Response(readable);
 }"
-        .to_owned(),
-    ));
+            .to_owned(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -318,7 +339,7 @@ async fn promise_reject_callback_after_response() {
     return new Response(readable);
 }"
         .to_owned(),
-    ));
+    ).snapshot_blob(include_bytes!("../../serverless/snapshot.bin")));
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 

--- a/crates/runtime/tests/timers.rs
+++ b/crates/runtime/tests/timers.rs
@@ -46,8 +46,9 @@ fn setup_logger() -> flume::Receiver<String> {
 #[tokio::test]
 async fn set_timeout() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const test = await new Promise((resolve) => {
         setTimeout(() => {
             resolve('test');
@@ -55,8 +56,10 @@ async fn set_timeout() {
     });
     return new Response(test);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -85,6 +88,7 @@ async fn set_timeout_not_blocking_response() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         .metadata(Some(("".to_owned(), "".to_owned()))),
     );
     let (tx, rx) = flume::unbounded();
@@ -103,8 +107,9 @@ async fn set_timeout_not_blocking_response() {
 #[tokio::test]
 async fn set_timeout_clear() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     let id;
     const test = await new Promise((resolve) => {
         id = setTimeout(() => {
@@ -117,8 +122,10 @@ async fn set_timeout_clear() {
     });
     return new Response(test);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -132,8 +139,9 @@ async fn set_timeout_clear() {
 #[tokio::test]
 async fn set_timeout_clear_correct() {
     setup();
-    let mut isolate = Isolate::new(IsolateOptions::new(
-        "export async function handler() {
+    let mut isolate = Isolate::new(
+        IsolateOptions::new(
+            "export async function handler() {
     const test = await new Promise((resolve) => {
         setTimeout(() => {
             resolve('first');
@@ -145,8 +153,10 @@ async fn set_timeout_clear_correct() {
     });
     return new Response(test);
 }"
-        .into(),
-    ));
+            .into(),
+        )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin")),
+    );
     let (tx, rx) = flume::unbounded();
     isolate.run(Request::default(), tx).await;
 
@@ -183,6 +193,7 @@ async fn set_interval() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         .metadata(Some(("".to_owned(), "".to_owned()))),
     );
     let (tx, rx) = flume::unbounded();
@@ -217,6 +228,7 @@ async fn queue_microtask() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         .metadata(Some(("".to_owned(), "".to_owned()))),
     );
     let (tx, rx) = flume::unbounded();
@@ -243,6 +255,7 @@ async fn queue_microtask_throw_not_function() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         .metadata(Some(("".to_owned(), "".to_owned()))),
     );
     let (tx, rx) = flume::unbounded();
@@ -286,6 +299,7 @@ async fn timers_order() {
 }"
             .into(),
         )
+        .snapshot_blob(include_bytes!("../../serverless/snapshot.bin"))
         .metadata(Some(("".to_owned(), "".to_owned()))),
     );
     let (tx, rx) = flume::unbounded();

--- a/crates/runtime_isolate/Cargo.toml
+++ b/crates/runtime_isolate/Cargo.toml
@@ -18,3 +18,7 @@ async-recursion = "1.0.2"
 lagon-runtime-v8-utils = { path = "../runtime_v8_utils" }
 lagon-runtime-http = { path = "../runtime_http" }
 lagon-runtime-crypto = { path = "../runtime_crypto" }
+
+[features]
+default = []
+ignore-snapshot = []

--- a/crates/runtime_isolate/src/callbacks.rs
+++ b/crates/runtime_isolate/src/callbacks.rs
@@ -10,8 +10,8 @@ pub extern "C" fn heap_limit_callback(
     _initial_heap_limit: usize,
 ) -> usize {
     let isolate = unsafe { &mut *(data as *mut Isolate) };
+    isolate.terminate();
 
-    isolate.heap_limit_reached();
     // Avoid OOM killer by increasing the limit, since we kill
     // the isolate above.
     current_heap_limit * 2

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -26,3 +26,7 @@ rand = { version = "0.8.5", features = ["std_rng"] }
 anyhow = "1.0.68"
 tokio-cron-scheduler = "0.9.3"
 uuid = "1.3.0"
+
+[build-dependencies]
+lagon-runtime = { path = "../runtime" }
+lagon-runtime-isolate = { path = "../runtime_isolate" }

--- a/crates/serverless/build.rs
+++ b/crates/serverless/build.rs
@@ -1,0 +1,14 @@
+use lagon_runtime::{options::RuntimeOptions, Runtime};
+use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
+
+fn main() {
+    let runtime = Runtime::new(RuntimeOptions::default());
+    let mut isolate = Isolate::new(IsolateOptions::new("".into()).snapshot(true));
+
+    let snapshot = isolate.snapshot();
+    let snapshot_slice: &[u8] = &snapshot;
+
+    std::fs::write("snapshot.bin", snapshot_slice).unwrap();
+
+    runtime.dispose();
+}

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -220,8 +220,7 @@ async fn handle_request(
                     // deployment and that the isolate should be called.
                     // TODO: read() then write() if not present
                     let mut isolates = ISOLATES.write().await;
-                    // let thread_isolates = isolates.entry(thread_id).or_insert_with(HashMap::new);
-                    let mut thread_isolates = HashMap::new();
+                    let thread_isolates = isolates.entry(thread_id).or_insert_with(HashMap::new);
 
                     let isolate = thread_isolates.entry(hostname).or_insert_with(|| {
                         increment_gauge!("lagon_isolates", 1.0, &thread_labels);

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -51,6 +51,7 @@ lazy_static! {
     pub static ref REGION: String = env::var("LAGON_REGION").expect("LAGON_REGION must be set");
 }
 
+const SNAPSHOT_BLOB: &[u8] = include_bytes!("../snapshot.bin");
 pub const POOL_SIZE: usize = 8;
 
 fn handle_error(
@@ -219,7 +220,8 @@ async fn handle_request(
                     // deployment and that the isolate should be called.
                     // TODO: read() then write() if not present
                     let mut isolates = ISOLATES.write().await;
-                    let thread_isolates = isolates.entry(thread_id).or_insert_with(HashMap::new);
+                    // let thread_isolates = isolates.entry(thread_id).or_insert_with(HashMap::new);
+                    let mut thread_isolates = HashMap::new();
 
                     let isolate = thread_isolates.entry(hostname).or_insert_with(|| {
                         increment_gauge!("lagon_isolates", 1.0, &thread_labels);
@@ -268,7 +270,8 @@ async fn handle_request(
                                         &labels
                                     );
                                 }
-                            }));
+                            }))
+                            .snapshot_blob(SNAPSHOT_BLOB);
 
                         Isolate::new(options)
                     });
@@ -316,7 +319,7 @@ async fn handle_request(
 #[tokio::main]
 async fn main() -> Result<()> {
     // Only load a .env file on development
-    #[cfg(debug_assertions)]
+    // #[cfg(debug_assertions)]
     dotenv::dotenv().expect("Failed to load .env file");
 
     let _flush_guard = init_logger(REGION.clone()).expect("Failed to init logger");
@@ -344,10 +347,10 @@ async fn main() -> Result<()> {
     let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
-    #[cfg(not(debug_assertions))]
-    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
-        Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
-    )));
+    // #[cfg(not(debug_assertions))]
+    // let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
+    //     Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
+    // )));
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 

--- a/packages/js-runtime/src/__tests__/console.test.ts
+++ b/packages/js-runtime/src/__tests__/console.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import '../';
 
 beforeEach(() => {
-  globalThis.Lagon = {
-    ...globalThis.Lagon,
+  globalThis.LagonSync = {
+    ...globalThis.LagonSync,
     log: vi.fn(),
   };
 });
@@ -16,7 +16,7 @@ describe('Console', () => {
   it('should log', () => {
     console.log('Hello World');
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', 'Hello World');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', 'Hello World');
   });
 
   it('should receive all logs type', () => {
@@ -25,7 +25,7 @@ describe('Console', () => {
     for (const type of types) {
       console[type](`Hello ${type}`);
 
-      expect(Lagon.log).toHaveBeenCalledWith(type, `Hello ${type}`);
+      expect(LagonSync.log).toHaveBeenCalledWith(type, `Hello ${type}`);
     }
   });
 
@@ -37,37 +37,37 @@ describe('Console', () => {
       },
     });
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', '{"hello":"world","nested":{"hello":"world"}}');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', '{"hello":"world","nested":{"hello":"world"}}');
   });
 
   it('should log numbers', () => {
     console.log(42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', '42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', '42');
 
     console.log(42.42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', '42.42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', '42.42');
   });
 
   it('should log booleans', () => {
     console.log(true);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'true');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'true');
 
     console.log(false);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'false');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'false');
   });
 
   it('should log undefined and null', () => {
     console.log(undefined);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'undefined');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'undefined');
 
     console.log(null);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'null');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'null');
   });
 
   it('should log arrays', () => {
     console.log(['hello', 'world']);
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', '["hello","world"]');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', '["hello","world"]');
   });
 
   it('should log functions', () => {
@@ -75,7 +75,7 @@ describe('Console', () => {
       return 'Hello World';
     });
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', '[Function]');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', '[Function]');
   });
 
   it('should log callbacks', () => {
@@ -83,12 +83,12 @@ describe('Console', () => {
       return 'Hello World';
     });
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', '[Function]');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', '[Function]');
   });
 
   it('should log objects with toString', () => {
     console.log(new Error('Hello World'));
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Error: Hello World');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Error: Hello World');
 
     class Empty {
       toString() {
@@ -97,20 +97,20 @@ describe('Console', () => {
     }
 
     console.log(new Empty());
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello World');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello World');
   });
 
   it('should format multiple strings', () => {
     console.log('Hello', 'World');
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', 'Hello World');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', 'Hello World');
   });
 
   it('should format multiple strings and objects', () => {
     console.log('Hello', {
       value: 'World',
     });
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
 
     console.log(
       'Hello',
@@ -120,54 +120,54 @@ describe('Console', () => {
       42,
       undefined,
     );
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"} 42 undefined');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"} 42 undefined');
   });
 
   it('should format printf like string', () => {
     console.log('Hello %s', 'World');
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', 'Hello World');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', 'Hello World');
   });
 
   it('should format printf like numbers', () => {
     console.log('Hello %d', 42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello 42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello 42');
 
     console.log('Hello %d', 42.42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello 42.42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello 42.42');
   });
 
   it('should format printf like integers', () => {
     console.log('Hello %i', 42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello 42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello 42');
 
     console.log('Hello %i', 42.42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello 42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello 42');
   });
 
   it('should format printf like floats', () => {
     console.log('Hello %f', 42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello 42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello 42');
 
     console.log('Hello %f', 42.42);
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello 42.42');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello 42.42');
   });
 
   it('should format printf like objects', () => {
     console.log('Hello %o', {
       value: 'World',
     });
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
 
     console.log('Hello %O', {
       value: 'World',
     });
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
 
     console.log('Hello %j', {
       value: 'World',
     });
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello {"value":"World"}');
   });
 
   it('should format print like multiple times', () => {
@@ -175,14 +175,14 @@ describe('Console', () => {
       value: 'World',
     });
 
-    expect(Lagon.log).toHaveBeenCalledWith('log', 'Hello World, this is the 42 test of printing {"value":"World"}');
+    expect(LagonSync.log).toHaveBeenCalledWith('log', 'Hello World, this is the 42 test of printing {"value":"World"}');
   });
 
   it('should format print like with fallback', () => {
     console.log('Hello %s, this is the %i test of printing %j', 'World');
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello World, this is the %i test of printing %j');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello World, this is the %i test of printing %j');
 
     console.log('Hello %s, this is the %i test of printing %j');
-    expect(Lagon.log).toHaveBeenLastCalledWith('log', 'Hello %s, this is the %i test of printing %j');
+    expect(LagonSync.log).toHaveBeenLastCalledWith('log', 'Hello %s, this is the %i test of printing %j');
   });
 });

--- a/packages/js-runtime/src/__tests__/crypto.test.ts
+++ b/packages/js-runtime/src/__tests__/crypto.test.ts
@@ -3,8 +3,8 @@ import '../';
 
 describe('randomUUID', () => {
   beforeEach(() => {
-    globalThis.Lagon = {
-      ...globalThis.Lagon,
+    globalThis.LagonSync = {
+      ...globalThis.LagonSync,
       uuid: vi.fn(),
     };
   });
@@ -13,9 +13,9 @@ describe('randomUUID', () => {
     vi.resetAllMocks();
   });
 
-  it('should call Lagon.uuid', () => {
-    // @ts-expect-error Lagon is not defined
-    globalThis.Lagon.uuid.mockReturnValueOnce('dff2d1a4-32b8-4a83-b455-88707848227a');
+  it('should call LagonSync.uuid', () => {
+    // @ts-expect-error LagonSync is not defined
+    globalThis.LagonSync.uuid.mockReturnValueOnce('dff2d1a4-32b8-4a83-b455-88707848227a');
 
     const uuid = crypto.randomUUID();
 
@@ -25,8 +25,8 @@ describe('randomUUID', () => {
 
 describe('getRandomValues', () => {
   beforeEach(() => {
-    globalThis.Lagon = {
-      ...globalThis.Lagon,
+    globalThis.LagonSync = {
+      ...globalThis.LagonSync,
       randomValues: vi.fn(),
     };
   });
@@ -35,9 +35,9 @@ describe('getRandomValues', () => {
     vi.resetAllMocks();
   });
 
-  it('should call Lagon.randomValues', () => {
-    // @ts-expect-error Lagon is not defined
-    globalThis.Lagon.randomValues.mockImplementationOnce(typedArray => typedArray);
+  it('should call LagonSync.randomValues', () => {
+    // @ts-expect-error LagonSync is not defined
+    globalThis.LagonSync.randomValues.mockImplementationOnce(typedArray => typedArray);
 
     const uuid = crypto.getRandomValues(new Uint8Array([0, 8, 2]));
 

--- a/packages/js-runtime/src/__tests__/fetch.test.ts
+++ b/packages/js-runtime/src/__tests__/fetch.test.ts
@@ -151,8 +151,8 @@ describe('Headers', () => {
 
 describe('fetch', () => {
   beforeEach(() => {
-    globalThis.Lagon = {
-      ...globalThis.Lagon,
+    globalThis.LagonAsync = {
+      ...globalThis.LagonAsync,
       fetch: vi.fn(),
     };
   });
@@ -161,24 +161,24 @@ describe('fetch', () => {
     vi.resetAllMocks();
   });
 
-  it('should call Lagon.fetch', async () => {
-    // @ts-expect-error Lagon is not defined
-    globalThis.Lagon.fetch.mockReturnValueOnce({
+  it('should call LagonAsync.fetch', async () => {
+    // @ts-expect-error LagonAsync is not defined
+    globalThis.LagonAsync.fetch.mockReturnValueOnce({
       b: 'Hello',
       s: 200,
     });
 
     await fetch('https://google.com');
 
-    expect(globalThis.Lagon.fetch).toHaveBeenCalledWith({
+    expect(globalThis.LagonAsync.fetch).toHaveBeenCalledWith({
       m: 'GET',
       u: 'https://google.com',
     });
   });
 
-  it('should call Lagon.fetch with options', async () => {
-    // @ts-expect-error Lagon is not defined
-    globalThis.Lagon.fetch.mockReturnValueOnce({
+  it('should call LagonAsync.fetch with options', async () => {
+    // @ts-expect-error LagonAsync is not defined
+    globalThis.LagonAsync.fetch.mockReturnValueOnce({
       b: 'Hello',
       s: 200,
     });
@@ -188,7 +188,7 @@ describe('fetch', () => {
       body: 'A body',
     });
 
-    expect(globalThis.Lagon.fetch).toHaveBeenCalledWith({
+    expect(globalThis.LagonAsync.fetch).toHaveBeenCalledWith({
       m: 'POST',
       u: 'https://google.com',
       b: 'A body',

--- a/packages/js-runtime/src/runtime/global/console.ts
+++ b/packages/js-runtime/src/runtime/global/console.ts
@@ -77,7 +77,7 @@
 
   types.forEach(type => {
     globalThis.console[type] = (input, ...args) => {
-      Lagon.log(type, format(input, ...args));
+      LagonSync.log(type, format(input, ...args));
     };
   });
 })(globalThis);

--- a/packages/js-runtime/src/runtime/global/crypto.ts
+++ b/packages/js-runtime/src/runtime/global/crypto.ts
@@ -4,8 +4,8 @@ interface CryptoKey {
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 (globalThis => {
-  const getRandomValues = <T extends ArrayBufferView | null>(array: T): T => Lagon.randomValues(array);
-  const randomUUID = () => Lagon.uuid();
+  const getRandomValues = <T extends ArrayBufferView | null>(array: T): T => LagonSync.randomValues(array);
+  const randomUUID = () => LagonSync.uuid();
 
   const SYMMETRIC_ALGORITHMS = ['HMAC', 'AES-CBC', 'AES-CTR', 'AES-GCM', 'AES-KW'];
 
@@ -26,7 +26,7 @@ interface CryptoKey {
       this.type = type!;
       this.usages = usages!;
 
-      this.keyValue = Lagon.getKeyValue();
+      this.keyValue = LagonSync.getKeyValue();
     }
   };
 
@@ -36,7 +36,7 @@ interface CryptoKey {
       key: CryptoKey,
       data: BufferSource,
     ): Promise<ArrayBuffer> {
-      return Lagon.decrypt(algorithm, key, data);
+      return LagonAsync.decrypt(algorithm, key, data);
     }
 
     async deriveBits(
@@ -58,7 +58,7 @@ interface CryptoKey {
     }
 
     async digest(algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer> {
-      return Lagon.digest(algorithm, data);
+      return LagonAsync.digest(algorithm, data);
     }
 
     async encrypt(
@@ -66,7 +66,7 @@ interface CryptoKey {
       key: CryptoKey,
       data: BufferSource,
     ): Promise<ArrayBuffer> {
-      return Lagon.encrypt(algorithm, key, data);
+      return LagonAsync.encrypt(algorithm, key, data);
     }
 
     async exportKey(format: 'jwk', key: CryptoKey): Promise<JsonWebKey>;
@@ -150,7 +150,7 @@ interface CryptoKey {
       key: CryptoKey,
       data: BufferSource,
     ): Promise<ArrayBuffer> {
-      return Lagon.sign(algorithm, key, data);
+      return LagonAsync.sign(algorithm, key, data);
     }
 
     async unwrapKey(
@@ -184,7 +184,7 @@ interface CryptoKey {
       signature: BufferSource,
       data: BufferSource,
     ): Promise<boolean> {
-      return Lagon.verify(algorithm, key, signature, data);
+      return LagonAsync.verify(algorithm, key, signature, data);
     }
 
     async wrapKey(

--- a/packages/js-runtime/src/runtime/global/timers.ts
+++ b/packages/js-runtime/src/runtime/global/timers.ts
@@ -15,7 +15,7 @@
       repeat,
     });
 
-    Lagon.sleep(timeout).then(() => {
+    LagonAsync.sleep(timeout).then(() => {
       const timer = timers.get(id);
 
       if (timer) {
@@ -46,6 +46,6 @@
   };
 
   globalThis.queueMicrotask = callback => {
-    Lagon.queueMicrotask(callback);
+    LagonSync.queueMicrotask(callback);
   };
 })(globalThis);

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -38,7 +38,7 @@
     try {
       checkAborted();
 
-      const response = await Lagon.fetch({
+      const response = await LagonAsync.fetch({
         m: init?.method || 'GET',
         u: input.toString(),
         b: body,

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,11 @@
       ],
       "outputs": []
     },
+    "@lagon/runtime#test": {
+      "dependsOn": [
+        "@lagon/serverless#build"
+      ]
+    },
     "lint": {
       "dependsOn": [
         "@lagon/runtime#build",


### PR DESCRIPTION
Add a `build.rs` in `crates/serverless` to generate a `snapshot.bin` file containing a V8 heap snapshot of the `js-runtime` code, which is then used when booting isolates (which only contains the user's code). It's not mandatory to use a snapshot to start a Lagon runtime, but it currently reduces the cold start by a lot. Here's a before/after running 6 times a cold start:

Before (or by not providing a V8 snapshot):

```
Statistics: IsolateStatistics { cpu_time: 5.660791ms, memory_usage: 583232 }
Statistics: IsolateStatistics { cpu_time: 3.700791ms, memory_usage: 583232 }
Statistics: IsolateStatistics { cpu_time: 3.214416ms, memory_usage: 583232 }
Statistics: IsolateStatistics { cpu_time: 2.923625ms, memory_usage: 583232 }
Statistics: IsolateStatistics { cpu_time: 3.115166ms, memory_usage: 583232 }
Statistics: IsolateStatistics { cpu_time: 3.400375ms, memory_usage: 583232 }
```

After, providing a V8 snapshot:

```
Statistics: IsolateStatistics { cpu_time: 3.1ms, memory_usage: 621864 }
Statistics: IsolateStatistics { cpu_time: 902.291µs, memory_usage: 621864 }
Statistics: IsolateStatistics { cpu_time: 651.5µs, memory_usage: 621864 }
Statistics: IsolateStatistics { cpu_time: 853.208µs, memory_usage: 621864 }
Statistics: IsolateStatistics { cpu_time: 584.375µs, memory_usage: 621864 }
Statistics: IsolateStatistics { cpu_time: 842.125µs, memory_usage: 621864 }
```

The first cold start goes from ~5ms to ~3ms, and subsequent cold starts goes from ~3ms to ~800us.

## About

Following https://github.com/lagonapp/lagon/pull/255:

- Run the tests with and without the heap snapshot, using the `ignore-snapshot` feature
- Split sync and async bindings to `globalThis.LagonSync` and `globalThis.LagonAsync`, because async bindings can't be serialized - only sync bindings are
