### PR TITLE
fix(runtime): block thread while waiting for new requests

### DIFF
--- a/.changeset/modern-peaches-repair.md
+++ b/.changeset/modern-peaches-repair.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Block thread while waiting for new requests

--- a/crates/runtime/tests/allow_codegen.rs
+++ b/crates/runtime/tests/allow_codegen.rs
@@ -6,41 +6,35 @@ mod utils;
 #[tokio::test]
 async fn allow_eval() {
     utils::setup_allow_codegen();
-    let (mut isolate, send, receiver) =
-        utils::create_isolate_without_snapshot(IsolateOptions::new(
-            "export function handler() {
+    let (send, receiver) = utils::create_isolate_without_snapshot(IsolateOptions::new(
+        "export function handler() {
 const result = eval('1 + 1')
 return new Response(result)
 }"
-            .into(),
-        ));
+        .into(),
+    ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("2")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("2"))
+    );
 }
 
 #[tokio::test]
 async fn allow_function() {
     utils::setup_allow_codegen();
-    let (mut isolate, send, receiver) =
-        utils::create_isolate_without_snapshot(IsolateOptions::new(
-            "export function handler() {
+    let (send, receiver) = utils::create_isolate_without_snapshot(IsolateOptions::new(
+        "export function handler() {
     const result = new Function('return 1 + 1')
     return new Response(result())
 }"
-            .into(),
-        ));
+        .into(),
+    ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("2")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("2"))
+    );
 }

--- a/crates/runtime/tests/crypto.rs
+++ b/crates/runtime/tests/crypto.rs
@@ -6,7 +6,7 @@ mod utils;
 #[tokio::test]
 async fn crypto_random_uuid() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     const uuid = crypto.randomUUID();
     const secondUuid = crypto.randomUUID();
@@ -16,18 +16,16 @@ async fn crypto_random_uuid() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("string 36 false")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("string 36 false"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_get_random_values() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     const typedArray = new Uint8Array([0, 8, 2]);
     const result = crypto.getRandomValues(typedArray);
@@ -37,18 +35,16 @@ async fn crypto_get_random_values() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("false 3 3")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("false 3 3"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_get_random_values_throw_not_typedarray() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     const result = crypto.getRandomValues(true);
     return new Response(`${result == typedArray} ${typedArray.length} ${result.length}`);
@@ -57,21 +53,19 @@ async fn crypto_get_random_values_throw_not_typedarray() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught TypeError: Parameter 1 is not of type 'TypedArray'\n  at handler (2:27)"
-                    .to_string()
-            ));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error(
+            "Uncaught TypeError: Parameter 1 is not of type 'TypedArray'\n  at handler (2:27)"
+                .to_string()
+        )
+    );
 }
 
 #[tokio::test]
 async fn crypto_key_value() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const { keyValue } = await crypto.subtle.importKey(
         'raw',
@@ -87,18 +81,16 @@ async fn crypto_key_value() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("object 32")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("object 32"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_unique_key_value() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const { keyValue: first } = await crypto.subtle.importKey(
         'raw',
@@ -121,18 +113,16 @@ async fn crypto_unique_key_value() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("false")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("false"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_sign() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
@@ -152,18 +142,16 @@ async fn crypto_sign() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("true 32")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("true 32"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_verify() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
@@ -187,18 +175,16 @@ async fn crypto_verify() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("true")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("true"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_digest_sha1() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const digest = await crypto.subtle.digest('SHA-1', new TextEncoder().encode('hello, world'));
 
@@ -208,18 +194,18 @@ async fn crypto_digest_sha1() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("20 183,226,62,194,154,242,43,11,78,65,218,49,232,104,213,114,38,18,28,132")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from(
+            "20 183,226,62,194,154,242,43,11,78,65,218,49,232,104,213,114,38,18,28,132"
+        ))
+    );
 }
 
 #[tokio::test]
 async fn crypto_digest_string() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode('hello, world'));
 
@@ -229,18 +215,13 @@ async fn crypto_digest_string() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91")));
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Response(Response::from("32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91")));
 }
 
 #[tokio::test]
 async fn crypto_digest_object() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const digest = await crypto.subtle.digest({ name: 'SHA-256' }, new TextEncoder().encode('hello, world'));
 
@@ -250,18 +231,13 @@ async fn crypto_digest_object() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91")));
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Response(Response::from("32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91")));
 }
 
 #[tokio::test]
 async fn crypto_encrypt() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
