### PR TITLE
feat(cli): arm64 binary for macOS

### DIFF
--- a/.changeset/nine-insects-sip.md
+++ b/.changeset/nine-insects-sip.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': minor
+---
+
+Publish arm64 binary for macOS

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,11 @@ jobs:
             asset_name: lagon-darwin-x64
             input: lagon-cli
             output: lagon
+          - os: macOS-latest
+            target: aarch64-apple-darwin
+            asset_name: lagon-darwin-arm64
+            input: lagon-cli
+            output: lagon
           - os: windows-2019
             target: x86_64-pc-windows-msvc
             asset_name: lagon-win-x64
@@ -54,10 +59,9 @@ jobs:
         with:
           node-version: 16
           cache: 'pnpm'
-      - name: Install cross compilation toolchain
+      - name: Install cross compilation toolchain (Linux)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          rustup target add aarch64-unknown-linux-gnu
           sudo apt update
           sudo apt install -yq --no-install-suggests --no-install-recommends \
             binfmt-support g++-10-aarch64-linux-gnu g++-10-multilib \

--- a/crates/cli/npm/getBinary.js
+++ b/crates/cli/npm/getBinary.js
@@ -27,9 +27,16 @@ function getPlatform() {
     };
   }
 
-  if (type === 'Darwin') {
+  if (type === 'Darwin' && arch === 'x64') {
     return {
       platform: 'lagon-darwin-x64',
+      name: 'lagon',
+    };
+  }
+
+  if (type === 'Darwin' && arch === 'arm64') {
+    return {
+      platform: 'lagon-darwin-arm64',
       name: 'lagon',
     };
   }


### PR DESCRIPTION
## About

Add `aarch64-apple-darwin` target to avoid using Rosetta on M1 macs.
