### PR TITLE
fix(runtime): avoid thread panicking when promise id not found

### DIFF
--- a/.changeset/lucky-cows-cross.md
+++ b/.changeset/lucky-cows-cross.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Avoid thread panicking when promise id is not found

--- a/crates/runtime_isolate/src/lib.rs
+++ b/crates/runtime_isolate/src/lib.rs
@@ -361,12 +361,9 @@ impl Isolate {
                 while let Poll::Ready(Some(BindingResult { id, result })) =
                     isolate_state.promises.poll_next_unpin(cx)
                 {
-                    let promise = isolate_state
-                        .js_promises
-                        .remove(&id)
-                        .unwrap_or_else(|| panic!("JS promise {id} not found"));
-
-                    promises.as_mut().unwrap().push((result, promise));
+                    if let Some(promise) = isolate_state.js_promises.remove(&id) {
+                        promises.as_mut().unwrap().push((result, promise));
+                    }
                 }
 
                 self.running_promises.store(false, Ordering::SeqCst);


### PR DESCRIPTION
## About

Avoid a `panic!()` when polling promises and removing the current promise id. This could occur if the execution was stopped by V8 but not yet caught by the runtime.
