### PR TITLE
fix(serverless): logs not streaming to axiom

### DIFF
--- a/.changeset/famous-elephants-cry.md
+++ b/.changeset/famous-elephants-cry.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Fix logs not streaming to Axiom

--- a/crates/serverless/src/deployments/pubsub.rs
+++ b/crates/serverless/src/deployments/pubsub.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, env, sync::Arc};
 
 use anyhow::Result;
-use log::{error, warn};
+use log::{error, info, warn};
 use metrics::increment_counter;
 use s3::Bucket;
 use serde_json::Value;
@@ -40,11 +40,15 @@ async fn run(
     let mut conn = client.get_connection()?;
     let mut pub_sub = conn.as_pubsub();
 
+    info!("Redis Pub/Sub connected");
+
     pub_sub.subscribe("deploy")?;
     pub_sub.subscribe("undeploy")?;
     pub_sub.subscribe("promote")?;
 
     loop {
+        tokio::task::yield_now().await;
+
         let msg = pub_sub.get_message()?;
         let channel = msg.get_channel_name();
         let payload: String = msg.get_payload()?;

--- a/crates/serverless/src/deployments/pubsub.rs
+++ b/crates/serverless/src/deployments/pubsub.rs
@@ -40,8 +40,6 @@ async fn run(
     let mut conn = client.get_connection()?;
     let mut pub_sub = conn.as_pubsub();
 
-    info!("Redis Pub/Sub connected");
-
     pub_sub.subscribe("deploy")?;
     pub_sub.subscribe("undeploy")?;
     pub_sub.subscribe("promote")?;

--- a/crates/serverless/src/deployments/pubsub.rs
+++ b/crates/serverless/src/deployments/pubsub.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, env, sync::Arc};
 
 use anyhow::Result;
-use log::{error, info, warn};
+use log::{error, warn};
 use metrics::increment_counter;
 use s3::Bucket;
 use serde_json::Value;


### PR DESCRIPTION
## About

Regression of https://github.com/lagonapp/lagon/pull/614

Yield between each pub/sub message to allow streaming logs to axiom.