### PR TITLE
fix(www): export fully static

### DIFF
--- a/.changeset/shy-terms-lay.md
+++ b/.changeset/shy-terms-lay.md
@@ -1,0 +1,5 @@
+---
+'@lagon/www': patch
+---
+
+Export fully static

--- a/www/next.config.js
+++ b/www/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   experimental: {
     appDir: true,
   },
+  output: 'export',
 };
 
 module.exports = withMDX(nextConfig);


### PR DESCRIPTION
## About

Using the new deployment summary from Vercel, I've noticed that www wasn't rendered as fully static:

![Screenshot 2023-04-26 at 20 47 05](https://user-images.githubusercontent.com/43268759/234673365-d7155bfe-e60b-4f91-a816-8ba4e829f514.png)

After digging a lot and using `vercel build`, turns out that you need to specify manually `output: 'export'` when using the app dir to create a fully static website.