@@ -284,18 +260,16 @@ async fn crypto_encrypt() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("true 28")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("true 28"))
+    );
 }
 
 #[tokio::test]
 async fn crypto_decrypt() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const key = await crypto.subtle.importKey(
         'raw',
@@ -324,10 +298,8 @@ async fn crypto_decrypt() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("hello, world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("hello, world"))
+    );
 }

--- a/crates/runtime/tests/disallow_codegen.rs
+++ b/crates/runtime/tests/disallow_codegen.rs
@@ -6,7 +6,7 @@ mod utils;
 #[tokio::test]
 async fn disallow_eval() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     const result = eval('1 + 1')
     return new Response(result)
@@ -15,20 +15,15 @@ async fn disallow_eval() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught EvalError: Code generation from strings disallowed for this context\n  at handler (2:20)".into()
-            ));
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Error(
+        "Uncaught EvalError: Code generation from strings disallowed for this context\n  at handler (2:20)".into()
+    ));
 }
 
 #[tokio::test]
 async fn disallow_function() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     const result = new Function('return 1 + 1')
     return new Response(result())
@@ -37,12 +32,7 @@ async fn disallow_function() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught EvalError: Code generation from strings disallowed for this context\n  at handler (2:20)".into()
-            ));
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Error(
+        "Uncaught EvalError: Code generation from strings disallowed for this context\n  at handler (2:20)".into()
+    ));
 }

--- a/crates/runtime/tests/errors.rs
+++ b/crates/runtime/tests/errors.rs
@@ -7,41 +7,37 @@ mod utils;
 #[tokio::test]
 async fn no_handler() {
     utils::setup();
-    let (mut isolate, send, receiver) =
+    let (send, receiver) =
         utils::create_isolate(IsolateOptions::new("console.log('Hello')".into()));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught Error: Handler function is not defined or is not a function".into()
-            ));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error(
+            "Uncaught Error: Handler function is not defined or is not a function".into()
+        )
+    );
 }
 
 #[tokio::test]
 async fn handler_not_function() {
     utils::setup();
-    let (mut isolate, send, receiver) =
+    let (send, receiver) =
         utils::create_isolate(IsolateOptions::new("export const handler = 'Hello'".into()));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught Error: Handler function is not defined or is not a function".into()
-            ));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error(
+            "Uncaught Error: Handler function is not defined or is not a function".into()
+        )
+    );
 }
 
 #[tokio::test]
 async fn handler_reject() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     throw new Error('Rejected');
 }"
@@ -49,20 +45,16 @@ async fn handler_reject() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught Error: Rejected\n  at handler (2:11)".into()
-            ));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: Rejected\n  at handler (2:11)".into())
+    );
 }
 
 #[tokio::test]
 async fn compilation_error() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     this syntax is invalid
 }"
@@ -70,20 +62,16 @@ async fn compilation_error() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught SyntaxError: Unexpected identifier 'syntax'".into()
-            ));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught SyntaxError: Unexpected identifier 'syntax'".into())
+    );
 }
 
 #[tokio::test]
 async fn import_errors() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "import test from 'test';
 
 export function handler() {
@@ -93,20 +81,19 @@ export function handler() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error(
-                "Uncaught Error: Can't import modules, everything should be bundled in a single file".into()
-            ));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error(
+            "Uncaught Error: Can't import modules, everything should be bundled in a single file"
+                .into()
+        )
+    );
 }
 
 #[tokio::test]
 async fn execution_timeout_reached() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     while(true) {}
     return new Response('Should not be reached');
@@ -115,18 +102,13 @@ async fn execution_timeout_reached() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Timeout);
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Timeout);
 }
 
 #[tokio::test]
 async fn init_timeout_reached() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "while(true) {}
 export function handler() {
     return new Response('Should not be reached');
@@ -135,18 +117,13 @@ export function handler() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Timeout);
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Timeout);
 }
 
 #[tokio::test]
 async fn memory_reached() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export function handler() {
     const storage = [];
@@ -168,18 +145,13 @@ async fn memory_reached() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Timeout);
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::MemoryLimit);
 }
 
 #[tokio::test]
 async fn stacktrace() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "function test(a) {
     return a() / 1;
 }
