### PR TITLE
fix(cli): returned exit code

### DIFF
--- a/.changeset/chilly-lions-shake.md
+++ b/.changeset/chilly-lions-shake.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix returned exit code

--- a/crates/cli/npm/getBinary.js
+++ b/crates/cli/npm/getBinary.js
@@ -38,9 +38,6 @@ function getPlatform() {
 }
 
 export function getBinary() {
-  // Prevent exiting with code 1
-  process.exit = () => { };
-
   const { platform, name } = getPlatform();
   const customRequire = createRequire(import.meta.url);
 


### PR DESCRIPTION
## About

`process.exit` calls were ignored due to this override.