### PR TITLE
perf(runtime): improve objects creation speed

### DIFF
--- a/.changeset/tame-ties-judge.md
+++ b/.changeset/tame-ties-judge.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Improve objects creation speed

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -6,7 +6,7 @@ use hyper::{
     Body, Request as HyperRequest,
 };
 use lagon_runtime_v8_utils::{
-    extract_v8_headers_object, extract_v8_string, v8_headers_object, v8_string, v8_string_onebyte,
+    extract_v8_headers_object, extract_v8_string, v8_headers_object, v8_string,
 };
 use std::{collections::HashMap, str::FromStr};
 
@@ -47,19 +47,19 @@ impl IntoV8 for Request {
         let mut names = Vec::with_capacity(len);
         let mut values = Vec::with_capacity(len);
 
-        names.push(v8_string_onebyte(scope, "i").into());
+        names.push(v8_string(scope, "i").into());
         values.push(v8_string(scope, &self.url).into());
 
-        names.push(v8_string_onebyte(scope, "m").into());
+        names.push(v8_string(scope, "m").into());
         values.push(v8_string(scope, self.method.into()).into());
 
         if body_exists {
-            names.push(v8_string_onebyte(scope, "b").into());
+            names.push(v8_string(scope, "b").into());
             values.push(v8_string(scope, &String::from_utf8(self.body.to_vec()).unwrap()).into());
         }
 
         if let Some(headers) = self.headers {
-            names.push(v8_string_onebyte(scope, "h").into());
+            names.push(v8_string(scope, "h").into());
             values.push(v8_headers_object(scope, headers).into());
         }
 
@@ -79,7 +79,7 @@ impl FromV8 for Request {
         };
 
         let mut body = Bytes::new();
-        let body_key = v8_string_onebyte(scope, "b");
+        let body_key = v8_string(scope, "b");
 
         if let Some(body_value) = request.get(scope, body_key.into()) {
             if !body_value.is_null_or_undefined() {
@@ -88,7 +88,7 @@ impl FromV8 for Request {
         }
 
         let mut headers = None;
-        let headers_key = v8_string_onebyte(scope, "h");
+        let headers_key = v8_string(scope, "h");
 
         if let Some(headers_value) = request.get(scope, headers_key.into()) {
             if !headers_value.is_null_or_undefined() {
@@ -97,14 +97,14 @@ impl FromV8 for Request {
         }
 
         let mut method = Method::GET;
-        let method_key = v8_string_onebyte(scope, "m");
+        let method_key = v8_string(scope, "m");
 
         if let Some(method_value) = request.get(scope, method_key.into()) {
             method = Method::from(extract_v8_string(method_value, scope)?.as_str());
         }
 
         let url;
-        let url_key = v8_string_onebyte(scope, "u");
+        let url_key = v8_string(scope, "u");
 
         if let Some(url_value) = request.get(scope, url_key.into()) {
             url = extract_v8_string(url_value, scope)?;

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -7,7 +7,7 @@ use hyper::{
 };
 use lagon_runtime_v8_utils::{
     extract_v8_headers_object, extract_v8_integer, extract_v8_string, v8_headers_object,
-    v8_integer, v8_string_onebyte, v8_uint8array,
+    v8_integer, v8_string, v8_uint8array,
 };
 use std::{collections::HashMap, str::FromStr};
 
@@ -51,14 +51,14 @@ impl IntoV8 for Response {
         let mut names = Vec::with_capacity(len);
         let mut values = Vec::with_capacity(len);
 
-        names.push(v8_string_onebyte(scope, "b").into());
+        names.push(v8_string(scope, "b").into());
         values.push(v8_uint8array(scope, self.body.to_vec()).into());
 
-        names.push(v8_string_onebyte(scope, "s").into());
+        names.push(v8_string(scope, "s").into());
         values.push(v8_integer(scope, self.status.into()).into());
 
         if let Some(headers) = self.headers {
-            names.push(v8_string_onebyte(scope, "h").into());
+            names.push(v8_string(scope, "h").into());
             values.push(v8_headers_object(scope, headers).into());
         }
 
@@ -78,7 +78,7 @@ impl FromV8 for Response {
         };
 
         let body;
-        let body_key = v8_string_onebyte(scope, "b");
+        let body_key = v8_string(scope, "b");
 
         if let Some(body_value) = response.get(scope, body_key.into()) {
             body = extract_v8_string(body_value, scope)?;
@@ -87,7 +87,7 @@ impl FromV8 for Response {
         }
 
         let mut headers = None;
-        let headers_key = v8_string_onebyte(scope, "h");
+        let headers_key = v8_string(scope, "h");
 
         if let Some(headers_object) = response.get(scope, headers_key.into()) {
             if let Some(headers_object) = headers_object.to_object(scope) {
@@ -104,7 +104,7 @@ impl FromV8 for Response {
         }
 
         let status;
-        let status_key = v8_string_onebyte(scope, "s");
+        let status_key = v8_string(scope, "s");
 
         if let Some(status_value) = response.get(scope, status_key.into()) {
             status = extract_v8_integer(status_value, scope)? as u16;

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -100,6 +100,13 @@ pub fn v8_string<'a>(
     v8::String::new(scope, value).unwrap()
 }
 
+pub fn v8_string_onebyte<'a>(
+    scope: &mut v8::HandleScope<'a, ()>,
+    value: &str,
+) -> v8::Local<'a, v8::String> {
+    v8::String::new_from_one_byte(scope, value.as_bytes(), v8::NewStringType::Normal).unwrap()
+}
+
 pub fn v8_integer<'a>(scope: &mut v8::HandleScope<'a>, value: i32) -> v8::Local<'a, v8::Integer> {
     v8::Integer::new(scope, value)
 }
@@ -121,22 +128,28 @@ pub fn v8_headers_object<'a>(
     scope: &mut v8::HandleScope<'a>,
     value: HashMap<String, Vec<String>>,
 ) -> v8::Local<'a, v8::Object> {
-    let headers = v8::Object::new(scope);
+    let len = value.len();
 
-    for (key, values) in value.iter() {
+    let mut names = Vec::with_capacity(len);
+    let mut values = Vec::with_capacity(len);
+
+    for (key, headers) in value.iter() {
         let key = v8_string(scope, key);
 
-        let array = v8::Array::new(scope, values.len() as i32);
+        let mut elements = Vec::with_capacity(headers.len());
 
-        for (i, value) in values.iter().enumerate() {
-            let value = v8_string(scope, value);
-            array.set_index(scope, i as u32, value.into());
+        for header in headers.iter() {
+            elements.push(v8_string(scope, header).into())
         }
 
-        headers.set(scope, key.into(), array.into());
+        let array = v8::Array::new_with_elements(scope, &elements);
+
+        names.push(key.into());
+        values.push(array.into());
     }
 
-    headers
+    let null = v8::null(scope).into();
+    v8::Object::with_prototype_and_properties(scope, null, &names, &values)
 }
 
 pub fn v8_boolean<'a>(scope: &mut v8::HandleScope<'a>, value: bool) -> v8::Local<'a, v8::Boolean> {

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -100,13 +100,6 @@ pub fn v8_string<'a>(
     v8::String::new(scope, value).unwrap()
 }
 
-pub fn v8_string_onebyte<'a>(
-    scope: &mut v8::HandleScope<'a, ()>,
-    value: &str,
-) -> v8::Local<'a, v8::String> {
-    v8::String::new_from_one_byte(scope, value.as_bytes(), v8::NewStringType::Normal).unwrap()
-}
-
 pub fn v8_integer<'a>(scope: &mut v8::HandleScope<'a>, value: i32) -> v8::Local<'a, v8::Integer> {
     v8::Integer::new(scope, value)
 }