@@ -195,10 +167,5 @@ export function handler() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught TypeError: a is not a function\n  at test (2:12)\n  at first (6:12)\n  at handler (10:25)".into()));
-        }
-    }
+    assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Error("Uncaught TypeError: a is not a function\n  at test (2:12)\n  at first (6:12)\n  at handler (10:25)".into()));
 }

--- a/crates/runtime/tests/fetch.rs
+++ b/crates/runtime/tests/fetch.rs
@@ -14,7 +14,7 @@ async fn basic_fetch() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}').then(res => res.text());
     return new Response(body);
@@ -22,12 +22,10 @@ async fn basic_fetch() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
@@ -40,7 +38,7 @@ async fn request_method() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'POST'
@@ -51,12 +49,10 @@ async fn request_method() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
@@ -69,7 +65,7 @@ async fn request_method_fallback() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'UNKNOWN'
@@ -80,12 +76,10 @@ async fn request_method_fallback() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
@@ -101,25 +95,23 @@ async fn request_headers() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         headers: {{
             'x-token': 'hello'
         }}
-    }}).then(res => res.text());
+        }}).then(res => res.text());
 
     return new Response(body);
 }}"
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
@@ -135,7 +127,7 @@ async fn request_headers_class() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         headers: new Headers({{
@@ -148,12 +140,10 @@ async fn request_headers_class() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
@@ -169,7 +159,7 @@ async fn request_body() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const body = await fetch('{url}', {{
         method: 'POST',
@@ -181,12 +171,10 @@ async fn request_body() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
@@ -199,7 +187,7 @@ async fn response_headers() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = [];
@@ -216,12 +204,10 @@ async fn response_headers() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("content-length: 0 x-token: hello")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("content-length: 0 x-token: hello"))
+    );
 }
 
 #[tokio::test]
@@ -238,7 +224,7 @@ async fn response_status() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.text();
@@ -248,12 +234,10 @@ async fn response_status() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Moved: 200")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Moved: 200"))
+    );
 }
 
 #[tokio::test]
@@ -266,7 +250,7 @@ async fn response_json() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.json();
@@ -276,12 +260,10 @@ async fn response_json() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from(r#"object {"hello":"world"}"#)));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from(r#"object {"hello":"world"}"#))
+    );
 }
 
 #[tokio::test]
@@ -294,7 +276,7 @@ async fn response_array_buffer() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const response = await fetch('{url}');
     const body = await response.arrayBuffer();
@@ -304,18 +286,16 @@ async fn response_array_buffer() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello, World")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello, World"))
+    );
 }
 
 #[tokio::test]
 async fn throw_invalid_url() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const response = await fetch('doesnotexist');
     const body = await response.text();
@@ -326,18 +306,16 @@ async fn throw_invalid_url() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught Error: client requires absolute-form URIs".into()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: client requires absolute-form URIs".into())
+    );
 }
 
 #[tokio::test]
 async fn throw_invalid_header() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const response = await fetch('http://localhost:5555/', {
         headers: {
@@ -352,12 +330,10 @@ async fn throw_invalid_header() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught Error: failed to parse header value".into()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: failed to parse header value".into())
+    );
 }
 
 #[tokio::test]
@@ -370,7 +346,7 @@ async fn abort_signal() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const controller = new AbortController();
     const signal = controller.signal;
@@ -387,12 +363,10 @@ async fn abort_signal() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Aborted")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Aborted"))
+    );
 }
 
 #[tokio::test]
@@ -405,7 +379,7 @@ async fn redirect() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
@@ -413,12 +387,10 @@ async fn redirect() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("200")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("200"))
+    );
 }
 
 #[tokio::test]
@@ -435,7 +407,7 @@ async fn redirect_relative_url() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
@@ -443,12 +415,10 @@ async fn redirect_relative_url() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("200")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("200"))
+    );
 }
 
 #[tokio::test]
@@ -460,7 +430,7 @@ async fn redirect_without_location_header() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
@@ -468,12 +438,10 @@ async fn redirect_without_location_header() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught Error: Got a redirect without Location header".into()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: Got a redirect without Location header".into())
+    );
 }
 
 #[tokio::test]
@@ -502,7 +470,7 @@ async fn redirect_loop() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "export async function handler() {{
     const status = (await fetch('{url}')).status;
     return new Response(status);
@@ -510,12 +478,10 @@ async fn redirect_loop() {
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught Error: Too many redirects".into()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: Too many redirects".into())
+    );
 }
 
 #[tokio::test]
