### PR TITLE
feat(cli,docs): add `--prod` to `lagon dev` to force `NODE_ENV` to "production"

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -152,6 +152,7 @@ async fn handle_request(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn dev(
     path: Option<PathBuf>,
     client: Option<PathBuf>,
@@ -160,9 +161,10 @@ pub async fn dev(
     hostname: Option<String>,
     env: Option<PathBuf>,
     allow_code_generation: bool,
+    prod: bool,
 ) -> Result<()> {
     let (root, function_config) = resolve_path(path, client, public_dir)?;
-    let (index, assets) = bundle_function(&function_config, &root, false)?;
+    let (index, assets) = bundle_function(&function_config, &root, prod)?;
 
     let server_index = index.clone();
     let assets = Arc::new(Mutex::new(assets));
@@ -279,7 +281,7 @@ pub async fn dev(
                 print!("\x1B[2J\x1B[1;1H");
                 println!("{}", info("Found change, updating..."));
 
-                let (new_index, new_assets) = bundle_function(&function_config, &root, false)?;
+                let (new_index, new_assets) = bundle_function(&function_config, &root, prod)?;
 
                 *assets.lock().await = new_assets;
                 index_tx.send_async(new_index).await.unwrap();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -75,6 +75,9 @@ enum Commands {
         /// Allow code generation from strings using `eval` / `new Function`
         #[clap(long)]
         allow_code_generation: bool,
+        /// Force `process.env.NODE_ENV` to be "production"
+        #[clap(visible_alias = "production", long)]
+        prod: bool,
     },
     /// Build a Function without deploying it
     Build {
@@ -141,6 +144,7 @@ async fn main() {
                 hostname,
                 env,
                 allow_code_generation,
+                prod,
             } => {
                 commands::dev(
                     path,
@@ -150,6 +154,7 @@ async fn main() {
                     hostname,
                     env,
                     allow_code_generation,
+                    prod,
                 )
                 .await
             }

--- a/packages/docs/pages/cli.mdx
+++ b/packages/docs/pages/cli.mdx
@@ -147,8 +147,7 @@ This command accepts the following arguments and options:
 - `--port <PORT>` allows you to specify a custom port to start the server on. (Default: `1234`)
 - `--env <FILE>` allows you to specify a custom path to an environment file to inject [environment variables](/cloud/environment-variables). (Default: `.env`)
 - `--allow-code-generation` allows you to enable code generation from strings (`eval` / `new Function`)
-
-Unlike other commands, `lagon dev` sets `process.env.NODE_ENV` to `"development"` instead of `"production"`.
+- `--prod` allows you to set `process.env.NODE_ENV` to `"production"` instead of `"development"`
 
 Examples:
 


### PR DESCRIPTION
## About

Following https://github.com/lagonapp/lagon/pull/788

Add a new `--prod` (or `--production`) flag to `lagon dev` to force `process.env.NODE_ENV` to "production" instead of "development".