### PR TITLE
fix(dashboard,ui): organization name/description validators

### DIFF
--- a/.changeset/empty-brooms-drum.md
+++ b/.changeset/empty-brooms-drum.md
@@ -1,0 +1,5 @@
+---
+'@lagon/ui': patch
+---
+
+Fix Text error not being red

--- a/.changeset/old-gifts-remain.md
+++ b/.changeset/old-gifts-remain.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Fix organization name/description validators

--- a/packages/dashboard/lib/pages/settings/SettingsGeneral.tsx
+++ b/packages/dashboard/lib/pages/settings/SettingsGeneral.tsx
@@ -87,7 +87,7 @@ const SettingsGeneral = () => {
               name="description"
               placeholder={t('description.placeholder')}
               disabled={updateOrganization.isLoading || !isOrganizationOwner}
-              validator={composeValidators(requiredValidator, maxLengthValidator(ORGANIZATION_DESCRIPTION_MAX_LENGTH))}
+              validator={composeValidators(maxLengthValidator(ORGANIZATION_DESCRIPTION_MAX_LENGTH))}
             />
             <Button variant="primary" disabled={updateOrganization.isLoading || !isOrganizationOwner} submit>
               {t('description.submit')}

--- a/packages/dashboard/lib/trpc/organizationsRouter.ts
+++ b/packages/dashboard/lib/trpc/organizationsRouter.ts
@@ -43,8 +43,8 @@ export const organizationsRouter = (t: T) =>
     organizationCreate: t.procedure
       .input(
         z.object({
-          name: z.string(),
-          description: z.string(),
+          name: z.string().min(ORGANIZATION_NAME_MIN_LENGTH).max(ORGANIZATION_NAME_MAX_LENGTH),
+          description: z.string().max(ORGANIZATION_DESCRIPTION_MAX_LENGTH).optional(),
         }),
       )
       .mutation(async ({ ctx, input }) => {
@@ -79,7 +79,7 @@ export const organizationsRouter = (t: T) =>
         z.object({
           organizationId: z.string(),
           name: z.string().min(ORGANIZATION_NAME_MIN_LENGTH).max(ORGANIZATION_NAME_MAX_LENGTH),
-          description: z.string().max(ORGANIZATION_DESCRIPTION_MAX_LENGTH).nullable(),
+          description: z.string().max(ORGANIZATION_DESCRIPTION_MAX_LENGTH).optional().nullable(),
         }),
       )
       .mutation(async ({ input, ctx }) => {

--- a/packages/ui/src/components/Text/styles.ts
+++ b/packages/ui/src/components/Text/styles.ts
@@ -13,7 +13,7 @@ export const variants = cva(null, {
       true: 'font-semibold',
     },
     error: {
-      true: 'text-red-500 dark:text-red-500',
+      true: '!text-red-500 !dark:text-red-500',
     },
   },
 });


### PR DESCRIPTION
## About

- Allow creating an organization without a description
- Allow removing completely a description when updating an organization
- Fix the `Text` component to be red when using the `error` prop
