### PR TITLE
fix(dashboard): small UX issues

### DIFF
--- a/.changeset/curly-apes-arrive.md
+++ b/.changeset/curly-apes-arrive.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Hide CLI auth code

--- a/.changeset/slow-lamps-speak.md
+++ b/.changeset/slow-lamps-speak.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Set the current theme for the editor inside the playground

--- a/.changeset/swift-jars-share.md
+++ b/.changeset/swift-jars-share.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Use DOM types for the playground

--- a/packages/dashboard/lib/components/Playground.tsx
+++ b/packages/dashboard/lib/components/Playground.tsx
@@ -1,4 +1,5 @@
 import Editor, { useMonaco } from '@monaco-editor/react';
+import useTheme from 'lib/hooks/useTheme';
 import { useEffect } from 'react';
 
 type PlaygroundProps = {
@@ -9,6 +10,13 @@ type PlaygroundProps = {
 
 const Playground = ({ defaultValue, width, height }: PlaygroundProps) => {
   const monaco = useMonaco();
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    if (monaco) {
+      monaco.editor.setTheme(theme === 'Dark' ? 'vs-dark' : 'vs-light');
+    }
+  }, [theme, monaco]);
 
   useEffect(() => {
     if (monaco) {
@@ -18,60 +26,9 @@ const Playground = ({ defaultValue, width, height }: PlaygroundProps) => {
       });
 
       monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-        lib: ['es2015'],
+        lib: ['es2015', 'dom'],
         allowNonTsExtensions: true,
       });
-
-      const code = `declare interface RequestInit {
-          method?: string;
-          headers?: Record<string, string | string[] | undefined>;
-          body?: string;
-        }
-
-        declare class Request {
-          constructor(input: string, options?: RequestInit);
-
-          method: string;
-          headers: Record<string, string | string[] | undefined>;
-          body?: string;
-          url: string;
-
-          text(): string;
-          json(): object;
-          formData(): Record<string, string>;
-        }
-
-        declare interface ResponseInit {
-          status?: number;
-          statusText?: string;
-          headers?: Record<string, string | string[] | undefined>;
-          url?: string;
-        }
-
-        declare class Response {
-          constructor(body?: string, options?: ResponseInit);
-
-          body: string;
-          headers?: Record<string, string | string[] | undefined>;
-          ok: boolean;
-          status: number;
-          statusText: string;
-          url: string;
-
-          text(): string;
-          json(): object;
-          formData(): Record<string, string>;
-        }
-
-        declare function fetch(resource: string, init?: RequestInit): Promise<Response>;
-        `;
-      const file = 'ts:filename/lagon.d.ts';
-
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(code, file);
-
-      if (!monaco.editor.getModel(monaco.Uri.parse(file))) {
-        monaco.editor.createModel(code, 'typescript', monaco.Uri.parse(file));
-      }
     }
   }, [monaco]);
 

--- a/packages/dashboard/pages/cli.tsx
+++ b/packages/dashboard/pages/cli.tsx
@@ -19,13 +19,13 @@ const CLI = () => {
     <LayoutTitle title={t('title')}>
       <div className="mx-auto mt-16 flex max-w-xs flex-col items-center justify-center gap-6 text-center">
         <Text>{t('description')}</Text>
-        <div>
+        <div className="flex flex-col gap-1">
           <button
             type="button"
             onClick={copyCode}
             className="rounded-lg border border-stone-300 bg-stone-100 px-4 py-2 text-2xl font-semibold text-stone-800 transition hover:bg-stone-200 active:bg-stone-300 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700 dark:active:bg-stone-600"
           >
-            {data?.code}
+            {data?.code?.replace(/./g, '*')}
           </button>
           <Text size="sm">{t('copy')}</Text>
         </div>


### PR DESCRIPTION
## About

Small UX issues on the dashboard after Daniel's live stream:

- Hide the auth code with `*` (it's already hidden when pasting inside the CLI):
![Screenshot 2023-02-20 at 18 53 59](https://user-images.githubusercontent.com/43268759/220173688-14a59fb5-f46e-4641-889e-c898900d7057.png)
- Set the theme of the editor inside the playground to the users's current theme
- Use DOM types for the playground instead of hardcoded (and wrong) ones
