### PR TITLE
fix(runtime): remove unused HTTP client

### DIFF
--- a/.changeset/selfish-parents-fail.md
+++ b/.changeset/selfish-parents-fail.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Remove unused HTTP client instance

--- a/crates/runtime_isolate/src/bindings/sleep.rs
+++ b/crates/runtime_isolate/src/bindings/sleep.rs
@@ -1,18 +1,10 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-use hyper::{client::HttpConnector, Body, Client};
-use hyper_tls::HttpsConnector;
-use lazy_static::lazy_static;
 
 use crate::bindings::PromiseResult;
 
 use super::BindingResult;
-
-lazy_static! {
-    static ref CLIENT: Client<HttpsConnector<HttpConnector>> =
-        Client::builder().build::<_, Body>(HttpsConnector::new());
-}
 
 type Arg = u64;
 

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -318,7 +318,7 @@ async fn handle_request(
 #[tokio::main]
 async fn main() -> Result<()> {
     // Only load a .env file on development
-    // #[cfg(debug_assertions)]
+    #[cfg(debug_assertions)]
     dotenv::dotenv().expect("Failed to load .env file");
 
     let _flush_guard = init_logger(REGION.clone()).expect("Failed to init logger");
@@ -346,10 +346,10 @@ async fn main() -> Result<()> {
     let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
-    // #[cfg(not(debug_assertions))]
-    // let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
-    //     Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
-    // )));
+    #[cfg(not(debug_assertions))]
+    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
+        Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
+    )));
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 


### PR DESCRIPTION
## About

Remove unused `hyper::Client` that was copied from the `fetch` binding and is useless inside the `sleep` binding.