### PR TITLE
feat(cli): improve DX by saving configuration in a local config file

### DIFF
--- a/.changeset/nice-cars-build.md
+++ b/.changeset/nice-cars-build.md
@@ -1,0 +1,10 @@
+---
+'@lagon/cli': minor
+'@lagon/docs': minor
+---
+
+Improve functions configuration by saving parameters into a local config file.
+
+When using `lagon dev`, `lagon build` or `lagon deploy`, you don't need anymore to specify the function's entrypoint and the public directory. These configuration are saved into a local `.lagon/config.json` file.
+
+Note that `lagon dev` still allows to specify an entrypoint and public directory as before using arguments and options, making it easy to test locally.

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -2,28 +2,21 @@ use std::{fs, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 
-use crate::utils::{
-    bundle_function, debug, print_progress, success, validate_code_file, validate_public_dir,
-};
+use crate::utils::{bundle_function, debug, get_root, print_progress, success, FunctionConfig};
 
-pub fn build(file: PathBuf, client: Option<PathBuf>, public_dir: Option<PathBuf>) -> Result<()> {
-    validate_code_file(&file)?;
-
-    let client = match client {
-        Some(client) => {
-            validate_code_file(&client)?;
-            Some(client)
-        }
-        None => None,
-    };
-
-    let public_dir = validate_public_dir(public_dir)?;
-    let (index, assets) = bundle_function(&file, &client, &public_dir)?;
+pub fn build(
+    client: Option<PathBuf>,
+    public_dir: Option<PathBuf>,
+    directory: Option<PathBuf>,
+) -> Result<()> {
+    let root = get_root(directory);
+    let function_config = FunctionConfig::load(&root, client, public_dir)?;
+    let (index, assets) = bundle_function(&function_config, &root)?;
 
     let end_progress = print_progress("Writting index.js...");
 
-    fs::create_dir_all(".lagon")?;
-    fs::write(".lagon/index.js", index)?;
+    fs::create_dir_all(root.join(".lagon"))?;
+    fs::write(root.join(".lagon").join("index.js"), index)?;
 
     end_progress();
 
@@ -31,13 +24,13 @@ pub fn build(file: PathBuf, client: Option<PathBuf>, public_dir: Option<PathBuf>
         let message = format!("Writting {path}...");
         let end_progress = print_progress(&message);
 
-        let dir = PathBuf::from(".lagon").join("public").join(
+        let dir = root.join(".lagon").join("public").join(
             PathBuf::from(&path)
                 .parent()
                 .ok_or_else(|| anyhow!("Could not find parent of {}", path))?,
         );
         fs::create_dir_all(dir)?;
-        fs::write(format!(".lagon/public/{path}"), content)?;
+        fs::write(root.join(".lagon").join("public").join(path), content)?;
 
         end_progress();
     }

--- a/crates/cli/src/commands/deploy.rs
+++ b/crates/cli/src/commands/deploy.rs
@@ -8,8 +8,7 @@ use dialoguer::{Confirm, Input, Select};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::{
-    create_deployment, debug, get_function_config, info, print_progress, validate_code_file,
-    validate_public_dir, write_function_config, Config, DeploymentConfig, TrpcClient,
+    create_deployment, debug, get_root, info, print_progress, Config, FunctionConfig, TrpcClient,
 };
 
 #[derive(Deserialize, Debug)]
@@ -54,124 +53,96 @@ impl Display for Function {
 pub type FunctionsResponse = Vec<Function>;
 
 pub async fn deploy(
-    file: PathBuf,
     client: Option<PathBuf>,
     public_dir: Option<PathBuf>,
     prod: bool,
+    directory: Option<PathBuf>,
 ) -> Result<()> {
     let config = Config::new()?;
 
     if config.token.is_none() {
         return Err(anyhow!(
-            "You are not logged in. Please login with `lagon login`",
+            "You are not logged in. Please log in with `lagon login`",
         ));
     }
 
-    validate_code_file(&file)?;
+    let root = get_root(directory);
+    let mut function_config = FunctionConfig::load(&root, client, public_dir)?;
 
-    let client = match client {
-        Some(client) => {
-            validate_code_file(&client)?;
-            Some(client)
-        }
-        None => None,
-    };
+    if function_config.function_id.is_empty() {
+        println!("{}", debug("No deployment config found..."));
+        println!();
 
-    let public_dir = validate_public_dir(public_dir)?;
-    match get_function_config(&file)? {
-        None => {
-            println!("{}", debug("No deployment config found..."));
-            println!();
+        let trpc_client = TrpcClient::new(&config);
+        let response = trpc_client
+            .query::<(), OrganizationsResponse>("organizationsList", None)
+            .await?;
+        let organizations = response.result.data;
 
-            let trpc_client = TrpcClient::new(&config);
-            let response = trpc_client
-                .query::<(), OrganizationsResponse>("organizationsList", None)
-                .await?;
-            let organizations = response.result.data;
+        let index = Select::new()
+            .items(&organizations)
+            .default(0)
+            .with_prompt(info("Select an Organization to deploy to"))
+            .interact()?;
+        let organization = &organizations[index];
 
-            let index = Select::new().items(&organizations).default(0).interact()?;
-            let organization = &organizations[index];
+        match Confirm::new()
+            .with_prompt(info("Link to an existing Function?"))
+            .interact()?
+        {
+            true => {
+                let response = trpc_client
+                    .query::<(), FunctionsResponse>("functionsList", None)
+                    .await?;
+                let functions = response.result.data;
 
-            match Confirm::new()
-                .with_prompt(info("Link to an existing Function?"))
-                .interact()?
-            {
-                true => {
-                    let response = trpc_client
-                        .query::<(), FunctionsResponse>("functionsList", None)
-                        .await?;
-                    let functions = response.result.data;
+                let index = Select::new()
+                    .items(&functions)
+                    .default(0)
+                    .with_prompt(info("Select a Function to link from"))
+                    .interact()?;
+                let function = &functions[index];
 
-                    let index = Select::new().items(&functions).default(0).interact()?;
-                    let function = &functions[index];
+                function_config.function_id = function.id.clone();
+                function_config.organization_id = organization.id.clone();
+                function_config.write(&root)?;
 
-                    write_function_config(
-                        &file,
-                        DeploymentConfig {
-                            function_id: function.id.clone(),
-                            organization_id: organization.id.clone(),
+                create_deployment(&config, &function_config, prod, &root).await?;
+            }
+            false => {
+                let name = Input::<String>::new()
+                    .with_prompt(info("What is the name of this new Function?"))
+                    .interact_text()?;
+
+                println!();
+                let message = format!("Creating Function {name}...");
+                let end_progress = print_progress(&message);
+
+                let response = trpc_client
+                    .mutation::<CreateFunctionRequest, CreateFunctionResponse>(
+                        "functionCreate",
+                        CreateFunctionRequest {
+                            name,
+                            domains: Vec::new(),
+                            env: Vec::new(),
+                            cron: None,
                         },
-                    )?;
-
-                    create_deployment(
-                        function.id.clone(),
-                        &file,
-                        &client,
-                        &public_dir,
-                        &config,
-                        prod,
                     )
                     .await?;
-                }
-                false => {
-                    let name = Input::<String>::new()
-                        .with_prompt(info("What is the name of this new Function?"))
-                        .interact_text()?;
+                let function = response.result.data;
 
-                    println!();
-                    let message = format!("Creating Function {name}...");
-                    let end_progress = print_progress(&message);
+                end_progress();
 
-                    let response = trpc_client
-                        .mutation::<CreateFunctionRequest, CreateFunctionResponse>(
-                            "functionCreate",
-                            CreateFunctionRequest {
-                                name,
-                                domains: Vec::new(),
-                                env: Vec::new(),
-                                cron: None,
-                            },
-                        )
-                        .await?;
-                    let function = response.result.data;
+                function_config.function_id = function.id.clone();
+                function_config.organization_id = organization.id.clone();
+                function_config.write(&root)?;
 
-                    end_progress();
-
-                    write_function_config(
-                        &file,
-                        DeploymentConfig {
-                            function_id: function.id.clone(),
-                            organization_id: organization.id.clone(),
-                        },
-                    )?;
-
-                    create_deployment(function.id, &file, &client, &public_dir, &config, prod)
-                        .await?;
-                }
-            };
-
-            Ok(())
+                create_deployment(&config, &function_config, prod, &root).await?;
+            }
         }
-        Some(function_config) => {
-            create_deployment(
-                function_config.function_id,
-                &file,
-                &client,
-                &public_dir,
-                &config,
-                prod,
-            )
-            .await
-        }
+    } else {
+        create_deployment(&config, &function_config, prod, &root).await?;
     }
+
+    Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -33,34 +33,34 @@ enum Commands {
     Logout,
     /// Deploy a new or existing Function
     Deploy {
-        /// Path to the file containing the Function
-        #[clap(value_parser)]
-        file: PathBuf,
         /// Path to a client-side script
         #[clap(short, long, value_parser)]
         client: Option<PathBuf>,
-        /// Path to the public directory to serve assets from
+        /// Path to a public directory to serve assets from
         #[clap(short, long, value_parser)]
         public_dir: Option<PathBuf>,
         /// Deploy as a production deployment
         #[clap(visible_alias = "production", long)]
         prod: bool,
+        /// Path to a directory containing a Function
+        #[clap(value_parser)]
+        directory: Option<PathBuf>,
     },
     /// Delete an existing Function
     Rm {
-        /// Path to the file containing the Function
+        /// Path to a directory containing a Function
         #[clap(value_parser)]
-        file: PathBuf,
+        directory: Option<PathBuf>,
     },
     /// Start a local dev server to test a Functon
     Dev {
-        /// Path to the file containing the Function
+        /// Path to a file or a directory containing a Function
         #[clap(value_parser)]
-        file: PathBuf,
+        path: PathBuf,
         /// Path to a client-side script
         #[clap(short, long, value_parser)]
         client: Option<PathBuf>,
-        /// Path to the public directory to serve assets from
+        /// Path to a public directory to serve assets from
         #[clap(short, long, value_parser)]
         public_dir: Option<PathBuf>,
         /// Port to start dev server on
@@ -78,43 +78,43 @@ enum Commands {
     },
     /// Build a Function without deploying it
     Build {
-        /// Path to the file containing the Function
-        #[clap(value_parser)]
-        file: PathBuf,
         /// Path to a client-side script
         #[clap(short, long, value_parser)]
         client: Option<PathBuf>,
-        /// Path to the public directory to serve assets from
+        /// Path to a public directory to serve assets from
         #[clap(short, long, value_parser)]
         public_dir: Option<PathBuf>,
+        /// Path to a directory containing a Function
+        #[clap(value_parser)]
+        directory: Option<PathBuf>,
     },
     /// Link a local Function file to an already deployed Function
     Link {
-        /// Path to the file containing the Function
+        /// Path to a directory containing a Function
         #[clap(value_parser)]
-        file: PathBuf,
+        directory: Option<PathBuf>,
     },
     /// List all the Deployments for a Function
     Ls {
-        /// Path to the file containing the Function
+        /// Path to a directory containing a Function
         #[clap(value_parser)]
-        file: PathBuf,
+        directory: Option<PathBuf>,
     },
     /// Undeploy the given Deployment
     Undeploy {
-        /// Path to the file containing the Function
-        #[clap(value_parser)]
-        file: PathBuf,
         /// ID of the Deployment to undeploy
         deployment_id: String,
+        /// Path to a directory containing a Function
+        #[clap(value_parser)]
+        directory: Option<PathBuf>,
     },
     /// Promote the given preview Deployment to production
     Promote {
-        /// Path to the file containing the Function
-        #[clap(value_parser)]
-        file: PathBuf,
         /// ID of the Deployment to promote
         deployment_id: String,
+        /// Path to a directory containing a Function
+        #[clap(value_parser)]
+        directory: Option<PathBuf>,
     },
 }
 
@@ -127,14 +127,14 @@ async fn main() {
             Commands::Login => commands::login().await,
             Commands::Logout => commands::logout(),
             Commands::Deploy {
-                file,
                 client,
                 public_dir,
                 prod,
-            } => commands::deploy(file, client, public_dir, prod).await,
-            Commands::Rm { file } => commands::rm(file).await,
+                directory,
+            } => commands::deploy(client, public_dir, prod, directory).await,
+            Commands::Rm { directory } => commands::rm(directory).await,
             Commands::Dev {
-                file,
+                path,
                 client,
                 public_dir,
                 port,
@@ -143,7 +143,7 @@ async fn main() {
                 allow_code_generation,
             } => {
                 commands::dev(
-                    file,
+                    path,
                     client,
                     public_dir,
                     port,
@@ -154,20 +154,20 @@ async fn main() {
                 .await
             }
             Commands::Build {
-                file,
                 client,
                 public_dir,
-            } => commands::build(file, client, public_dir),
-            Commands::Link { file } => commands::link(file).await,
-            Commands::Ls { file } => commands::ls(file).await,
+                directory,
+            } => commands::build(client, public_dir, directory),
+            Commands::Link { directory } => commands::link(directory).await,
+            Commands::Ls { directory } => commands::ls(directory).await,
             Commands::Undeploy {
-                file,
                 deployment_id,
-            } => commands::undeploy(file, deployment_id).await,
+                directory,
+            } => commands::undeploy(deployment_id, directory).await,
             Commands::Promote {
-                file,
                 deployment_id,
-            } => commands::promote(file, deployment_id).await,
+                directory,
+            } => commands::promote(deployment_id, directory).await,
         } {
             println!("{}", error(&err.to_string()));
         }

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use colored::Colorize;
+use dialoguer::{Confirm, Input};
 use hyper::{Body, Method, Request};
 use std::{
     collections::HashMap,
@@ -13,9 +14,12 @@ use walkdir::{DirEntry, WalkDir};
 use pathdiff::diff_paths;
 use serde::{Deserialize, Serialize};
 
-use crate::utils::{debug, print_progress, success, TrpcClient};
+use crate::utils::{debug, info, print_progress, success, TrpcClient};
 
-use super::{Config, MAX_ASSETS_PER_FUNCTION, MAX_ASSET_SIZE_MB, MAX_FUNCTION_SIZE_MB};
+use super::{
+    validate_assets_dir, validate_code_file, Config, MAX_ASSETS_PER_FUNCTION, MAX_ASSET_SIZE_MB,
+    MAX_FUNCTION_SIZE_MB,
+};
 
 pub type Assets = HashMap<String, Vec<u8>>;
 
@@ -26,62 +30,142 @@ const ESBUILD: &str = "C:\\Program Files\\nodejs\\esbuild.cmd";
 const ESBUILD: &str = "esbuild";
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct DeploymentConfig {
+pub struct FunctionConfig {
     pub function_id: String,
     pub organization_id: String,
+    pub index: PathBuf,
+    pub client: Option<PathBuf>,
+    pub assets: Option<PathBuf>,
 }
 
-pub fn get_function_config(file: &Path) -> Result<Option<DeploymentConfig>> {
-    let path = format!(
-        ".lagon/{}.json",
-        file.file_name().unwrap().to_str().unwrap()
-    );
-    let path = Path::new(&path);
+impl FunctionConfig {
+    pub fn load(
+        root: &Path,
+        client_override: Option<PathBuf>,
+        assets_override: Option<PathBuf>,
+    ) -> Result<FunctionConfig> {
+        let path = get_function_config_path(root);
 
-    if !path.exists() {
-        return Ok(None);
+        if !path.exists() {
+            println!(
+                "{}",
+                debug("No configuration found in current directory...")
+            );
+            println!();
+
+            let index = match client_override {
+                Some(index) => {
+                    println!("{}", debug("Using custom entrypoint..."));
+                    index
+                }
+                None => {
+                    let index = Input::<String>::new()
+                        .with_prompt(info("Path to your Function's entrypoint?"))
+                        .interact_text()?;
+                    PathBuf::from(index)
+                }
+            };
+
+            validate_code_file(&root.join(&index), root)?;
+
+            let assets = match assets_override {
+                Some(assets) => {
+                    println!("{}", debug("Using custom public directory..."));
+                    Some(assets)
+                }
+                None => match Confirm::new()
+                    .with_prompt(info("Do you have a public directory to serve assets from?"))
+                    .interact()?
+                {
+                    true => {
+                        let assets = Input::<String>::new()
+                            .with_prompt(info("Path to your Function's public directory?"))
+                            .interact_text()?;
+                        let assets = PathBuf::from(assets);
+
+                        validate_assets_dir(&Some(root.join(&assets)), root)?;
+
+                        Some(assets)
+                    }
+                    false => None,
+                },
+            };
+
+            let config = FunctionConfig {
+                function_id: String::from(""),
+                organization_id: String::from(""),
+                index,
+                client: None,
+                assets,
+            };
+
+            config.write(root)?;
+
+            return Ok(config);
+        }
+
+        let content = fs::read_to_string(path)?;
+        let mut config = serde_json::from_str::<FunctionConfig>(&content)?;
+
+        if let Some(client_override) = client_override {
+            println!("{}", debug("Using custom entrypoint..."));
+            config.client = Some(client_override);
+        }
+
+        if let Some(assets_override) = assets_override {
+            println!("{}", debug("Using custom public directory..."));
+            config.assets = Some(assets_override);
+        }
+
+        validate_code_file(&config.index, root)?;
+
+        if let Some(client) = &config.client {
+            validate_code_file(client, root)?;
+        }
+
+        validate_assets_dir(&config.assets, root)?;
+
+        Ok(config)
     }
 
-    let content = fs::read_to_string(path)?;
-    let config = serde_json::from_str::<DeploymentConfig>(&content)?;
+    pub fn write(&self, root: &Path) -> Result<()> {
+        let path = get_function_config_path(root);
 
-    Ok(Some(config))
-}
+        if !path.exists() {
+            fs::create_dir_all(root.join(".lagon"))?;
+        }
 
-pub fn write_function_config(file: &Path, config: DeploymentConfig) -> Result<()> {
-    let path = format!(
-        ".lagon/{}.json",
-        file.file_name().unwrap().to_str().unwrap()
-    );
-    let path = Path::new(&path);
-
-    if !path.exists() {
-        fs::create_dir_all(".lagon")?;
+        let content = serde_json::to_string(self)?;
+        fs::write(path, content)?;
+        Ok(())
     }
 
-    let content = serde_json::to_string(&config)?;
-    fs::write(path, content)?;
-    Ok(())
-}
+    pub fn delete(&self, root: &Path) -> Result<()> {
+        let path = get_function_config_path(root);
 
-pub fn delete_function_config(file: &Path) -> Result<()> {
-    let path = format!(
-        ".lagon/{}.json",
-        file.file_name().unwrap().to_str().unwrap()
-    );
-    let path = Path::new(&path);
+        if !path.exists() {
+            return Err(anyhow!("No configuration found in this directory.",));
+        }
 
-    if !path.exists() {
-        return Err(anyhow!("No configuration found in this directory.",));
+        fs::remove_file(path)?;
+        Ok(())
     }
-
-    fs::remove_file(path)?;
-    Ok(())
 }
 
-fn esbuild(file: &PathBuf) -> Result<Vec<u8>> {
+pub fn get_root(root: Option<PathBuf>) -> PathBuf {
+    match root {
+        Some(path) => path,
+        None => std::env::current_dir().unwrap(),
+    }
+}
+
+pub fn get_function_config_path(root: &Path) -> PathBuf {
+    root.join(".lagon").join("config.json")
+}
+
+fn esbuild(file: &Path, root: &Path) -> Result<Vec<u8>> {
     let result = Command::new(ESBUILD)
-        .arg(file)
+        .arg(root.join(file))
         .arg("--define:process.env.NODE_ENV=\"production\"")
         .arg("--bundle")
         .arg("--format=esm")
@@ -112,11 +196,7 @@ fn esbuild(file: &PathBuf) -> Result<Vec<u8>> {
     ))
 }
 
-pub fn bundle_function(
-    index: &PathBuf,
-    client: &Option<PathBuf>,
-    public_dir: &PathBuf,
-) -> Result<(Vec<u8>, Assets)> {
+pub fn bundle_function(function_config: &FunctionConfig, root: &Path) -> Result<(Vec<u8>, Assets)> {
     if let Err(error) = Command::new(ESBUILD).arg("--version").output() {
         return if error.kind() == ErrorKind::NotFound {
             Err(anyhow!(
@@ -131,25 +211,25 @@ pub fn bundle_function(
     }
 
     let end_progress = print_progress("Bundling Function handler...");
-    let index_output = esbuild(index)?;
+    let index_output = esbuild(&function_config.index, root)?;
     end_progress();
 
-    let mut assets = Assets::new();
+    let mut final_assets = Assets::new();
 
-    if let Some(client) = client {
+    if let Some(client) = &function_config.client {
         let end_progress = print_progress("Bundling client file...");
-        let client_output = esbuild(client)?;
+        let client_output = esbuild(client, root)?;
         end_progress();
 
         let client_path = client.as_path().with_extension("js");
         let client_path = client_path.file_name().unwrap();
 
-        if public_dir.exists() && public_dir.is_dir() {
-            let client_path = public_dir.join(client_path);
+        if let Some(assets) = &function_config.assets {
+            let client_path = assets.join(client_path);
             fs::write(client_path, &client_output)?;
         }
 
-        assets.insert(
+        final_assets.insert(
             client
                 .as_path()
                 .file_stem()
@@ -162,14 +242,11 @@ pub fn bundle_function(
         );
     }
 
-    if public_dir.exists() && public_dir.is_dir() {
-        let msg = format!(
-            "Found public directory ({}), bundling assets...",
-            public_dir.display()
-        );
+    if let Some(assets) = &function_config.assets {
+        let msg = format!("Found public directory ({:?}), bundling assets...", assets);
         let end_progress = print_progress(&msg);
 
-        let files = WalkDir::new(public_dir)
+        let files = WalkDir::new(root.join(assets))
             .into_iter()
             .collect::<Vec<walkdir::Result<DirEntry>>>();
 
@@ -193,14 +270,14 @@ pub fn bundle_function(
                     ));
                 }
 
-                let diff = diff_paths(path, public_dir)
+                let diff = diff_paths(path, root.join(assets))
                     .unwrap()
                     .to_str()
                     .unwrap()
                     .to_string();
                 let file_content = fs::read(path)?;
 
-                assets.insert(diff, file_content);
+                final_assets.insert(diff, file_content);
             }
         }
 
@@ -209,7 +286,7 @@ pub fn bundle_function(
         println!("{}", debug("No public directory found, skipping..."));
     }
 
-    Ok((index_output, assets))
+    Ok((index_output, final_assets))
 }
 
 #[derive(Serialize, Debug)]
@@ -248,14 +325,12 @@ struct DeployDeploymentResponse {
 }
 
 pub async fn create_deployment(
-    function_id: String,
-    file: &PathBuf,
-    client: &Option<PathBuf>,
-    public_dir: &PathBuf,
     config: &Config,
+    function_config: &FunctionConfig,
     prod: bool,
+    root: &Path,
 ) -> Result<()> {
-    let (index, assets) = bundle_function(file, client, public_dir)?;
+    let (index, assets) = bundle_function(function_config, root)?;
 
     let end_progress = print_progress("Creating deployment...");
 
@@ -264,7 +339,7 @@ pub async fn create_deployment(
         .mutation::<CreateDeploymentRequest, CreateDeploymentResponse>(
             "deploymentCreate",
             CreateDeploymentRequest {
-                function_id: function_id.clone(),
+                function_id: function_config.function_id.clone(),
                 function_size: index.len(),
                 assets: assets
                     .iter()
@@ -314,7 +389,7 @@ pub async fn create_deployment(
         .mutation::<DeployDeploymentRequest, DeployDeploymentResponse>(
             "deploymentDeploy",
             DeployDeploymentRequest {
-                function_id,
+                function_id: function_config.function_id.clone(),
                 deployment_id,
                 is_production: prod,
             },
@@ -329,7 +404,6 @@ pub async fn create_deployment(
         "➤".bright_black(),
         response.result.data.url.blue()
     );
-    println!();
 
     Ok(())
 }

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -15,12 +15,14 @@ pub const MAX_FUNCTION_SIZE_MB: usize = 10 * 1024 * 1024; // 10MB
 pub const MAX_ASSET_SIZE_MB: u64 = 10 * 1024 * 1024; // 10MB
 pub const MAX_ASSETS_PER_FUNCTION: usize = 100;
 
-pub fn validate_code_file(file: &Path) -> Result<()> {
-    if !file.exists() || !file.is_file() {
-        return Err(anyhow!("{} is not a file", file.to_str().unwrap()));
+pub fn validate_code_file(file: &Path, root: &Path) -> Result<()> {
+    let path = root.join(file);
+
+    if !path.exists() || !path.is_file() {
+        return Err(anyhow!("{:?} is not a file", path));
     }
 
-    match file.extension() {
+    match path.extension() {
         Some(ext) => {
             let validate = ext == "js"
                 || ext == "jsx"
@@ -38,17 +40,14 @@ pub fn validate_code_file(file: &Path) -> Result<()> {
     }
 }
 
-pub fn validate_public_dir(public_dir: Option<PathBuf>) -> Result<PathBuf> {
-    if let Some(dir) = public_dir {
-        if !dir.is_dir() {
-            return Err(anyhow!(
-                "Public directory {} does not exist.",
-                dir.to_str().unwrap()
-            ));
-        }
+pub fn validate_assets_dir(assets_dir: &Option<PathBuf>, root: &Path) -> Result<()> {
+    if let Some(dir) = assets_dir {
+        let path = root.join(dir);
 
-        return Ok(dir);
+        if !path.is_dir() {
+            return Err(anyhow!("Public directory {:?} does not exist.", path));
+        }
     }
 
-    Ok(PathBuf::from("./public"))
+    Ok(())
 }

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -39,63 +39,74 @@ To proceed, run `lagon logout` and follow the instructions.
 
 ### `lagon deploy`
 
-Create a new Function or a new Deployment for the given files. Make sure you are [logged in](#lagon-login) before proceeding. If you are executing the command for the first time:
+Create a new Function or a new Deployment in the given directory. Make sure you are [logged in](#lagon-login) before proceeding. If you are executing the command for the first time:
 
 1. You will be prompted to select an Organization
 2. You will be able to link to an existing Function, or create a new one by specifying a name
 
-If you then want to trigger a new Deployment, re-run the same command. This command accepts the following arguments and options:
+If you then want to trigger a new Deployment, re-run the same command. By default, subsequent Deployments are created in preview mode. Specify `--prod` to deploy in production mode.
 
-- `<FILE>` is the only required argument. It should be the path to a file containing and exporting a Function.
+This command accepts the following arguments and options:
+
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
 - `--client, -c <CLIENT>` allows you to specify a path to an additional file to bundle as a client-side script.
-- `--public, -p <FOLDER>` allows you to specify a path to a custom assets directory, that will be served at the root (`/`) of the Function. (Default: `public`)
+- `--public, -p <<PUBLIC_DIR>>` allows you to specify a path to a directory containing assets to be served statically.
 - `--production, --prod` allows you to deploy the Function in production mode. (Default: `false`)
 
 Examples:
 
 ```bash
-# Create a new Deployment in production mode
-lagon deploy ./index.ts --prod
-# Create a new Function with a client file and some assets
-lagon deploy ./server.tsx --client App.tsx --public ./assets
+# Deploy the current directory to Production
+lagon deploy --prod
+# Deploy the my-project directory and override the public directory
+lagon deploy ./my-project --public ./my-project/assets
 ```
 
 ### `lagon ls`
 
-List all the Deployments of the given Function. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts only one argument:
+List all the Deployments of the given directory. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts only one argument:
 
-- `<FILE>` path to a file containing the Function to list deployments.
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
 
 Example:
 
 ```bash
-lagon ls ./index.ts
+# List Deployments in the current directory
+lagon ls
+# List Deployments of the my-project directory
+lagon ls ./my-project
 ```
 
 ### `lagon promote`
 
 Promote the given Deployment to production. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts the following arguments:
 
-- `<FILE>` path to a file containing the Function to promote a Deployment from.
 - `<DEPLOYMENT_ID>` the ID of the Deployment to promote.
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
 
 Example:
 
 ```bash
-lagon promote ./index.ts claxnlc230738q5pa7iximskm
+# Promote the cl...km Deployment in the current directory
+lagon promote claxnlc230738q5pa7iximskm
+# Promote the cl...km Deployment of the my-project directory
+lagon promote claxnlc230738q5pa7iximskm ./my-project
 ```
 
 ### `lagon undeploy`
 
 Un-deploy a Deployment. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts the following arguments:
 
-- `<FILE>` path to a file containing the Function to undeploy a Deployment from.
 - `<DEPLOYMENT_ID>` the ID of the Deployment to undeploy.
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
 
 Example:
 
 ```bash
-lagon undeploy ./index.ts claxnlc230738q5pa7iximskm
+# Undeploy the cl...km Deployment in the current directory
+lagon undeploy claxnlc230738q5pa7iximskm
+# Undeploy the cl...km Deployment of the my-project directory
+lagon undeploy claxnlc230738q5pa7iximskm ./my-project
 ```
 
 ### `lagon rm`
@@ -104,22 +115,32 @@ lagon undeploy ./index.ts claxnlc230738q5pa7iximskm
   Deleting a Function also deletes permanently all of its Deployments, statistics and logs.
 </Callout>
 
-Delete completely a Function. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts only one argument:
+Delete completely a Function. You'll be asked to confirm before proceeding. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts only one argument:
 
-- `<FILE>` path to a file containing the Function to undeploy.
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
 
 Example:
 
 ```bash
-lagon rm ./index.ts
+# Delete the current directory's Function
+lagon rm
+# Delete the my-project directory's Function
+lagon rm ./my-project
 ```
 
 ### `lagon dev`
 
-Launch a local dev server, using the same Runtime as when deployed to the Cloud.
+Launch a local dev server, using the same Runtime as when deployed to the Cloud. You can either:
 
-This command accepts the same arguments and options as `lagon deploy` and `lagon build`. It can also accept the following options:
+- Use this command without arguments, to use the current directory configuration
+- Specify a path to a directory containing a Function and its configuration
+- Specify a path to a file containing a Function
 
+This command accepts the following arguments and options:
+
+- `[PATH]` is an optional path to a directory or file containing the Function. (Default: `.`)
+- `--client, -c <CLIENT>` allows you to specify a path to an additional file to bundle as a client-side script.
+- `--public, -p <<PUBLIC_DIR>>` allows you to specify a path to a directory containing assets to be served statically.
 - `--hostname <HOSTNAME>` allows you to specify a custom hostname to start the server on. (Default: `127.0.0.1`)
 - `--port <PORT>` allows you to specify a custom port to start the server on. (Default: `1234`)
 - `--env <FILE>` allows you to specify an environment file (typically `.env`) to use to inject environment variables.
@@ -133,17 +154,23 @@ This command accepts the same arguments and options as `lagon deploy` and `lagon
 Examples:
 
 ```bash
-# Run a local dev server on port 56565
-lagon dev ./index.ts --port 56565
+# Run a local dev server on the current directory
+lagon dev
+# Run a local dev server inside the my-project directory using a custom port
+lagon dev ./my-project --port 56565
 # Run a local dev server with a client file and some assets
 lagon dev ./server.tsx --client App.tsx --public ./assets
 ```
 
 ### `lagon build`
 
-For debugging purposes, you can build a Function and see its output without deploying it. Under the hood, `lagon build` does the same steps as `lagon deploy`, but skip the deployment part and instead writes the output to a local `.lagon` folder.
+For debugging purposes, you can build a Function and see its output without deploying it. Under the hood, `lagon build` does the same steps as `lagon deploy`, but skips the deployment part and instead writes the output to a local `.lagon` folder.
 
-This command accepts the same arguments and options as `lagon deploy` and `lagon build`.
+This command accepts the following arguments and options:
+
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
+- `--client, -c <CLIENT>` allows you to specify a path to an additional file to bundle as a client-side script.
+- `--public, -p <<PUBLIC_DIR>>` allows you to specify a path to a directory containing assets to be served statically.
 
 Examples:
 
@@ -158,9 +185,9 @@ tree .lagon/
 
 ### `lagon link`
 
-Link a local Function to a deployed one, without triggering a new Deployment. Make sure you are [logged in](#lagon-login) before proceeding. This command accept only one argument:
+Link a local Function to a deployed one, without triggering a new Deployment. Make sure you are [logged in](#lagon-login) before proceeding. This command accepts only one argument:
 
-- `<FILE>` path to a file containing the Function to list deployments.
+- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
 
 Example:
 
@@ -179,4 +206,4 @@ If you are [self-hosting](/self-hosted/installation) Lagon, you will need to upd
 }
 ```
 
-Replace the `site_url` field by the one configured during the installation. To verify if it's working correctly, log in to your installation using `lagon login`.
+Replace the `site_url` field with the one configured during the installation. To verify if it's working correctly, log in to your installation using `lagon login`.


### PR DESCRIPTION
## About

Improve functions configuration by saving parameters into a local config file.

When using `lagon dev`, `lagon build` or `lagon deploy`, you don't need anymore to specify the function's entrypoint and the public directory. These configuration are saved into a local `.lagon/config.json` file.

Note that `lagon dev` still allows to specify an entrypoint and public directory as before using arguments and options, making it easy to test locally.

---

That means after the first configuration asks us the path to the function's entrypoint and (optionally) the path to an assets directory, we can simply run `lagon dev` / `lagon deploy` without specifying again these settings.