### PR TITLE
fix(cli): re-use the same isolate between requests to keep server-side state

### DIFF
--- a/.changeset/wise-beers-joke.md
+++ b/.changeset/wise-beers-joke.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Re-use the same isolate between requests to keep server-side state


### PR DESCRIPTION
## About

Previously, the server-side state wasn't kept between requests because a new isolate was recreated every time. This is no longer the case for the dev server.

The isolate is now created once when receiving an initial request and is kept in memory for subsequent requests. When the function's entry point is updated (meaning the dev server needs to reload), the isolate is cleared and a new one is recreated on the next request.
