### PR TITLE
perf(serverless): download deployments in parallel

### DIFF
--- a/.changeset/quiet-days-begin.md
+++ b/.changeset/quiet-days-begin.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Download deployments in parallel

--- a/crates/serverless/src/deployments/mod.rs
+++ b/crates/serverless/src/deployments/mod.rs
@@ -169,31 +169,21 @@ OR
         error!("Failed to delete old deployments: {:?}", error);
     }
 
-    {
-        // let mut cronjob = cronjob.lock().await;
-
-        for deployment in deployments_list {
-            if !deployment.has_code() {
-                if let Err(error) = download_deployment(&deployment, Arc::clone(&downloader)).await
-                {
-                    error!("Failed to download deployment {}: {}", deployment.id, error);
-                    continue;
-                }
+    futures::future::join_all(deployments_list.into_iter().map(|deployment| async {
+        if !deployment.has_code() {
+            if let Err(error) = download_deployment(&deployment, Arc::clone(&downloader)).await {
+                error!("Failed to download deployment {}: {}", deployment.id, error);
+                return;
             }
-
-            let deployment = Arc::new(deployment);
-
-            for domain in deployment.get_domains() {
-                deployments.insert(domain, Arc::clone(&deployment));
-            }
-
-            // if deployment.should_run_cron() {
-            //     if let Err(error) = cronjob.add(deployment).await {
-            //         error!("Failed to register cron: {}", error);
-            //     }
-            // }
         }
-    }
+
+        let deployment = Arc::new(deployment);
+
+        for domain in deployment.get_domains() {
+            deployments.insert(domain, Arc::clone(&deployment));
+        }
+    }))
+    .await;
 
     Ok(deployments)
 }

--- a/crates/serverless/src/deployments/mod.rs
+++ b/crates/serverless/src/deployments/mod.rs
@@ -182,6 +182,12 @@ OR
         for domain in deployment.get_domains() {
             deployments.insert(domain, Arc::clone(&deployment));
         }
+
+        // if deployment.should_run_cron() {
+        //     if let Err(error) = cronjob.add(deployment).await {
+        //         error!("Failed to register cron: {}", error);
+        //     }
+        // }
     }))
     .await;
 


### PR DESCRIPTION
## About

Download deployments (index + assets) in parallel instead of sequentially: from ~15s to ~2s to download 150 deployments
