### PR TITLE
perf(serverless,runtime,cli): use DashMap & with_capacity where possible

### DIFF
--- a/.changeset/large-rivers-cough.md
+++ b/.changeset/large-rivers-cough.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Use ThreadRng instead of creating a new StdRng every time

--- a/.changeset/loud-seahorses-yell.md
+++ b/.changeset/loud-seahorses-yell.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Use DashMap instead of RwLock<HashMap>

--- a/.changeset/swift-tables-grow.md
+++ b/.changeset/swift-tables-grow.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/runtime': patch
+---
+
+Create HashMap with_capacity to avoid reallocations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,13 +610,14 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "dashmap"
-version = "5.3.4"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
  "hashbrown",
  "lock_api",
+ "once_cell",
  "parking_lot_core",
 ]
 
@@ -1493,6 +1494,7 @@ name = "lagon-serverless"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dashmap",
  "dotenv",
  "flume",
  "hyper",
@@ -1662,9 +1664,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2076,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -158,7 +158,15 @@ impl Request {
     }
 
     pub async fn from_hyper(request: HyperRequest<Body>) -> Result<Self> {
-        let mut headers = HashMap::<String, Vec<String>>::new();
+        Self::from_hyper_with_capacity(request, 0).await
+    }
+
+    pub async fn from_hyper_with_capacity(
+        request: HyperRequest<Body>,
+        capacity: usize,
+    ) -> Result<Self> {
+        let mut headers =
+            HashMap::<String, Vec<String>>::with_capacity(request.headers().keys_len() + capacity);
 
         for (key, value) in request.headers().iter() {
             if key != X_LAGON_ID {

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -159,7 +159,8 @@ impl Response {
     }
 
     pub async fn from_hyper(response: HyperResponse<Body>) -> Result<Self> {
-        let mut headers = HashMap::<String, Vec<String>>::new();
+        let mut headers =
+            HashMap::<String, Vec<String>>::with_capacity(response.headers().keys_len());
 
         for (key, value) in response.headers().iter() {
             headers

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -39,7 +39,7 @@ pub fn handle_asset(root: PathBuf, asset: &String) -> Result<Response> {
         },
     );
 
-    let mut headers = HashMap::new();
+    let mut headers = HashMap::with_capacity(1);
     headers.insert("content-type".into(), vec![content_type.into()]);
 
     Ok(Response {

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -32,10 +32,11 @@ pub fn extract_v8_headers_object(
     let map = unsafe { v8::Local::<v8::Map>::cast(value) };
 
     if map.size() > 0 {
-        let mut headers = HashMap::new();
         let headers_keys = map.as_array(scope);
+        let length = headers_keys.length();
+        let mut headers = HashMap::with_capacity((length / 2) as usize);
 
-        for mut index in 0..headers_keys.length() {
+        for mut index in 0..length {
             if index % 2 != 0 {
                 continue;
             }

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -26,6 +26,7 @@ rand = { version = "0.8.5", features = ["std_rng"] }
 anyhow = "1.0.69"
 tokio-cron-scheduler = "0.9.4"
 uuid = "1.3.0"
+dashmap = "5.4.0"
 
 [build-dependencies]
 lagon-runtime = { path = "../runtime" }

--- a/crates/serverless/src/worker.rs
+++ b/crates/serverless/src/worker.rs
@@ -6,7 +6,7 @@ use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
 use lagon_runtime_utils::Deployment;
 use log::{error, info};
 use metrics::{decrement_gauge, histogram, increment_gauge};
-use rand::{Rng, SeedableRng};
+use rand::{thread_rng, Rng};
 use tokio_util::task::LocalPoolHandle;
 
 use crate::{REGION, SNAPSHOT_BLOB, WORKERS};
@@ -41,10 +41,7 @@ pub fn create_workers() -> Workers {
 pub fn get_thread_id(thread_ids: Arc<DashMap<String, usize>>, hostname: String) -> usize {
     *thread_ids
         .entry(hostname)
-        .or_insert_with(|| {
-            let mut rng = rand::rngs::StdRng::from_entropy();
-            rng.gen_range(0..*WORKERS)
-        })
+        .or_insert_with(|| thread_rng().gen_range(0..*WORKERS))
         .value()
 }
 

--- a/crates/serverless/src/worker.rs
+++ b/crates/serverless/src/worker.rs
@@ -1,18 +1,17 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use dashmap::DashMap;
 use lagon_runtime_http::{Request, RunResult};
 use lagon_runtime_isolate::{options::IsolateOptions, Isolate};
 use lagon_runtime_utils::Deployment;
 use log::{error, info};
 use metrics::{decrement_gauge, histogram, increment_gauge};
 use rand::{Rng, SeedableRng};
-use tokio::sync::RwLock;
 use tokio_util::task::LocalPoolHandle;
 
 use crate::{REGION, SNAPSHOT_BLOB, WORKERS};
 
-pub type Workers =
-    Arc<RwLock<HashMap<usize, (flume::Sender<WorkerEvent>, flume::Receiver<WorkerEvent>)>>>;
+pub type Workers = Arc<DashMap<usize, (flume::Sender<WorkerEvent>, flume::Receiver<WorkerEvent>)>>;
 
 pub enum WorkerEvent {
     Request {
@@ -28,43 +27,32 @@ pub enum WorkerEvent {
     },
 }
 
-pub async fn create_workers() -> Workers {
-    let workers = Arc::new(RwLock::new(HashMap::new()));
+pub fn create_workers() -> Workers {
+    let workers = Arc::new(DashMap::new());
 
     for i in 0..*WORKERS {
         let worker = flume::unbounded();
-        workers.write().await.insert(i, worker);
+        workers.insert(i, worker);
     }
 
     workers
 }
 
-pub async fn get_thread_id(
-    thread_ids: Arc<RwLock<HashMap<String, usize>>>,
-    hostname: &String,
-) -> usize {
-    let thread_ids_reader = thread_ids.read().await;
-
-    let thread_id = match thread_ids_reader.get(hostname) {
-        Some(thread_id) => *thread_id,
-        None => {
+pub fn get_thread_id(thread_ids: Arc<DashMap<String, usize>>, hostname: String) -> usize {
+    *thread_ids
+        .entry(hostname)
+        .or_insert_with(|| {
             let mut rng = rand::rngs::StdRng::from_entropy();
-            let id = rng.gen_range(0..*WORKERS);
-
-            drop(thread_ids_reader);
-
-            thread_ids.write().await.insert(hostname.clone(), id);
-            id
-        }
-    };
-
-    thread_id
+            rng.gen_range(0..*WORKERS)
+        })
+        .value()
 }
 
 pub async fn start_workers(workers: Workers) {
     let pool = LocalPoolHandle::new(*WORKERS);
 
-    for (id, worker) in workers.read().await.iter() {
+    for worker in workers.iter() {
+        let (id, worker) = worker.pair();
         let id = *id;
         let receiver = worker.1.clone();
 


### PR DESCRIPTION
## About

Improve performance in serverless, runtime, and cli by:
- using `DashMap` instead of `RwLock<HashMap>`
- using `HashMap::with_capacity` where possible
- using `ThreadRng` instead of creating a new `StdRng` every time
