### PR TITLE
ci: use `moonrepo/setup-rust`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: moonrepo/setup-rust@v0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: moonrepo/setup-rust@v0
+        with:
+          components: clippy
       - uses: pnpm/action-setup@v2.2.4
       - name: Use Node.js 16
         uses: actions/setup-node@v3
@@ -36,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: moonrepo/setup-rust@v0
       - uses: pnpm/action-setup@v2.2.4
       - name: Use Node.js 16
         uses: actions/setup-node@v3
@@ -69,14 +71,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-20.04
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: moonrepo/setup-rust@v0
       - uses: pnpm/action-setup@v2.2.4
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           submodules: true
       - uses: moonrepo/setup-rust@v0
+        with:
+          bins: cargo-all-features
       - uses: pnpm/action-setup@v2.2.4
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.PAT }}
-      - uses: Swatinem/rust-cache@v2
       - uses: pnpm/action-setup@v2.2.4
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -14,14 +14,11 @@ jobs:
   wpt:
     name: web-platform-tests
     runs-on: ubuntu-20.04
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: Swatinem/rust-cache@v2
+      - uses: moonrepo/setup-rust@v0
       - uses: pnpm/action-setup@v2.2.4
       - name: Use Node.js 16
         uses: actions/setup-node@v3

--- a/crates/runtime/package.json
+++ b/crates/runtime/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "cargo build",
-    "test": "cargo test && cargo test -F ignore-snapshot",
+    "test": "cargo test-all-features",
     "lint": "cargo clippy -- -Dwarnings --no-deps"
   }
 }


### PR DESCRIPTION
## About

Try https://github.com/moonrepo/setup-rust for improved caching

Also remove useless `env` in jobs because we have them globally, remove rust setup for release, use https://crates.io/crates/cargo-all-features for runtime tests
