### PR TITLE
fix(cli): ESBuild path on Windows

### DIFF
--- a/.changeset/flat-walls-fry.md
+++ b/.changeset/flat-walls-fry.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix ESBuild path on Windows

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -25,7 +25,7 @@ use super::{
 pub type Assets = HashMap<String, Vec<u8>>;
 
 #[cfg(windows)]
-const ESBUILD: &str = "C:\\Program Files\\nodejs\\esbuild.cmd";
+const ESBUILD: &str = "esbuild.cmd";
 
 #[cfg(not(windows))]
 const ESBUILD: &str = "esbuild";


### PR DESCRIPTION
## About

Closes #629 

Regression of https://github.com/lagonapp/lagon/pull/434, ESBuild's path was too specific and doesn't work in CI (e.g GitHub Actions, see https://github.com/hattipjs/hattip/pull/38)
