### PR TITLE
ci: add NPM packages provenance

### DIFF
--- a/.changeset/few-gifts-confess.md
+++ b/.changeset/few-gifts-confess.md
@@ -1,0 +1,7 @@
+---
+'@lagon/cli': patch
+'@lagon/astro': patch
+'@lagon/remix': patch
+---
+
+Add NPM packages provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   release:
     name: Release
+    permissions: write-all
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -35,3 +36,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## About

Add [NPM packages provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) to `@lagon/cli`, `@lagon/astro` & `@lagon/remix`
