### PR TITLE
fix(www): set body `background-color`

### DIFF
--- a/.changeset/proud-roses-allow.md
+++ b/.changeset/proud-roses-allow.md
@@ -1,0 +1,5 @@
+---
+'@lagon/www': patch
+---
+
+Avoid white blank space when scrolling to the top/bottom of the page

--- a/www/styles/globals.css
+++ b/www/styles/globals.css
@@ -8,6 +8,7 @@ html {
 
 body {
   overflow-x: hidden;
+  background-color: #050211;
 }
 
 *::selection {


### PR DESCRIPTION
Add a `background-color` to the body to avoid white blank space when scrolling to the top/bottom of the page ❤️