### PR TITLE
feat(dashboard): add a "copy" button to the tokens list

### DIFF
--- a/.changeset/dry-shrimps-hide.md
+++ b/.changeset/dry-shrimps-hide.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Add a "Copy" button to the tokens list

--- a/packages/dashboard/lib/trpc/tokensRouter.ts
+++ b/packages/dashboard/lib/trpc/tokensRouter.ts
@@ -13,6 +13,7 @@ export const tokensRouter = (t: T) =>
         },
         select: {
           id: true,
+          value: true,
           createdAt: true,
         },
         orderBy: {

--- a/packages/dashboard/locales/en.ts
+++ b/packages/dashboard/locales/en.ts
@@ -110,8 +110,11 @@ export default {
   'profile.information.success': 'Information updated successfully.',
 
   'profile.tokens.title': 'Tokens',
-  'profile.tokens.description': 'Below are your personal Tokens, used for the CLI.',
+  'profile.tokens.description':
+    'Below are your personal Tokens, used for authenticating through the CLI and the GitHub Action.',
   'profile.tokens.created': 'Created:',
+  'profile.tokens.copy': 'Copy',
+  'profile.tokens.copy.success': 'Token copied to clipboard.',
   'profile.tokens.delete.submit': 'Delete',
   'profile.tokens.delete.modal.title': 'Delete Token',
   'profile.tokens.delete.modal.description':

--- a/packages/dashboard/locales/fr.ts
+++ b/packages/dashboard/locales/fr.ts
@@ -114,8 +114,11 @@ export default defineLocale({
   'profile.information.success': 'Les informations ont été mises à jour.',
 
   'profile.tokens.title': 'Tokens',
-  'profile.tokens.description': 'Voici vos Tokens personnels, utilisés pour la CLI.',
+  'profile.tokens.description':
+    'Voici vos Tokens personnels, utilisés pour vous authentifier dans la CLI et la GitHub Action.',
   'profile.tokens.created': 'Créé :',
+  'profile.tokens.copy': 'Copier',
+  'profile.tokens.copy.success': 'Le Token a été copié dans le presse-papiers.',
   'profile.tokens.delete.submit': 'Supprimer',
   'profile.tokens.delete.modal.title': 'Supprimer un Token',
   'profile.tokens.delete.modal.description':

--- a/packages/dashboard/pages/profile.tsx
+++ b/packages/dashboard/pages/profile.tsx
@@ -7,6 +7,7 @@ import { getLocaleProps, useI18n } from 'locales';
 import { GetStaticProps } from 'next';
 import { useSession } from 'next-auth/react';
 import { Suspense, useCallback } from 'react';
+import { ClipboardIcon } from '@heroicons/react/24/outline';
 import toast from 'react-hot-toast';
 
 const Tokens = () => {
@@ -27,6 +28,11 @@ const Tokens = () => {
     [deleteToken, refetch, t],
   );
 
+  const copyToken = async (value: string) => {
+    await navigator.clipboard.writeText(value);
+    toast.success(t('tokens.copy.success'));
+  };
+
   return (
     <Card title={t('tokens.title')} description={t('tokens.description')}>
       <div>
@@ -45,22 +51,27 @@ const Tokens = () => {
                   year: 'numeric',
                 })}
               </Text>
-              <Dialog
-                title={t('tokens.delete.modal.title')}
-                description={t('tokens.delete.modal.description')}
-                disclosure={
-                  <Button variant="danger" disabled={deleteToken.isLoading}>
-                    {t('tokens.delete.submit')}
-                  </Button>
-                }
-              >
-                <Dialog.Buttons>
-                  <Dialog.Cancel disabled={deleteToken.isLoading} />
-                  <Dialog.Action variant="danger" onClick={() => removeToken(token)} disabled={deleteToken.isLoading}>
-                    {t('tokens.delete.modal.submit')}
-                  </Dialog.Action>
-                </Dialog.Buttons>
-              </Dialog>
+              <div className="flex gap-2 md:w-1/3 md:justify-end">
+                <Button leftIcon={<ClipboardIcon className="h-4 w-4" />} onClick={() => copyToken(token.value)}>
+                  {t('tokens.copy')}
+                </Button>
+                <Dialog
+                  title={t('tokens.delete.modal.title')}
+                  description={t('tokens.delete.modal.description')}
+                  disclosure={
+                    <Button variant="danger" disabled={deleteToken.isLoading}>
+                      {t('tokens.delete.submit')}
+                    </Button>
+                  }
+                >
+                  <Dialog.Buttons>
+                    <Dialog.Cancel disabled={deleteToken.isLoading} />
+                    <Dialog.Action variant="danger" onClick={() => removeToken(token)} disabled={deleteToken.isLoading}>
+                      {t('tokens.delete.modal.submit')}
+                    </Dialog.Action>
+                  </Dialog.Buttons>
+                </Dialog>
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## About

Closes #699

Add a "Copy" button to the tokens list, useful when using the [GitHub Action](https://github.com/lagonapp/github-action/) instead of authenticating and searching manually in `~/.lagon/config.json`. A success toast is displayed when copying a token.

| Before | After |
|---|---|
| ![Image](https://user-images.githubusercontent.com/43268759/227763078-881f8bd8-d413-44d2-9d6e-964d0ad6fd0a.png) | ![Screenshot 2023-04-01 at 11 01 11](https://user-images.githubusercontent.com/43268759/229276658-7f56da93-cb24-4a0c-8177-c2503af71b23.png) |



