### PR TITLE
feat(cli): add `worker` import condition

### DIFF
--- a/.changeset/clever-bananas-agree.md
+++ b/.changeset/clever-bananas-agree.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Add a `worker` import condition after `lagon` when bundling

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -223,7 +223,7 @@ fn esbuild(file: &Path, root: &Path) -> Result<Vec<u8>> {
         .arg("--format=esm")
         .arg("--target=esnext")
         .arg("--platform=browser")
-        .arg("--conditions=lagon")
+        .arg("--conditions=lagon,worker")
         .arg("--loader:.wasm=binary")
         .output()?;
 


### PR DESCRIPTION
## About

Relates to https://github.com/lagonapp/lagon/issues/743

vite-plugin-ssr has the following conditions:

![Screenshot 2023-04-09 at 14 20 16](https://user-images.githubusercontent.com/43268759/230772146-ebab5324-0b29-401b-99f3-b4ab207d6b9f.png)

Since Lagon uses the browser platform to bundle using ESBuild, it tried to import the wrong file using the `browser` condition.