@@ -529,7 +495,7 @@ async fn limit_fetch_calls() {
     );
     let url = server.url("/");
 
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(format!(
         "let pass = false;
 export async function handler() {{
     if (!pass) {{
@@ -545,34 +511,29 @@ export async function handler() {{
     )));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught Error: fetch() can only be called 20 times per requests".into()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: fetch() can only be called 20 times per requests".into())
+    );
 
     // Test if we can still call fetch in subsequent requests
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught Error: fetch() can only be called 20 times per requests".into()));
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("ok")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error("Uncaught Error: fetch() can only be called 20 times per requests".into())
+    );
+
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("ok"))
+    );
 }
 
 #[tokio::test]
 async fn fetch_https() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {{
     const status = (await fetch('https://google.com')).status;
     return new Response(status);
@@ -581,10 +542,8 @@ async fn fetch_https() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("200")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("200"))
+    );
 }

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -8,7 +8,7 @@ mod utils;
 #[tokio::test]
 async fn execute_function() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world');
 }"
@@ -16,18 +16,16 @@ async fn execute_function() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
 async fn execute_function_twice() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world');
 }"
@@ -35,27 +33,23 @@ async fn execute_function_twice() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
 async fn environment_variables() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export function handler() {
     return new Response(process.env.TEST);
@@ -70,18 +64,16 @@ async fn environment_variables() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
 async fn get_body() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.body);
 }"
@@ -94,18 +86,16 @@ async fn get_body() {
         url: "".into(),
     });
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
 async fn get_input() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.url);
 }"
@@ -118,18 +108,16 @@ async fn get_input() {
         url: "https://hello.world".into(),
     });
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("https://hello.world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("https://hello.world"))
+    );
 }
 
 #[tokio::test]
 async fn get_method() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.method);
 }"
@@ -142,18 +130,16 @@ async fn get_method() {
         url: "".into(),
     });
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("POST")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("POST"))
+    );
 }
 
 #[tokio::test]
 async fn get_headers() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler(request) {
     return new Response(request.headers.get('x-auth'));
 }"
@@ -170,18 +156,16 @@ async fn get_headers() {
         url: "".into(),
     });
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("token")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("token"))
+    );
 }
 
 #[tokio::test]
 async fn return_headers() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world', {
         headers: {
@@ -199,22 +183,20 @@ async fn return_headers() {
 
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response {
-                body: "Hello world".into(),
-                headers: Some(headers),
-                status: 200,
-            }));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response {
+            body: "Hello world".into(),
+            headers: Some(headers),
+            status: 200,
+        })
+    );
 }
 
 #[tokio::test]
 async fn return_headers_from_headers_api() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response('Hello world', {
         headers: new Headers({
@@ -232,22 +214,20 @@ async fn return_headers_from_headers_api() {
 
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response {
-                body: "Hello world".into(),
-                headers: Some(headers),
-                status: 200,
-            }));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response {
+            body: "Hello world".into(),
+            headers: Some(headers),
+            status: 200,
+        })
+    );
 }
 
 #[tokio::test]
 async fn return_status() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response('Moved permanently', {
         status: 302,
@@ -257,22 +237,20 @@ async fn return_status() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response {
-                body: "Moved permanently".into(),
-                headers: None,
-                status: 302,
-            }));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response {
+            body: "Moved permanently".into(),
+            headers: None,
+            status: 302,
+        })
+    );
 }
 
 #[tokio::test]
 async fn return_uint8array() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     // TextEncoder#encode returns a Uint8Array
     const body = new TextEncoder().encode('Hello world');
@@ -282,18 +260,16 @@ async fn return_uint8array() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
 async fn console_log() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     const types = ['log', 'info', 'debug', 'error', 'warn'];
 
@@ -307,18 +283,16 @@ async fn console_log() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::default()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::default())
+    );
 }
 
 #[tokio::test]
 async fn atob() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response(atob('SGVsbG8='));
 }"
@@ -326,18 +300,16 @@ async fn atob() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello"))
+    );
 }
 
 #[tokio::test]
 async fn btoa() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export function handler() {
     return new Response(btoa('Hello'));
 }"
@@ -345,10 +317,8 @@ async fn btoa() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("SGVsbG8=")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("SGVsbG8="))
+    );
 }

