### PR TITLE
fix(cli): allow `lagon dev` without arguments

### DIFF
--- a/.changeset/loud-mugs-arrive.md
+++ b/.changeset/loud-mugs-arrive.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+`lagon dev --env PATH` is relative to the root

--- a/.changeset/ten-wolves-kneel.md
+++ b/.changeset/ten-wolves-kneel.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Allow using `lagon dev` without any argument to use the current directory configuration

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -56,7 +56,7 @@ enum Commands {
     Dev {
         /// Path to a file or a directory containing a Function
         #[clap(value_parser)]
-        path: PathBuf,
+        path: Option<PathBuf>,
         /// Path to a client-side script
         #[clap(short, long, value_parser)]
         client: Option<PathBuf>,

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -154,12 +154,12 @@ This command accepts the following arguments and options:
 Examples:
 
 ```bash
-# Run a local dev server on the current directory
+# Run a local dev server in the current directory
 lagon dev
+# Run a local dev server with a file entrypoint and some assets
+lagon dev ./server.tsx --public ./assets
 # Run a local dev server inside the my-project directory using a custom port
 lagon dev ./my-project --port 56565
-# Run a local dev server with a client file and some assets
-lagon dev ./server.tsx --client App.tsx --public ./assets
 ```
 
 ### `lagon build`


### PR DESCRIPTION
## About

Allow using `lagon dev` without any arguments, to use the current directory configuration (or create a new one if none is present). Also fix the `--env` option to be relative from the root.
