### PR TITLE
fix(astro): bundle for Node.js by excluding all dependencies

### DIFF
--- a/.changeset/bright-hairs-rescue.md
+++ b/.changeset/bright-hairs-rescue.md
@@ -1,0 +1,5 @@
+---
+'@lagon/astro': patch
+---
+
+Bundle for Node.js by excluding all dependencies

--- a/packages/integrations/astro/package.json
+++ b/packages/integrations/astro/package.json
@@ -25,8 +25,8 @@
     "astro-adapter"
   ],
   "scripts": {
-    "watch": "tsup src/index.ts src/server.ts --format esm --dts --watch",
-    "build": "tsup src/index.ts src/server.ts --format esm --dts",
+    "watch": "tsup-node src/index.ts src/server.ts --format esm --dts --watch",
+    "build": "tsup-node src/index.ts src/server.ts --format esm --dts",
     "lint": "eslint --cache .",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## About

Fix regression of https://github.com/lagonapp/lagon/pull/569. Since the adapter is used in Node.js, we can bundle for Node.js using `tsup-node` that excludes all dependencies from the bundle.