--- a/crates/runtime/tests/timers.rs
+++ b/crates/runtime/tests/timers.rs
@@ -7,7 +7,7 @@ mod utils;
 #[tokio::test]
 async fn set_timeout() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const test = await new Promise((resolve) => {
         setTimeout(() => {
@@ -20,12 +20,10 @@ async fn set_timeout() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("test")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("test"))
+    );
 }
 
 #[tokio::test]
@@ -33,7 +31,7 @@ async fn set_timeout() {
 async fn set_timeout_not_blocking_response() {
     utils::setup();
     let log_rx = utils::setup_logger();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export async function handler() {
     console.log('before')
@@ -50,30 +48,18 @@ async fn set_timeout_not_blocking_response() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "before".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello!")));
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "after".to_string());
-        }
-    }
+    assert_eq!(log_rx.recv_async().await.unwrap(), "before".to_string());
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello!"))
+    );
+    assert_eq!(log_rx.recv_async().await.unwrap(), "after".to_string());
 }
 
 #[tokio::test]
 async fn set_timeout_clear() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     let id;
     const test = await new Promise((resolve) => {
@@ -91,18 +77,16 @@ async fn set_timeout_clear() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("second")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("second"))
+    );
 }
 
 #[tokio::test]
 async fn set_timeout_clear_correct() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(IsolateOptions::new(
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
         "export async function handler() {
     const test = await new Promise((resolve) => {
         setTimeout(() => {
@@ -119,12 +103,10 @@ async fn set_timeout_clear_correct() {
     ));
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("first")));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("first"))
+    );
 }
 
 #[tokio::test]
@@ -132,7 +114,7 @@ async fn set_timeout_clear_correct() {
 async fn set_interval() {
     let log_rx = utils::setup_logger();
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export async function handler() {
     await new Promise(resolve => {
@@ -157,36 +139,14 @@ async fn set_interval() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "interval 1".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "interval 2".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "interval 3".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "res".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(log_rx.recv_async().await.unwrap(), "interval 1".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "interval 2".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "interval 3".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "res".to_string());
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
@@ -194,7 +154,7 @@ async fn set_interval() {
 async fn queue_microtask() {
     let log_rx = utils::setup_logger();
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export async function handler() {
     queueMicrotask(() => {
@@ -211,30 +171,18 @@ async fn queue_microtask() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "before".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "microtask".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(log_rx.recv_async().await.unwrap(), "before".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "microtask".to_string());
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }
 
 #[tokio::test]
 async fn queue_microtask_throw_not_function() {
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export async function handler() {
     queueMicrotask(true);
@@ -246,12 +194,12 @@ async fn queue_microtask_throw_not_function() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Error("Uncaught TypeError: Parameter 1 is not of type 'Function'\n  at handler (2:5)".into()));
-        }
-    }
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Error(
+            "Uncaught TypeError: Parameter 1 is not of type 'Function'\n  at handler (2:5)".into()
+        )
+    );
 }
 
 #[tokio::test]
@@ -259,7 +207,7 @@ async fn queue_microtask_throw_not_function() {
 async fn timers_order() {
     let log_rx = utils::setup_logger();
     utils::setup();
-    let (mut isolate, send, receiver) = utils::create_isolate(
+    let (send, receiver) = utils::create_isolate(
         IsolateOptions::new(
             "export async function handler() {
     queueMicrotask(() => {
@@ -287,40 +235,13 @@ async fn timers_order() {
     );
     send(Request::default());
 
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "main".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "microtask".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "promise".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "timeout".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = log_rx.recv_async() => {
-            assert_eq!(result.unwrap(), "main 2".to_string());
-        }
-    }
-    tokio::select! {
-        _ = isolate.run_event_loop() => {}
-        result = receiver.recv_async() => {
-            assert_eq!(result.unwrap(), RunResult::Response(Response::from("Hello world")));
-        }
-    }
+    assert_eq!(log_rx.recv_async().await.unwrap(), "main".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "microtask".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "promise".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "timeout".to_string());
+    assert_eq!(log_rx.recv_async().await.unwrap(), "main 2".to_string());
+    assert_eq!(
+        receiver.recv_async().await.unwrap(),
+        RunResult::Response(Response::from("Hello world"))
+    );
 }


### PR DESCRIPTION
## About

Instead of running the event loop "in the void" for nothing, maxing the CPU, we can block the thread (since each isolate runs in its own thread) while we wait for new requests.

This PR also updates the tests from `@lagon/runtime` to spawn the test isolate to a dedicated thread, and simplifies the way tests are written.
