### PR TITLE
fix(runtime): terminate isolates with 2 heartbeats missed

### DIFF
--- a/.changeset/early-elephants-repeat.md
+++ b/.changeset/early-elephants-repeat.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Terminate isolates with 2 heartbeats missed


### PR DESCRIPTION
## About

Isolates are terminated when they miss at least two heartbeats. The heartbeat missed count isn't reset to zero when a heartbeat has been successfully received: instead, the heartbeat missed count is decremented by one, allowing to safely terminate faulty isolates that are stuck in an infinite loop, and not randomly terminate isolates that just happen to be "slow"