### PR TITLE
feat(cli,docs): automatically load `.env` files with `lagon dev`

### DIFF
--- a/.changeset/twenty-bears-flash.md
+++ b/.changeset/twenty-bears-flash.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/docs': patch
+---
+
+Automatically load .env files with `lagon dev` if present in root

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -1,4 +1,4 @@
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
 use chrono::offset::Local;
 use colored::Colorize;
 use envfile::EnvFile;
@@ -180,7 +180,11 @@ pub async fn dev(
         .assets
         .as_ref()
         .map(|assets| root.join(assets));
-    let environment_variables = parse_environment_variables(&root, env)?;
+
+    let environment_variables = match parse_environment_variables(&root, env) {
+        Ok(env) => env,
+        Err(err) => return Err(anyhow!("Could not load environment variables: {:?}", err)),
+    };
 
     let (tx, rx) = flume::unbounded();
     let (index_tx, index_rx) = flume::unbounded();

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -21,7 +21,9 @@ use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
-use crate::utils::{bundle_function, error, info, input, resolve_path, success, warn, Assets};
+use crate::utils::{
+    bundle_function, debug, error, info, input, resolve_path, success, warn, Assets,
+};
 
 const LOCAL_REGION: &str = "local";
 
@@ -37,6 +39,12 @@ fn parse_environment_variables(
         for (key, value) in envfile.store {
             environment_variables.insert(key, value);
         }
+    } else if let Ok(envfile) = EnvFile::new(root.join(".env")) {
+        for (key, value) in envfile.store {
+            environment_variables.insert(key, value);
+        }
+
+        println!("{}", debug("Automatically loaded .env file..."));
     }
 
     Ok(environment_variables)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -69,7 +69,7 @@ enum Commands {
         /// Hostname to start dev server on
         #[clap(long)]
         hostname: Option<String>,
-        /// Path to a env file to parse
+        /// Path to a custom environment variables file to use
         #[clap(short, long, value_parser)]
         env: Option<PathBuf>,
         /// Allow code generation from strings using `eval` / `new Function`

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -145,7 +145,7 @@ This command accepts the following arguments and options:
 - `--public, -p <<PUBLIC_DIR>>` allows you to specify a path to a directory containing assets to be served statically.
 - `--hostname <HOSTNAME>` allows you to specify a custom hostname to start the server on. (Default: `127.0.0.1`)
 - `--port <PORT>` allows you to specify a custom port to start the server on. (Default: `1234`)
-- `--env <FILE>` allows you to specify an environment file (typically `.env`) to use to inject environment variables.
+- `--env <FILE>` allows you to specify a custom path to an environment file to inject [environment variables](/cloud/environment-variables). (Default: `.env`)
 - `--allow-code-generation` allows you to enable code generation from strings (`eval` / `new Function`)
 
 <Callout type="warning">

--- a/packages/docs/pages/cloud/environment-variables.mdx
+++ b/packages/docs/pages/cloud/environment-variables.mdx
@@ -16,7 +16,7 @@ export function handler(request: Request): Response {
 
 ## Development
 
-During development, you can use the `--env` flag of the [`dev` command](http://localhost:3000/cli#lagon-dev) to specify a `.env` file to load.
+During development, `.env` files are automatically detected and loaded. You can also manually specify the `--env` flag of the [`dev` command](http://localhost:3000/cli#lagon-dev) to use a custom path for your environment file.
 
 ## Adding environment variables
 


### PR DESCRIPTION
## About

Automatically load `.env` files with `lagon dev` if present in root. Specifying `--env <PATH>` (or `-e <PATH>`) will override and use the provided path.