### PR TITLE
refactor(serverless): clean pubsub code

### DIFF
--- a/crates/serverless/src/deployments/downloader/fake.rs
+++ b/crates/serverless/src/deployments/downloader/fake.rs
@@ -15,9 +15,3 @@ impl Downloader for FakeDownloader {
         Ok(bytes)
     }
 }
-
-impl Clone for FakeDownloader {
-    fn clone(&self) -> Self {
-        Self {}
-    }
-}

--- a/crates/serverless/src/deployments/downloader/mod.rs
+++ b/crates/serverless/src/deployments/downloader/mod.rs
@@ -8,6 +8,6 @@ pub use fake::FakeDownloader;
 pub use s3_bucket::S3BucketDownloader;
 
 #[async_trait]
-pub trait Downloader: Sync + Clone {
+pub trait Downloader {
     async fn download(&self, path: String) -> Result<Vec<u8>>;
 }

--- a/crates/serverless/src/deployments/downloader/s3_bucket.rs
+++ b/crates/serverless/src/deployments/downloader/s3_bucket.rs
@@ -14,14 +14,6 @@ impl S3BucketDownloader {
     }
 }
 
-impl Clone for S3BucketDownloader {
-    fn clone(&self) -> Self {
-        Self {
-            bucket: self.bucket.clone(),
-        }
-    }
-}
-
 #[async_trait]
 impl Downloader for S3BucketDownloader {
     async fn download(&self, path: String) -> Result<Vec<u8>> {

--- a/crates/serverless/src/deployments/mod.rs
+++ b/crates/serverless/src/deployments/mod.rs
@@ -26,7 +26,7 @@ pub mod pubsub;
 
 pub type Deployments = Arc<DashMap<String, Arc<Deployment>>>;
 
-pub async fn download_deployment<D>(deployment: &Deployment, downloader: D) -> Result<()>
+pub async fn download_deployment<D>(deployment: &Deployment, downloader: Arc<D>) -> Result<()>
 where
     D: Downloader,
 {
@@ -72,7 +72,7 @@ type QueryResult = (
 
 pub async fn get_deployments<D>(
     mut conn: PooledConn,
-    downloader: D,
+    downloader: Arc<D>,
     cronjob: Arc<Mutex<Cronjob>>,
 ) -> Result<Deployments>
 where
@@ -179,7 +179,8 @@ OR
 
         for deployment in deployments_list {
             if !deployment.has_code() {
-                if let Err(error) = download_deployment(&deployment, downloader.clone()).await {
+                if let Err(error) = download_deployment(&deployment, Arc::clone(&downloader)).await
+                {
                     error!("Failed to download deployment {}: {}", deployment.id, error);
                     continue;
                 }

--- a/crates/serverless/src/deployments/pubsub/fake.rs
+++ b/crates/serverless/src/deployments/pubsub/fake.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 
 pub struct FakePubSub {
-    tx: flume::Sender<(PubSubMessage, String)>,
-    rx: flume::Receiver<(PubSubMessage, String)>,
+    tx: flume::Sender<PubSubMessage>,
+    rx: flume::Receiver<PubSubMessage>,
 }
 
 impl FakePubSub {
@@ -15,7 +15,7 @@ impl FakePubSub {
         Self { tx, rx }
     }
 
-    pub fn get_tx(&self) -> flume::Sender<(PubSubMessage, String)> {
+    pub fn get_tx(&self) -> flume::Sender<PubSubMessage> {
         self.tx.clone()
     }
 }
@@ -32,9 +32,7 @@ impl PubSubListener for FakePubSub {
         Ok(())
     }
 
-    fn get_stream(
-        &mut self,
-    ) -> Box<dyn Stream<Item = (PubSubMessage, String)> + Unpin + Send + '_> {
+    fn get_stream(&mut self) -> Box<dyn Stream<Item = PubSubMessage> + Unpin + Send + '_> {
         Box::new(self.rx.clone().into_stream().boxed())
     }
 }

--- a/crates/serverless/src/deployments/pubsub/redis.rs
+++ b/crates/serverless/src/deployments/pubsub/redis.rs
@@ -41,14 +41,12 @@ impl PubSubListener for RedisPubSub {
         Ok(())
     }
 
-    fn get_stream(
-        &mut self,
-    ) -> Box<dyn Stream<Item = (PubSubMessage, String)> + Unpin + Send + '_> {
+    fn get_stream(&mut self) -> Box<dyn Stream<Item = PubSubMessage> + Unpin + Send + '_> {
         Box::new(self.pubsub.as_mut().unwrap().on_message().map(|msg| {
-            let channel = msg.get_channel_name().to_string().into();
+            let kind = msg.get_channel_name().to_string().into();
             let payload = msg.get_payload::<String>().unwrap();
 
-            (channel, payload)
+            PubSubMessage { kind, payload }
         }))
     }
 }

--- a/crates/serverless/src/serverless.rs
+++ b/crates/serverless/src/serverless.rs
@@ -237,7 +237,7 @@ async fn handle_request(
 pub async fn start<D, P>(
     deployments: Deployments,
     addr: SocketAddr,
-    downloader: D,
+    downloader: Arc<D>,
     pubsub: P,
     cronjob: Arc<Mutex<Cronjob>>,
 ) -> Result<impl Future<Output = ()> + Send>
@@ -254,7 +254,7 @@ where
     let pubsub = Arc::new(Mutex::new(pubsub));
 
     listen_pub_sub(
-        downloader.clone(),
+        Arc::clone(&downloader),
         Arc::clone(&deployments),
         Arc::clone(&workers),
         Arc::clone(&cronjob),

--- a/crates/serverless/src/serverless.rs
+++ b/crates/serverless/src/serverless.rs
@@ -242,7 +242,7 @@ pub async fn start<D, P>(
     cronjob: Arc<Mutex<Cronjob>>,
 ) -> Result<impl Future<Output = ()> + Send>
 where
-    D: Downloader + Send + 'static,
+    D: Downloader + Send + Sync + 'static,
     P: PubSubListener + Unpin + 'static,
 {
     let last_requests = Arc::new(DashMap::new());

--- a/crates/serverless/tests/assets.rs
+++ b/crates/serverless/tests/assets.rs
@@ -39,7 +39,7 @@ async fn html_assets() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -94,7 +94,7 @@ async fn assets_nested() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -146,7 +146,7 @@ async fn set_content_type() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )

--- a/crates/serverless/tests/deployments.rs
+++ b/crates/serverless/tests/deployments.rs
@@ -39,7 +39,7 @@ async fn simple() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -76,7 +76,7 @@ async fn custom_domains() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -123,7 +123,7 @@ async fn reuse_isolate() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -164,7 +164,7 @@ async fn reuse_isolate_across_domains() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )

--- a/crates/serverless/tests/errors.rs
+++ b/crates/serverless/tests/errors.rs
@@ -25,7 +25,7 @@ async fn return_404_no_deployment_found() -> Result<()> {
     let serverless = start(
         Arc::new(DashMap::new()),
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -63,7 +63,7 @@ async fn return_403_cron_deployment() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -101,7 +101,7 @@ async fn return_500_unknown_code() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -139,7 +139,7 @@ async fn return_502_timeout() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -177,7 +177,7 @@ async fn return_500_code_invalid() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -215,7 +215,7 @@ async fn return_500_throw_error() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )

--- a/crates/serverless/tests/pubsub.rs
+++ b/crates/serverless/tests/pubsub.rs
@@ -5,7 +5,7 @@ use lagon_serverless::{
     cronjob::Cronjob,
     deployments::{
         downloader::FakeDownloader,
-        pubsub::{FakePubSub, PubSubMessage},
+        pubsub::{FakePubSub, PubSubMessage, PubSubMessageKind},
     },
     serverless::start,
 };
@@ -24,7 +24,7 @@ async fn deploy_undeploy() -> Result<()> {
     let serverless = start(
         Arc::new(DashMap::new()),
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         pubsub,
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -35,8 +35,8 @@ async fn deploy_undeploy() -> Result<()> {
     assert_eq!(response.status(), 404);
     assert_eq!(response.text().await?, PAGE_404);
 
-    tx.send_async((
-        PubSubMessage::Deploy,
+    tx.send_async(PubSubMessage::new(
+        PubSubMessageKind::Deploy,
         r#"{
     "functionId": "function_id",
     "functionName": "function_name",
@@ -60,8 +60,8 @@ async fn deploy_undeploy() -> Result<()> {
     assert_eq!(response.status(), 200);
     assert_eq!(response.text().await?, "Hello world");
 
-    tx.send_async((
-        PubSubMessage::Undeploy,
+    tx.send_async(PubSubMessage::new(
+        PubSubMessageKind::Undeploy,
         r#"{
     "functionId": "function_id",
     "functionName": "function_name",
@@ -97,15 +97,15 @@ async fn assign_correct_domains_prod() -> Result<()> {
     let serverless = start(
         Arc::new(DashMap::new()),
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         pubsub,
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
     .await?;
     tokio::spawn(serverless);
 
-    tx.send_async((
-        PubSubMessage::Deploy,
+    tx.send_async(PubSubMessage::new(
+        PubSubMessageKind::Deploy,
         r#"{
     "functionId": "function_id",
     "functionName": "function_name",
@@ -158,15 +158,15 @@ async fn assign_correct_domains_dev() -> Result<()> {
     let serverless = start(
         Arc::new(DashMap::new()),
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         pubsub,
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
     .await?;
     tokio::spawn(serverless);
 
-    tx.send_async((
-        PubSubMessage::Deploy,
+    tx.send_async(PubSubMessage::new(
+        PubSubMessageKind::Deploy,
         r#"{
     "functionId": "function_id",
     "functionName": "function_name",
@@ -219,15 +219,15 @@ async fn skip_cron_not_same_region() -> Result<()> {
     let serverless = start(
         Arc::new(DashMap::new()),
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         pubsub,
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
     .await?;
     tokio::spawn(serverless);
 
-    tx.send_async((
-        PubSubMessage::Deploy,
+    tx.send_async(PubSubMessage::new(
+        PubSubMessageKind::Deploy,
         r#"{
     "functionId": "function_id",
     "functionName": "function_name",
@@ -263,15 +263,15 @@ async fn warn_cron_direct_access() -> Result<()> {
     let serverless = start(
         Arc::new(DashMap::new()),
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         pubsub,
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
     .await?;
     tokio::spawn(serverless);
 
-    tx.send_async((
-        PubSubMessage::Deploy,
+    tx.send_async(PubSubMessage::new(
+        PubSubMessageKind::Deploy,
         r#"{
     "functionId": "function_id",
     "functionName": "function_name",

--- a/crates/serverless/tests/requests.rs
+++ b/crates/serverless/tests/requests.rs
@@ -41,7 +41,7 @@ async fn returns_correct_http() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -82,7 +82,7 @@ async fn returns_correct_path() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -131,7 +131,7 @@ async fn forwards_headers() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )
@@ -171,7 +171,7 @@ async fn stream_sequentially() -> Result<()> {
     let serverless = start(
         deployments,
         "127.0.0.1:4000".parse().unwrap(),
-        FakeDownloader,
+        Arc::new(FakeDownloader),
         FakePubSub::default(),
         Arc::new(Mutex::new(Cronjob::new().await)),
     )


### PR DESCRIPTION
## About

- Replace `(PubSubMessage, String)` tuple by a new `PubSubMessage` struct, and rename the old `PubSubMessage` enum to `PubSubMessageKind`
- Remove `Clone` impl from `Downloader` and use an `Arc` instead

