### PR TITLE
fix(cli): allow `lagon deploy` & `lagon build` to specify files

### DIFF
--- a/.changeset/smart-hotels-camp.md
+++ b/.changeset/smart-hotels-camp.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/docs': patch
+---
+
+Allow `lagon deploy` & `lagon build` to specify files and folders

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -2,15 +2,14 @@ use std::{fs, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 
-use crate::utils::{bundle_function, debug, get_root, print_progress, success, FunctionConfig};
+use crate::utils::{bundle_function, debug, print_progress, resolve_path, success};
 
 pub fn build(
+    path: Option<PathBuf>,
     client: Option<PathBuf>,
     public_dir: Option<PathBuf>,
-    directory: Option<PathBuf>,
 ) -> Result<()> {
-    let root = get_root(directory);
-    let function_config = FunctionConfig::load(&root, client, public_dir)?;
+    let (root, function_config) = resolve_path(path, client, public_dir)?;
     let (index, assets) = bundle_function(&function_config, &root)?;
 
     let end_progress = print_progress("Writting index.js...");

--- a/crates/cli/src/commands/deploy.rs
+++ b/crates/cli/src/commands/deploy.rs
@@ -8,7 +8,7 @@ use dialoguer::{Confirm, Input, Select};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::{
-    create_deployment, debug, get_root, info, print_progress, Config, FunctionConfig, TrpcClient,
+    create_deployment, debug, info, print_progress, resolve_path, Config, TrpcClient,
 };
 
 #[derive(Deserialize, Debug)]
@@ -53,10 +53,10 @@ impl Display for Function {
 pub type FunctionsResponse = Vec<Function>;
 
 pub async fn deploy(
+    path: Option<PathBuf>,
     client: Option<PathBuf>,
     public_dir: Option<PathBuf>,
     prod: bool,
-    directory: Option<PathBuf>,
 ) -> Result<()> {
     let config = Config::new()?;
 
@@ -66,8 +66,7 @@ pub async fn deploy(
         ));
     }
 
-    let root = get_root(directory);
-    let mut function_config = FunctionConfig::load(&root, client, public_dir)?;
+    let (root, mut function_config) = resolve_path(path, client, public_dir)?;
 
     if function_config.function_id.is_empty() {
         println!("{}", debug("No deployment config found..."));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -33,6 +33,9 @@ enum Commands {
     Logout,
     /// Deploy a new or existing Function
     Deploy {
+        /// Path to a file or a directory containing a Function
+        #[clap(value_parser)]
+        path: Option<PathBuf>,
         /// Path to a client-side script
         #[clap(short, long, value_parser)]
         client: Option<PathBuf>,
@@ -42,9 +45,6 @@ enum Commands {
         /// Deploy as a production deployment
         #[clap(visible_alias = "production", long)]
         prod: bool,
-        /// Path to a directory containing a Function
-        #[clap(value_parser)]
-        directory: Option<PathBuf>,
     },
     /// Delete an existing Function
     Rm {
@@ -78,15 +78,15 @@ enum Commands {
     },
     /// Build a Function without deploying it
     Build {
+        /// Path to a file or a directory containing a Function
+        #[clap(value_parser)]
+        path: Option<PathBuf>,
         /// Path to a client-side script
         #[clap(short, long, value_parser)]
         client: Option<PathBuf>,
         /// Path to a public directory to serve assets from
         #[clap(short, long, value_parser)]
         public_dir: Option<PathBuf>,
-        /// Path to a directory containing a Function
-        #[clap(value_parser)]
-        directory: Option<PathBuf>,
     },
     /// Link a local Function file to an already deployed Function
     Link {
@@ -127,11 +127,11 @@ async fn main() {
             Commands::Login => commands::login().await,
             Commands::Logout => commands::logout(),
             Commands::Deploy {
+                path,
                 client,
                 public_dir,
                 prod,
-                directory,
-            } => commands::deploy(client, public_dir, prod, directory).await,
+            } => commands::deploy(path, client, public_dir, prod).await,
             Commands::Rm { directory } => commands::rm(directory).await,
             Commands::Dev {
                 path,
@@ -154,10 +154,10 @@ async fn main() {
                 .await
             }
             Commands::Build {
+                path,
                 client,
                 public_dir,
-                directory,
-            } => commands::build(client, public_dir, directory),
+            } => commands::build(path, client, public_dir),
             Commands::Link { directory } => commands::link(directory).await,
             Commands::Ls { directory } => commands::ls(directory).await,
             Commands::Undeploy {

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -48,7 +48,7 @@ If you then want to trigger a new Deployment, re-run the same command. By defaul
 
 This command accepts the following arguments and options:
 
-- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
+- `[PATH]` is an optional path to a file or directory containing the Function. (Default: `.`)
 - `--client, -c <CLIENT>` allows you to specify a path to an additional file to bundle as a client-side script.
 - `--public, -p <<PUBLIC_DIR>>` allows you to specify a path to a directory containing assets to be served statically.
 - `--production, --prod` allows you to deploy the Function in production mode. (Default: `false`)
@@ -58,6 +58,8 @@ Examples:
 ```bash
 # Deploy the current directory to Production
 lagon deploy --prod
+# Deploy the index.ts file
+lagon deploy ./index.ts
 # Deploy the my-project directory and override the public directory
 lagon deploy ./my-project --public ./my-project/assets
 ```
@@ -168,7 +170,7 @@ For debugging purposes, you can build a Function and see its output without depl
 
 This command accepts the following arguments and options:
 
-- `[DIRECTORY]` is an optional path to a directory containing the Function. (Default: `.`)
+- `[PATH]` is an optional path to a file or directory containing the Function. (Default: `.`)
 - `--client, -c <CLIENT>` allows you to specify a path to an additional file to bundle as a client-side script.
 - `--public, -p <<PUBLIC_DIR>>` allows you to specify a path to a directory containing assets to be served statically.
 


### PR DESCRIPTION
## About

Closes #683

Previously, only `lagon dev` allowed either files or directories containing a configuration as the first argument.

Now, `lagon deploy` and `lagon build` also work the same way, meaning you can type:
- `lagon dev/deploy/build` to use the local configuration (`.lagon/config.json`), or create a new one in the current directory
- `lagon dev/deploy/build path/to/directory` to use the configuration specified in the given path
- `lagon dev/deploy/build yourFile.ts` to not use any configuration file, making it easier to test