### PR TITLE
feat(cli,docs): set `X-Lagon-Region` header to `local` for `lagon dev`

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -6,7 +6,7 @@ use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse, Server};
 use lagon_runtime::{options::RuntimeOptions, Runtime};
-use lagon_runtime_http::{Request, Response, RunResult, X_FORWARDED_FOR};
+use lagon_runtime_http::{Request, Response, RunResult, X_FORWARDED_FOR, X_LAGON_REGION};
 use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
 use lagon_runtime_utils::assets::{find_asset, handle_asset};
 use lagon_runtime_utils::response::{handle_response, ResponseEvent, FAVICON_URL};
@@ -25,6 +25,8 @@ use tokio::sync::Mutex;
 use tokio_util::task::LocalPoolHandle;
 
 use crate::utils::{bundle_function, error, info, input, success, warn, Assets, FunctionConfig};
+
+const LOCAL_REGION: &str = "local";
 
 struct SimpleLogger;
 
@@ -116,6 +118,7 @@ async fn handle_request(
         match Request::from_hyper(req).await {
             Ok(mut request) => {
                 request.set_header(X_FORWARDED_FOR.to_string(), ip);
+                request.set_header(X_LAGON_REGION.to_string(), LOCAL_REGION.to_string());
 
                 pool.spawn_pinned_by_idx(
                     move || async move {

--- a/packages/docs/pages/cloud/regions.mdx
+++ b/packages/docs/pages/cloud/regions.mdx
@@ -1,4 +1,4 @@
-Lagon is currently deployed in 14 regions all around the world. We increase the number of regions regularly, and you can also [request a new Region here](https://tally.so/r/mDqAYN).
+Lagon is currently deployed in 14 regions all around the world. We increase the number of regions regularly, and you can also [request a new Region](#request-a-new-region).
 
 We use multiple hosting providers to prevent a single point of failure and provide resiliency in the case of an outage from one of our providers. Users are routed to the region that is geographically closest to them when they request a Function, using a mix of Anycast and GeoIP.
 
@@ -20,3 +20,7 @@ You can access the Region that is responding to the current requests using the [
 - Sydney, Australia (`sydney-ap-south`)
 - Tokio, Japan (`tokio-ap-east`)
 - Johannesburg, South Africa (`johannesburg-af-south`)
+
+## Request a new region
+
+If you would like to see a new region, please [fill out this form](https://tally.so/r/mDqAYN). We will prioritize the regions that are the most requested.

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -34,6 +34,10 @@ export function handler(request: Request) {
 
 The `X-Lagon-Region` header is also automatically added to each response, making it easy to identify which Region served the request.
 
+<Callout type="info">
+  When developing locally using [`lagon dev`](/cli#lagon-dev), the `X-Lagon-Region` header will be set to `local`.
+</Callout>
+
 ## Global objects
 
 ### `AbortController`


### PR DESCRIPTION
## About

To match correctly the development environment to the production one when deployed, the `X-Lagon-Region` header must be present. This PR sets this header to `local` when using `lagon dev`, and updates the docs to mention it.