### PR TITLE
fix(www): client-side fetching for status badge

### DIFF
--- a/.changeset/sharp-yaks-exist.md
+++ b/.changeset/sharp-yaks-exist.md
@@ -1,0 +1,5 @@
+---
+'@lagon/www': patch
+---
+
+Switch to client-side fetching for the status badge

--- a/www/lib/components/Footer.tsx
+++ b/www/lib/components/Footer.tsx
@@ -49,7 +49,6 @@ export const Footer = () => {
           <Text size="a" href="/pricing">
             Pricing
           </Text>
-          {/* @ts-expect-error RSC */}
           <StatusBadge />
         </FooterSection>
         <FooterSection title="Community">

--- a/www/lib/components/StatusBadge.tsx
+++ b/www/lib/components/StatusBadge.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import { Text } from './Text';
 
 type Status = 'up' | 'incident' | 'outage' | 'maintenance';
@@ -16,15 +19,19 @@ const STATUS_TO_TEXT: Record<Status, string> = {
   maintenance: 'Under maintenance',
 };
 
-async function getStatus() {
-  const res = await fetch(`https://status.lagon.app/status.json`, { next: { revalidate: 60 } });
-  const data = await res.json();
+export const StatusBadge = () => {
+  const [status, setStatus] = useState<Status>('up');
 
-  return data.indicator as Status;
-}
-
-export const StatusBadge = async () => {
-  const status = await getStatus();
+  useEffect(() => {
+    fetch('https://status.lagon.app/status.json')
+      .then(res => res.json())
+      .then(data => {
+        setStatus(data.indicator);
+      })
+      .catch(error => {
+        console.error(error);
+      });
+  }, []);
 
   return (
     <Text size="a" href="https://status.lagon.app" target="_blank">


### PR DESCRIPTION
## About

Fix https://twitter.com/tomlienard/status/1645462410185121793

Fetching the status using `{ next: { revalidate: 60 } }` on the server causes Vercel to create an ISR function, invoking it every minute (60 seconds) and causing abnormal bandwidth/functions usage.

This PR switch to client-side fetching to make sure the site is fully static and never use any function.