### PR TITLE
feat(cli,docs): set `process.env.NODE_ENV` to "development" when using `lagon dev`

### DIFF
--- a/.changeset/popular-pigs-hide.md
+++ b/.changeset/popular-pigs-hide.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/docs': patch
+---
+
+Set `process.env.NODE_ENV` to "development" when using `lagon dev`

--- a/crates/cli/src/commands/build.rs
+++ b/crates/cli/src/commands/build.rs
@@ -10,7 +10,7 @@ pub fn build(
     public_dir: Option<PathBuf>,
 ) -> Result<()> {
     let (root, function_config) = resolve_path(path, client, public_dir)?;
-    let (index, assets) = bundle_function(&function_config, &root)?;
+    let (index, assets) = bundle_function(&function_config, &root, true)?;
 
     let end_progress = print_progress("Writting index.js...");
 

--- a/crates/cli/src/commands/deploy.rs
+++ b/crates/cli/src/commands/deploy.rs
@@ -56,7 +56,7 @@ pub async fn deploy(
     path: Option<PathBuf>,
     client: Option<PathBuf>,
     public_dir: Option<PathBuf>,
-    prod: bool,
+    is_production: bool,
 ) -> Result<()> {
     let config = Config::new()?;
 
@@ -106,7 +106,7 @@ pub async fn deploy(
                 function_config.organization_id = organization.id.clone();
                 function_config.write(&root)?;
 
-                create_deployment(config, &function_config, prod, &root).await?;
+                create_deployment(config, &function_config, is_production, &root, true).await?;
             }
             false => {
                 let name = Input::<String>::new()
@@ -136,11 +136,11 @@ pub async fn deploy(
                 function_config.organization_id = organization.id.clone();
                 function_config.write(&root)?;
 
-                create_deployment(config, &function_config, prod, &root).await?;
+                create_deployment(config, &function_config, is_production, &root, true).await?;
             }
         }
     } else {
-        create_deployment(config, &function_config, prod, &root).await?;
+        create_deployment(config, &function_config, is_production, &root, true).await?;
     }
 
     Ok(())

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -162,7 +162,7 @@ pub async fn dev(
     allow_code_generation: bool,
 ) -> Result<()> {
     let (root, function_config) = resolve_path(path, client, public_dir)?;
-    let (index, assets) = bundle_function(&function_config, &root)?;
+    let (index, assets) = bundle_function(&function_config, &root, false)?;
 
     let server_index = index.clone();
     let assets = Arc::new(Mutex::new(assets));
@@ -279,7 +279,7 @@ pub async fn dev(
                 print!("\x1B[2J\x1B[1;1H");
                 println!("{}", info("Found change, updating..."));
 
-                let (new_index, new_assets) = bundle_function(&function_config, &root)?;
+                let (new_index, new_assets) = bundle_function(&function_config, &root, false)?;
 
                 *assets.lock().await = new_assets;
                 index_tx.send_async(new_index).await.unwrap();

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -148,10 +148,7 @@ This command accepts the following arguments and options:
 - `--env <FILE>` allows you to specify a custom path to an environment file to inject [environment variables](/cloud/environment-variables). (Default: `.env`)
 - `--allow-code-generation` allows you to enable code generation from strings (`eval` / `new Function`)
 
-<Callout type="warning">
-  Although the `dev` command uses the same Runtime as when deployed, the local HTTP server itself doesn't have the same
-  optimizations. As such, you shouldn't run a production environment on it, or run any kind of load tests/benchmarks.
-</Callout>
+Unlike other commands, `lagon dev` sets `process.env.NODE_ENV` to `"development"` instead of `"production"`.
 
 Examples:
 
@@ -163,6 +160,11 @@ lagon dev ./server.tsx --public ./assets
 # Run a local dev server inside the my-project directory using a custom port
 lagon dev ./my-project --port 56565
 ```
+
+<Callout type="warning">
+  Although the `dev` command uses the same Runtime as when deployed, the local HTTP server itself doesn't have the same
+  optimizations. As such, you shouldn't run any production environment on it, or run any kind of load tests/benchmarks.
+</Callout>
 
 ### `lagon build`
 

--- a/packages/docs/pages/cloud/environment-variables.mdx
+++ b/packages/docs/pages/cloud/environment-variables.mdx
@@ -14,6 +14,8 @@ export function handler(request: Request): Response {
 }
 ```
 
+By default, it will only contain the `NODE_ENV` variable, which is set to `"production"` when deployed, and to `"development"` when using [`lagon dev`](/cli#lagon-dev).
+
 ## Development
 
 During development, `.env` files are automatically detected and loaded. You can also manually specify the `--env` flag of the [`dev` command](http://localhost:3000/cli#lagon-dev) to use a custom path for your environment file.

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -168,7 +168,9 @@ The standard `FormData` object. [See the documentation on MDN](https://developer
 
 ### `process.env`
 
-The only usage of `process` is to access environment variables. [Learn more about environment variables](/cloud/environment-variables).
+The only usage of `process` is to access environment variables. By default, it will only contain the `NODE_ENV` variable, which is set to `"production"` when deployed, and to `"development"` when using [`lagon dev`](/cli#lagon-dev).
+
+[Learn more about environment variables](/cloud/environment-variables).
 
 ### `ProgressEvent`
 


### PR DESCRIPTION
## About

Closes #786

`process.env.NODE_ENV` was always "production", even when using `lagon dev`. Now, `NODE_ENV` will be set to  "development" when using `lagon dev`, and "production" when deployed.