### PR TITLE
feat(runtime,serverless,wpt): use `once_cell` instead of `lazy_static`

### DIFF
--- a/.changeset/poor-parents-fetch.md
+++ b/.changeset/poor-parents-fetch.md
@@ -1,0 +1,7 @@
+---
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+'@lagon/wpt-runner': patch
+---
+
+Use once_cell instead of lazy_static

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,9 +1696,9 @@ dependencies = [
  "lagon-runtime-crypto",
  "lagon-runtime-http",
  "lagon-runtime-v8-utils",
- "lazy_static",
  "linked-hash-map",
  "log",
+ "once_cell",
  "tokio",
  "v8",
 ]
@@ -1741,11 +1741,11 @@ dependencies = [
  "lagon-serverless-downloader",
  "lagon-serverless-logger",
  "lagon-serverless-pubsub",
- "lazy_static",
  "log",
  "metrics",
  "metrics-exporter-prometheus",
  "mysql",
+ "once_cell",
  "reqwest",
  "serde",
  "serde_json",
@@ -1798,7 +1798,7 @@ dependencies = [
  "lagon-runtime",
  "lagon-runtime-http",
  "lagon-runtime-isolate",
- "lazy_static",
+ "once_cell",
  "tokio",
 ]
 

--- a/crates/runtime_isolate/Cargo.toml
+++ b/crates/runtime_isolate/Cargo.toml
@@ -12,7 +12,7 @@ hyper-tls = { version = "0.5.0", features = ["vendored"] }
 flume = "0.10.14"
 anyhow = "1.0.70"
 log = { version = "0.4.17", features = ["std", "kv_unstable"] }
-lazy_static = "1.4.0"
+once_cell = "1.17.1"
 async-recursion = "1.0.4"
 linked-hash-map = "0.5.6"
 lagon-runtime-v8-utils = { path = "../runtime_v8_utils" }

--- a/crates/runtime_isolate/src/bindings/fetch.rs
+++ b/crates/runtime_isolate/src/bindings/fetch.rs
@@ -7,16 +7,14 @@ use hyper::{
 };
 use hyper_tls::HttpsConnector;
 use lagon_runtime_http::{FromV8, Request, Response};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 use crate::{bindings::PromiseResult, Isolate};
 
 use super::BindingResult;
 
-lazy_static! {
-    static ref CLIENT: Client<HttpsConnector<HttpConnector>> =
-        Client::builder().build::<_, Body>(HttpsConnector::new());
-}
+static CLIENT: Lazy<Client<HttpsConnector<HttpConnector>>> =
+    Lazy::new(|| Client::builder().build::<_, Body>(HttpsConnector::new()));
 
 type Arg = Request;
 

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 metrics = "0.21.0"
 metrics-exporter-prometheus = { version = "0.12.0", default-features = false, features = ["http-listener"] }
 log = { version = "0.4.17", features = ["std", "kv_unstable", "kv_unstable_serde"] }
-lazy_static = "1.4.0"
+once_cell = "1.17.1"
 anyhow = "1.0.70"
 tokio-cron-scheduler = "0.9.4"
 dashmap = "5.4.0"

--- a/crates/serverless/src/lib.rs
+++ b/crates/serverless/src/lib.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::env;
 
 // TODO add back cron jobs
@@ -7,8 +7,7 @@ pub mod clickhouse;
 pub mod deployments;
 pub mod serverless;
 
-lazy_static! {
-    pub static ref REGION: String = env::var("LAGON_REGION").expect("LAGON_REGION must be set");
-}
+pub static REGION: Lazy<String> =
+    Lazy::new(|| env::var("LAGON_REGION").expect("LAGON_REGION must be set"));
 
 pub const SNAPSHOT_BLOB: &[u8] = include_bytes!("../snapshot.bin");

--- a/crates/wpt-runner/Cargo.toml
+++ b/crates/wpt-runner/Cargo.toml
@@ -10,4 +10,4 @@ lagon-runtime-http = { path = "../runtime_http" }
 lagon-runtime-isolate = { path = "../runtime_isolate" }
 flume = "0.10.14"
 colored = "2.0.0"
-lazy_static = "1.4.0"
+once_cell = "1.17.1"

--- a/crates/wpt-runner/src/main.rs
+++ b/crates/wpt-runner/src/main.rs
@@ -2,7 +2,7 @@ use colored::*;
 use lagon_runtime::{options::RuntimeOptions, Runtime};
 use lagon_runtime_http::{Request, RunResult};
 use lagon_runtime_isolate::{options::IsolateOptions, Isolate, IsolateEvent, IsolateRequest};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -39,13 +39,13 @@ const SUPPORT_BLOB: &str = include_str!("../../../tools/wpt/FileAPI/support/Blob
 const SUPPORT_FORMDATA: &str =
     include_str!("../../../tools/wpt/FileAPI/support/send-file-formdata-helper.js");
 
-lazy_static! {
-    static ref RESULT: Mutex<(usize, usize, usize)> = Mutex::new((0, 0, 0));
-    static ref TEST_HARNESS: String = include_str!("../../../tools/wpt/resources/testharness.js")
+static RESULT: Lazy<Mutex<(usize, usize, usize)>> = Lazy::new(|| Mutex::new((0, 0, 0)));
+static TEST_HARNESS: Lazy<String> = Lazy::new(|| {
+    include_str!("../../../tools/wpt/resources/testharness.js")
         .to_owned()
         .replace("})(self);", "})(globalThis);")
-        .replace("debug: false", "debug: true");
-}
+        .replace("debug: false", "debug: true")
+});
 
 const SKIP_TESTS: [&str; 16] = [
     // request


### PR DESCRIPTION
## About

Migrate from `lazy_static` to `once_cell`, since it has been merged to Rust'std. It's currently only available in nightly, but that will be easy to remove `once_cell::Lazy` and use `std::sync::LazyLock` instead: https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html