### PR DESCRIPTION
## About

Improve objects creation speed from Rust -> JS, mostly noticeable on small objects. Instead of creating an object and then assigning properties, we can use [`v8::Object::New(isolate, prototype_or_null, names, values, length)`](https://v8.github.io/api/head/classv8_1_1Object.html#afdb58efc2065a4e7a012db394c302159) (`v8::Object::with_prototype_and_properties` in rusty_v8) to immediately create an object with the given properties.

This optimization is made in `Request::into_v8`, `Response::into_v8`, and `v8_headers_object`. The same can be made for Arrays by using [`v8::Array::New(isolate, elements, length)`](https://v8.github.io/api/head/classv8_1_1Array.html#a1689924b348f352fa5bc389c44f71cd6) (`v8::Array::new_with_elements` in rusty_v8).

Before, `Request::into_v8` takes ~12.5% (~74k req/s)
![Screenshot 2023-02-26 at 14 51 49](https://user-images.githubusercontent.com/43268759/221414551-7f5b07a5-6f54-4b8f-a1d8-bc2f17182166.png)

After, `Request::into_v8` takes ~9% (~80k req/s)
![Screenshot 2023-02-26 at 14 51 20](https://user-images.githubusercontent.com/43268759/221414510-41b22c96-ea95-4b8c-9a08-f3cca7326134.png)
