### PR TITLE
fix(serverless): don't skip deployment when an asset failed to download

### DIFF
--- a/.changeset/blue-colts-agree.md
+++ b/.changeset/blue-colts-agree.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Don't skip deployment when asset failed to download

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use colored::Colorize;
 use dialoguer::{Confirm, Input};
 use hyper::{Body, Method, Request};
+use std::sync::Arc;
 use std::{
     collections::HashMap,
     fs,
@@ -9,7 +10,6 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use std::sync::Arc;
 use walkdir::{DirEntry, WalkDir};
 
 use pathdiff::diff_paths;

--- a/crates/serverless/src/deployments/mod.rs
+++ b/crates/serverless/src/deployments/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use lagon_runtime_utils::Deployment;
-use log::{error, info};
+use log::{error, info, warn};
 use mysql::{prelude::Queryable, PooledConn};
 use s3::Bucket;
 use tokio::sync::{Mutex, RwLock};
@@ -35,7 +35,9 @@ pub async fn download_deployment(deployment: &Deployment, bucket: &Bucket) -> Re
                         Ok(object) => {
                             deployment.write_asset(asset, object.bytes())?;
                         }
-                        Err(error) => return Err(anyhow!(error)),
+                        Err(error) => {
+                            warn!(deployment = deployment.id, asset = asset; "Failed to download deployment asset: {}", error)
+                        }
                     };
                 }
             }


### PR DESCRIPTION
## About

Don't skip deployment by not returning the error and instead print a warning when an asset failed to download.
