### PR TITLE
feat(runtime,js-runtime): use ArrayBuffer for Request/Response body

### DIFF
--- a/.changeset/stupid-spies-jog.md
+++ b/.changeset/stupid-spies-jog.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime': patch
+'@lagon/js-runtime': patch
+---
+
+Use ArrayBuffer for Request/response body

--- a/crates/runtime/tests/async_context.rs
+++ b/crates/runtime/tests/async_context.rs
@@ -49,7 +49,7 @@ export function handler() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
-        Response::from("")
+        Response::default()
     );
 }
 
@@ -75,7 +75,7 @@ export function handler() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
-        Response::from("")
+        Response::default()
     );
 }
 
@@ -115,7 +115,7 @@ export function handler() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
-        Response::from("")
+        Response::default()
     );
 }
 
@@ -167,7 +167,7 @@ export function handler() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
-        Response::from("")
+        Response::default()
     );
 }
 

--- a/crates/runtime/tests/crypto.rs
+++ b/crates/runtime/tests/crypto.rs
@@ -296,7 +296,7 @@ async fn crypto_decrypt() {
         ciphertext,
     );
 
-    return new Response(text);
+    return new Response(new TextDecoder().decode(text));
 }"
         .into(),
     ));

--- a/crates/runtime/tests/fetch.rs
+++ b/crates/runtime/tests/fetch.rs
@@ -288,7 +288,10 @@ async fn response_array_buffer() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
-        Response::from("Hello, World")
+        Response {
+            body: "Hello, World".into(),
+            ..Default::default()
+        }
     );
 }
 

--- a/crates/runtime/tests/streams.rs
+++ b/crates/runtime/tests/streams.rs
@@ -32,9 +32,11 @@ async fn sync_streaming() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Start(Response::from(
-            "[object ReadableStream]"
-        )))
+        RunResult::Stream(StreamResult::Start(Response {
+            headers: None,
+            body: Bytes::from("[object ReadableStream]"),
+            status: 200,
+        }))
     );
 }
 
@@ -72,9 +74,11 @@ async fn queue_multiple() {
     assert!(receiver.recv_async().await.unwrap().as_stream_done());
     assert_eq!(
         receiver.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Start(Response::from(
-            "[object ReadableStream]"
-        )))
+        RunResult::Stream(StreamResult::Start(Response {
+            headers: None,
+            body: Bytes::from("[object ReadableStream]"),
+            status: 200,
+        }))
     );
 }
 
@@ -158,9 +162,11 @@ async fn start_and_pull() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Start(Response::from(
-            "[object ReadableStream]"
-        )))
+        RunResult::Stream(StreamResult::Start(Response {
+            headers: None,
+            body: Bytes::from("[object ReadableStream]"),
+            status: 200,
+        }))
     );
 }
 
@@ -200,9 +206,11 @@ async fn response_before_write() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Start(Response::from(
-            "[object ReadableStream]"
-        )))
+        RunResult::Stream(StreamResult::Start(Response {
+            headers: None,
+            body: Bytes::from("[object ReadableStream]"),
+            status: 200,
+        }))
     );
 
     assert_eq!(
@@ -228,9 +236,11 @@ async fn timeout_infinite_streaming() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Start(Response::from(
-            "[object ReadableStream]"
-        )))
+        RunResult::Stream(StreamResult::Start(Response {
+            headers: None,
+            body: Bytes::from("[object ReadableStream]"),
+            status: 200,
+        }))
     );
 
     assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Timeout);
@@ -289,9 +299,11 @@ async fn promise_reject_callback_after_response() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap(),
-        RunResult::Stream(StreamResult::Start(Response::from(
-            "[object ReadableStream]"
-        )))
+        RunResult::Stream(StreamResult::Start(Response {
+            headers: None,
+            body: Bytes::from("[object ReadableStream]"),
+            status: 200,
+        }))
     );
 
     assert_eq!(receiver.recv_async().await.unwrap(), RunResult::Error("Uncaught ReferenceError: doesNotExists is not defined\n  at 12:17\n  at stream (11:19)".to_owned()));

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -6,7 +6,8 @@ use hyper::{
     Body, Request as HyperRequest,
 };
 use lagon_runtime_v8_utils::{
-    extract_v8_headers_object, extract_v8_string, v8_headers_object, v8_string,
+    extract_v8_headers_object, extract_v8_string, extract_v8_uint8array, v8_headers_object,
+    v8_string, v8_uint8array,
 };
 use std::{collections::HashMap, str::FromStr};
 
@@ -55,7 +56,7 @@ impl IntoV8 for Request {
 
         if body_exists {
             names.push(v8_string(scope, "b").into());
-            values.push(v8_string(scope, &String::from_utf8(self.body.to_vec()).unwrap()).into());
+            values.push(v8_uint8array(scope, self.body.to_vec()).into());
         }
 
         if let Some(headers) = self.headers {
@@ -83,7 +84,7 @@ impl FromV8 for Request {
 
         if let Some(body_value) = request.get(scope, body_key.into()) {
             if !body_value.is_null_or_undefined() {
-                body = Bytes::from(extract_v8_string(body_value, scope)?);
+                body = Bytes::from(extract_v8_uint8array(body_value)?);
             }
         }
 

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -6,7 +6,7 @@ use hyper::{
     Body, Response as HyperResponse,
 };
 use lagon_runtime_v8_utils::{
-    extract_v8_headers_object, extract_v8_integer, extract_v8_string, v8_headers_object,
+    extract_v8_headers_object, extract_v8_integer, extract_v8_uint8array, v8_headers_object,
     v8_integer, v8_string, v8_uint8array,
 };
 use std::{collections::HashMap, str::FromStr};
@@ -81,7 +81,7 @@ impl FromV8 for Response {
         let body_key = v8_string(scope, "b");
 
         if let Some(body_value) = response.get(scope, body_key.into()) {
-            body = extract_v8_string(body_value, scope)?;
+            body = extract_v8_uint8array(body_value)?;
         } else {
             return Err(anyhow!("Could not find body"));
         }

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -35,7 +35,10 @@ impl Default for Response {
 impl From<&str> for Response {
     fn from(body: &str) -> Self {
         Response {
-            headers: None,
+            headers: Some(HashMap::from([(
+                "content-type".into(),
+                Vec::from(["text/plain;charset=UTF-8".into()]),
+            )])),
             body: Bytes::from(body.to_string()),
             status: 200,
         }

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Only load a .env file on development
-    #[cfg(debug_assertions)]
+    // #[cfg(debug_assertions)]
     dotenv::dotenv().expect("Failed to load .env file");
 
     let _flush_guard = init_logger(REGION.clone()).expect("Failed to init logger");
@@ -51,10 +51,10 @@ async fn main() -> Result<()> {
     let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
-    #[cfg(not(debug_assertions))]
-    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
-        Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
-    )));
+    // #[cfg(not(debug_assertions))]
+    // let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
+    //     Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
+    // )));
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Only load a .env file on development
-    // #[cfg(debug_assertions)]
+    #[cfg(debug_assertions)]
     dotenv::dotenv().expect("Failed to load .env file");
 
     let _flush_guard = init_logger(REGION.clone()).expect("Failed to init logger");
@@ -51,10 +51,10 @@ async fn main() -> Result<()> {
     let url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     let url = url.as_str();
     let opts = Opts::from_url(url).expect("Failed to parse DATABASE_URL");
-    // #[cfg(not(debug_assertions))]
-    // let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
-    //     Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
-    // )));
+    #[cfg(not(debug_assertions))]
+    let opts = OptsBuilder::from_opts(opts).ssl_opts(Some(SslOpts::default().with_root_cert_path(
+        Some(Cow::from(Path::new("/etc/ssl/certs/ca-certificates.crt"))),
+    )));
     let pool = Pool::new(opts)?;
     let conn = pool.get_conn()?;
 

--- a/crates/wpt-runner/current-results.md
+++ b/crates/wpt-runner/current-results.md
@@ -283,9 +283,9 @@ Running ../../tools/wpt/fetch/api/request/request-disturbed.any.js
 TEST DONE 1 Request's body: initial state
 TEST DONE 1 Request without body cannot be disturbed
 TEST DONE 1 Check cloning a disturbed request
-TEST DONE 1 Check creating a new request from a disturbed request
+TEST DONE 0 Check creating a new request from a disturbed request
 TEST DONE 1 Request construction failure should not set "bodyUsed"
-TEST DONE 0 Check creating a new request with a new body from a disturbed request
+TEST DONE 1 Check creating a new request with a new body from a disturbed request
 TEST DONE 1 Input request used for creating new request became disturbed
 TEST DONE 1 Input request used for creating new request became disturbed even if body is not used
 TEST DONE 0 Check consuming a disturbed request
@@ -351,7 +351,7 @@ TEST DONE 1 Request should get its content-type from the body if none is provide
 TEST DONE 1 Request should get its content-type from init headers if one is provided
 TEST DONE 0 Testing request header creations with various objects
 TEST DONE 0 Test that Request.headers has the [SameObject] extended attribute
-TEST DONE 0 Testing empty Request Content-Type header
+TEST DONE 1 Testing empty Request Content-Type header
 Running ../../tools/wpt/fetch/api/request/request-init-002.any.js
 TEST DONE 0 Initialize Request with headers values
 TEST DONE 0 Initialize Request's body with "undefined", undefined
@@ -365,10 +365,10 @@ Running ../../tools/wpt/fetch/api/request/request-init-contenttype.any.js
 TEST DONE 0 Default Content-Type for Request with empty body
 TEST DONE 0 Default Content-Type for Request with Blob body (no type set)
 TEST DONE 0 Default Content-Type for Request with Blob body (empty type)
-TEST DONE 1 Default Content-Type for Request with Blob body (set type)
+TEST DONE 0 Default Content-Type for Request with Blob body (set type)
 TEST DONE 0 Default Content-Type for Request with buffer source body
 TEST DONE 0 Default Content-Type for Request with URLSearchParams body
-TEST DONE 1 Default Content-Type for Request with string body
+TEST DONE 0 Default Content-Type for Request with string body
 TEST DONE 0 Default Content-Type for Request with ReadableStream body
 TEST DONE 0 Can override Content-Type for Request with empty body
 TEST DONE 0 Can override Content-Type for Request with Blob body (no type set)
@@ -376,7 +376,7 @@ TEST DONE 0 Can override Content-Type for Request with Blob body (empty type)
 TEST DONE 0 Can override Content-Type for Request with Blob body (set type)
 TEST DONE 0 Can override Content-Type for Request with buffer source body
 TEST DONE 0 Can override Content-Type for Request with FormData body
-TEST DONE 1 Can override Content-Type for Request with URLSearchParams body
+TEST DONE 0 Can override Content-Type for Request with URLSearchParams body
 TEST DONE 0 Can override Content-Type for Request with string body
 TEST DONE 0 Can override Content-Type for Request with ReadableStream body
 TEST DONE 1 Default Content-Type for Request with FormData body
@@ -426,15 +426,15 @@ TEST DONE 1 Consume response's body as blob
 TEST DONE 1 Consume response's body as arrayBuffer
 TEST DONE 1 Consume response's body as json (error case)
 TEST DONE 1 Consume response's body as formData with correct multipart type (error case)
-TEST DONE 1 Consume response's body as formData with correct urlencoded type
+TEST DONE 0 Consume response's body as formData with correct urlencoded type
 TEST DONE 1 Consume response's body as formData without correct type (error case)
 TEST DONE 0 Consume empty blob response body as arrayBuffer
 TEST DONE 0 Consume empty text response body as arrayBuffer
-TEST DONE 1 Consume empty blob response body as text
+TEST DONE 0 Consume empty blob response body as text
 TEST DONE 0 Consume empty text response body as text
 TEST DONE 0 Consume empty URLSearchParams response body as text
-TEST DONE 0 Consume empty FormData response body as text
-TEST DONE 1 Consume empty ArrayBuffer response body as text
+TEST DONE 1 Consume empty FormData response body as text
+TEST DONE 0 Consume empty ArrayBuffer response body as text
 Running ../../tools/wpt/fetch/api/response/response-consume-stream.any.js
 TEST DONE 0 Getting an error Response stream
 TEST DONE 0 Getting a redirect Response stream
@@ -480,20 +480,20 @@ TEST DONE 0 Test that Response.headers has the [SameObject] extended attribute
 Running ../../tools/wpt/fetch/api/response/response-init-002.any.js
 TEST DONE 0 Initialize Response with headers values
 TEST DONE 0 Testing null Response body
-TEST DONE 1 Initialize Response's body with application/octet-binary
+TEST DONE 0 Initialize Response's body with application/octet-binary
 TEST DONE 1 Initialize Response's body with multipart/form-data
-TEST DONE 1 Initialize Response's body with application/x-www-form-urlencoded;charset=UTF-8
-TEST DONE 1 Initialize Response's body with text/plain;charset=UTF-8
+TEST DONE 0 Initialize Response's body with application/x-www-form-urlencoded;charset=UTF-8
+TEST DONE 0 Initialize Response's body with text/plain;charset=UTF-8
 TEST DONE 1 Read Response's body as readableStream
-TEST DONE 0 Testing empty Response Content-Type header
+TEST DONE 1 Testing empty Response Content-Type header
 Running ../../tools/wpt/fetch/api/response/response-init-contenttype.any.js
 TEST DONE 0 Default Content-Type for Response with empty body
 TEST DONE 0 Default Content-Type for Response with Blob body (no type set)
 TEST DONE 0 Default Content-Type for Response with Blob body (empty type)
-TEST DONE 1 Default Content-Type for Response with Blob body (set type)
+TEST DONE 0 Default Content-Type for Response with Blob body (set type)
 TEST DONE 0 Default Content-Type for Response with buffer source body
 TEST DONE 0 Default Content-Type for Response with URLSearchParams body
-TEST DONE 1 Default Content-Type for Response with string body
+TEST DONE 0 Default Content-Type for Response with string body
 TEST DONE 0 Default Content-Type for Response with ReadableStream body
 TEST DONE 0 Can override Content-Type for Response with empty body
 TEST DONE 0 Can override Content-Type for Response with Blob body (no type set)
@@ -501,7 +501,7 @@ TEST DONE 0 Can override Content-Type for Response with Blob body (empty type)
 TEST DONE 0 Can override Content-Type for Response with Blob body (set type)
 TEST DONE 0 Can override Content-Type for Response with buffer source body
 TEST DONE 0 Can override Content-Type for Response with FormData body
-TEST DONE 1 Can override Content-Type for Response with URLSearchParams body
+TEST DONE 0 Can override Content-Type for Response with URLSearchParams body
 TEST DONE 0 Can override Content-Type for Response with string body
 TEST DONE 0 Can override Content-Type for Response with ReadableStream body
 TEST DONE 1 Default Content-Type for Response with FormData body
@@ -932,74 +932,74 @@ TEST DONE 1 URLSearchParams constructed with: id=0&value=%
 TEST DONE 1 URLSearchParams constructed with: b=%2sf%2a
 TEST DONE 1 URLSearchParams constructed with: b=%2%2af%2a
 TEST DONE 1 URLSearchParams constructed with: b=%%2a
-TEST DONE 1 request.formData() with input: test
-TEST DONE 1 response.formData() with input: test
-TEST DONE 1 request.formData() with input: ﻿test=﻿
-TEST DONE 1 response.formData() with input: ﻿test=﻿
-TEST DONE 1 request.formData() with input: %EF%BB%BFtest=%EF%BB%BF
-TEST DONE 1 response.formData() with input: %EF%BB%BFtest=%EF%BB%BF
-TEST DONE 1 request.formData() with input: %FE%FF
-TEST DONE 1 response.formData() with input: %FE%FF
-TEST DONE 1 request.formData() with input: %FF%FE
-TEST DONE 1 response.formData() with input: %FF%FE
-TEST DONE 1 request.formData() with input: †&†=x
-TEST DONE 1 response.formData() with input: †&†=x
-TEST DONE 1 request.formData() with input: %C2
-TEST DONE 1 response.formData() with input: %C2
-TEST DONE 1 request.formData() with input: %C2x
-TEST DONE 1 response.formData() with input: %C2x
-TEST DONE 1 request.formData() with input: _charset_=windows-1252&test=%C2x
-TEST DONE 1 response.formData() with input: _charset_=windows-1252&test=%C2x
+TEST DONE 0 request.formData() with input: test
+TEST DONE 0 response.formData() with input: test
+TEST DONE 0 request.formData() with input: ﻿test=﻿
+TEST DONE 0 response.formData() with input: ﻿test=﻿
+TEST DONE 0 request.formData() with input: %EF%BB%BFtest=%EF%BB%BF
+TEST DONE 0 response.formData() with input: %EF%BB%BFtest=%EF%BB%BF
+TEST DONE 0 request.formData() with input: %FE%FF
+TEST DONE 0 response.formData() with input: %FE%FF
+TEST DONE 0 request.formData() with input: %FF%FE
+TEST DONE 0 response.formData() with input: %FF%FE
+TEST DONE 0 request.formData() with input: †&†=x
+TEST DONE 0 response.formData() with input: †&†=x
+TEST DONE 0 request.formData() with input: %C2
+TEST DONE 0 response.formData() with input: %C2
+TEST DONE 0 request.formData() with input: %C2x
+TEST DONE 0 response.formData() with input: %C2x
+TEST DONE 0 request.formData() with input: _charset_=windows-1252&test=%C2x
+TEST DONE 0 response.formData() with input: _charset_=windows-1252&test=%C2x
 TEST DONE 0 request.formData() with input: 
 TEST DONE 0 response.formData() with input: 
-TEST DONE 1 request.formData() with input: a
-TEST DONE 1 response.formData() with input: a
-TEST DONE 1 request.formData() with input: a=b
-TEST DONE 1 response.formData() with input: a=b
-TEST DONE 1 request.formData() with input: a=
-TEST DONE 1 response.formData() with input: a=
-TEST DONE 1 request.formData() with input: =b
-TEST DONE 1 response.formData() with input: =b
-TEST DONE 1 request.formData() with input: &
-TEST DONE 1 response.formData() with input: &
-TEST DONE 1 request.formData() with input: &a
-TEST DONE 1 response.formData() with input: &a
-TEST DONE 1 request.formData() with input: a&
-TEST DONE 1 response.formData() with input: a&
-TEST DONE 1 request.formData() with input: a&a
-TEST DONE 1 response.formData() with input: a&a
-TEST DONE 1 request.formData() with input: a&b&c
-TEST DONE 1 response.formData() with input: a&b&c
-TEST DONE 1 request.formData() with input: a=b&c=d
-TEST DONE 1 response.formData() with input: a=b&c=d
-TEST DONE 1 request.formData() with input: a=b&c=d&
-TEST DONE 1 response.formData() with input: a=b&c=d&
-TEST DONE 1 request.formData() with input: &&&a=b&&&&c=d&
-TEST DONE 1 response.formData() with input: &&&a=b&&&&c=d&
-TEST DONE 1 request.formData() with input: a=a&a=b&a=c
-TEST DONE 1 response.formData() with input: a=a&a=b&a=c
-TEST DONE 1 request.formData() with input: a==a
-TEST DONE 1 response.formData() with input: a==a
-TEST DONE 1 request.formData() with input: a=a+b+c+d
-TEST DONE 1 response.formData() with input: a=a+b+c+d
-TEST DONE 1 request.formData() with input: %=a
-TEST DONE 1 response.formData() with input: %=a
-TEST DONE 1 request.formData() with input: %a=a
-TEST DONE 1 response.formData() with input: %a=a
-TEST DONE 1 request.formData() with input: %a_=a
-TEST DONE 1 response.formData() with input: %a_=a
-TEST DONE 1 request.formData() with input: %61=a
-TEST DONE 1 response.formData() with input: %61=a
-TEST DONE 1 request.formData() with input: %61+%4d%4D=
-TEST DONE 1 response.formData() with input: %61+%4d%4D=
-TEST DONE 1 request.formData() with input: id=0&value=%
-TEST DONE 1 response.formData() with input: id=0&value=%
-TEST DONE 1 request.formData() with input: b=%2sf%2a
-TEST DONE 1 response.formData() with input: b=%2sf%2a
-TEST DONE 1 request.formData() with input: b=%2%2af%2a
-TEST DONE 1 response.formData() with input: b=%2%2af%2a
-TEST DONE 1 request.formData() with input: b=%%2a
-TEST DONE 1 response.formData() with input: b=%%2a
+TEST DONE 0 request.formData() with input: a
+TEST DONE 0 response.formData() with input: a
+TEST DONE 0 request.formData() with input: a=b
+TEST DONE 0 response.formData() with input: a=b
+TEST DONE 0 request.formData() with input: a=
+TEST DONE 0 response.formData() with input: a=
+TEST DONE 0 request.formData() with input: =b
+TEST DONE 0 response.formData() with input: =b
+TEST DONE 0 request.formData() with input: &
+TEST DONE 0 response.formData() with input: &
+TEST DONE 0 request.formData() with input: &a
+TEST DONE 0 response.formData() with input: &a
+TEST DONE 0 request.formData() with input: a&
+TEST DONE 0 response.formData() with input: a&
+TEST DONE 0 request.formData() with input: a&a
+TEST DONE 0 response.formData() with input: a&a
+TEST DONE 0 request.formData() with input: a&b&c
+TEST DONE 0 response.formData() with input: a&b&c
+TEST DONE 0 request.formData() with input: a=b&c=d
+TEST DONE 0 response.formData() with input: a=b&c=d
+TEST DONE 0 request.formData() with input: a=b&c=d&
+TEST DONE 0 response.formData() with input: a=b&c=d&
+TEST DONE 0 request.formData() with input: &&&a=b&&&&c=d&
+TEST DONE 0 response.formData() with input: &&&a=b&&&&c=d&
+TEST DONE 0 request.formData() with input: a=a&a=b&a=c
+TEST DONE 0 response.formData() with input: a=a&a=b&a=c
+TEST DONE 0 request.formData() with input: a==a
+TEST DONE 0 response.formData() with input: a==a
+TEST DONE 0 request.formData() with input: a=a+b+c+d
+TEST DONE 0 response.formData() with input: a=a+b+c+d
+TEST DONE 0 request.formData() with input: %=a
+TEST DONE 0 response.formData() with input: %=a
+TEST DONE 0 request.formData() with input: %a=a
+TEST DONE 0 response.formData() with input: %a=a
+TEST DONE 0 request.formData() with input: %a_=a
+TEST DONE 0 response.formData() with input: %a_=a
+TEST DONE 0 request.formData() with input: %61=a
+TEST DONE 0 response.formData() with input: %61=a
+TEST DONE 0 request.formData() with input: %61+%4d%4D=
+TEST DONE 0 response.formData() with input: %61+%4d%4D=
+TEST DONE 0 request.formData() with input: id=0&value=%
+TEST DONE 0 response.formData() with input: id=0&value=%
+TEST DONE 0 request.formData() with input: b=%2sf%2a
+TEST DONE 0 response.formData() with input: b=%2sf%2a
+TEST DONE 0 request.formData() with input: b=%2%2af%2a
+TEST DONE 0 response.formData() with input: b=%2%2af%2a
+TEST DONE 0 request.formData() with input: b=%%2a
+TEST DONE 0 response.formData() with input: b=%%2a
 Running ../../tools/wpt/url/urlsearchparams-append.any.js
 TEST DONE 1 Append same name
 TEST DONE 1 Append empty strings
@@ -1586,10 +1586,55 @@ TEST DONE 0 Unusual but valid property bag: function() {}
 TEST DONE 1 Property bag propagates exceptions
 Running ../../tools/wpt/FileAPI/file/send-file-formdata-controls.any.js
 TEST DONE 1 Upload file-for-upload-in-form-NUL-[ ].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-BS-[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-VT-[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-LF-[
+].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-LF-CR-[
+].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-CR-[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-CR-LF-[
+].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-HT-[	].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-FF-[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-DEL-[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-ESC-[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-SPACE-[ ].txt (ASCII) in fetch with FormData
 Running ../../tools/wpt/FileAPI/file/send-file-formdata-punctuation.any.js
 TEST DONE 1 Upload file-for-upload-in-form-QUOTATION-MARK-["].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload "file-for-upload-in-form-double-quoted.txt" (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-REVERSE-SOLIDUS-[\].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-EXCLAMATION-MARK-[!].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-DOLLAR-SIGN-[$].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-PERCENT-SIGN-[%].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-AMPERSAND-[&].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-APOSTROPHE-['].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-LEFT-PARENTHESIS-[(].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-RIGHT-PARENTHESIS-[)].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-ASTERISK-[*].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-PLUS-SIGN-[+].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-COMMA-[,].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-FULL-STOP-[.].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-SOLIDUS-[/].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-COLON-[:].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-SEMICOLON-[;].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-EQUALS-SIGN-[=].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-QUESTION-MARK-[?].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-CIRCUMFLEX-ACCENT-[^].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-LEFT-SQUARE-BRACKET-[[].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-RIGHT-SQUARE-BRACKET-[]].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-LEFT-CURLY-BRACKET-[{].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-VERTICAL-LINE-[|].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-RIGHT-CURLY-BRACKET-[}].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-TILDE-[~].txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload 'file-for-upload-in-form-single-quoted.txt' (ASCII) in fetch with FormData
 Running ../../tools/wpt/FileAPI/file/send-file-formdata-utf-8.any.js
 TEST DONE 1 Upload file-for-upload-in-form.txt (ASCII) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-.txt (x-user-defined) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-â˜ºðŸ˜‚.txt (windows-1252) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-★星★.txt (JIS X 0201 and JIS X 0208) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-☺😂.txt (Unicode) in fetch with FormData
+TEST DONE 1 Upload file-for-upload-in-form-ABC~‾¥≈¤･・•∙·☼★星🌟星★☼·∙•・･¤≈¥‾~XYZ.txt (Unicode) in fetch with FormData
 Running ../../tools/wpt/FileAPI/file/send-file-formdata.any.js
 TEST DONE 1 Upload file-for-upload-in-form.txt (ASCII) in fetch with FormData
 Running ../../tools/wpt/FileAPI/reading-data-section/Determining-Encoding.any.js
@@ -1700,5 +1745,5 @@ Running ../../tools/wpt/urlpattern/urlpattern-compare.https.any.js
 Running ../../tools/wpt/urlpattern/urlpattern.any.js
 Running ../../tools/wpt/urlpattern/urlpattern.https.any.js
 
-1576 tests, 456 passed, 1111 failed
- -> 28% conformance
+1615 tests, 531 passed, 1078 failed
+ -> 32% conformance

--- a/crates/wpt-runner/current-results.md
+++ b/crates/wpt-runner/current-results.md
@@ -426,7 +426,7 @@ TEST DONE 1 Consume response's body as blob
 TEST DONE 1 Consume response's body as arrayBuffer
 TEST DONE 1 Consume response's body as json (error case)
 TEST DONE 1 Consume response's body as formData with correct multipart type (error case)
-TEST DONE 0 Consume response's body as formData with correct urlencoded type
+TEST DONE 1 Consume response's body as formData with correct urlencoded type
 TEST DONE 1 Consume response's body as formData without correct type (error case)
 TEST DONE 0 Consume empty blob response body as arrayBuffer
 TEST DONE 0 Consume empty text response body as arrayBuffer
@@ -932,74 +932,74 @@ TEST DONE 1 URLSearchParams constructed with: id=0&value=%
 TEST DONE 1 URLSearchParams constructed with: b=%2sf%2a
 TEST DONE 1 URLSearchParams constructed with: b=%2%2af%2a
 TEST DONE 1 URLSearchParams constructed with: b=%%2a
-TEST DONE 0 request.formData() with input: test
-TEST DONE 0 response.formData() with input: test
-TEST DONE 0 request.formData() with input: ﻿test=﻿
-TEST DONE 0 response.formData() with input: ﻿test=﻿
-TEST DONE 0 request.formData() with input: %EF%BB%BFtest=%EF%BB%BF
-TEST DONE 0 response.formData() with input: %EF%BB%BFtest=%EF%BB%BF
-TEST DONE 0 request.formData() with input: %FE%FF
-TEST DONE 0 response.formData() with input: %FE%FF
-TEST DONE 0 request.formData() with input: %FF%FE
-TEST DONE 0 response.formData() with input: %FF%FE
-TEST DONE 0 request.formData() with input: †&†=x
-TEST DONE 0 response.formData() with input: †&†=x
-TEST DONE 0 request.formData() with input: %C2
-TEST DONE 0 response.formData() with input: %C2
-TEST DONE 0 request.formData() with input: %C2x
-TEST DONE 0 response.formData() with input: %C2x
-TEST DONE 0 request.formData() with input: _charset_=windows-1252&test=%C2x
-TEST DONE 0 response.formData() with input: _charset_=windows-1252&test=%C2x
+TEST DONE 1 request.formData() with input: test
+TEST DONE 1 response.formData() with input: test
+TEST DONE 1 request.formData() with input: ﻿test=﻿
+TEST DONE 1 response.formData() with input: ﻿test=﻿
+TEST DONE 1 request.formData() with input: %EF%BB%BFtest=%EF%BB%BF
+TEST DONE 1 response.formData() with input: %EF%BB%BFtest=%EF%BB%BF
+TEST DONE 1 request.formData() with input: %FE%FF
+TEST DONE 1 response.formData() with input: %FE%FF
+TEST DONE 1 request.formData() with input: %FF%FE
+TEST DONE 1 response.formData() with input: %FF%FE
+TEST DONE 1 request.formData() with input: †&†=x
+TEST DONE 1 response.formData() with input: †&†=x
+TEST DONE 1 request.formData() with input: %C2
+TEST DONE 1 response.formData() with input: %C2
+TEST DONE 1 request.formData() with input: %C2x
+TEST DONE 1 response.formData() with input: %C2x
+TEST DONE 1 request.formData() with input: _charset_=windows-1252&test=%C2x
+TEST DONE 1 response.formData() with input: _charset_=windows-1252&test=%C2x
 TEST DONE 0 request.formData() with input: 
 TEST DONE 0 response.formData() with input: 
-TEST DONE 0 request.formData() with input: a
-TEST DONE 0 response.formData() with input: a
-TEST DONE 0 request.formData() with input: a=b
-TEST DONE 0 response.formData() with input: a=b
-TEST DONE 0 request.formData() with input: a=
-TEST DONE 0 response.formData() with input: a=
-TEST DONE 0 request.formData() with input: =b
-TEST DONE 0 response.formData() with input: =b
-TEST DONE 0 request.formData() with input: &
-TEST DONE 0 response.formData() with input: &
-TEST DONE 0 request.formData() with input: &a
-TEST DONE 0 response.formData() with input: &a
-TEST DONE 0 request.formData() with input: a&
-TEST DONE 0 response.formData() with input: a&
-TEST DONE 0 request.formData() with input: a&a
-TEST DONE 0 response.formData() with input: a&a
-TEST DONE 0 request.formData() with input: a&b&c
-TEST DONE 0 response.formData() with input: a&b&c
-TEST DONE 0 request.formData() with input: a=b&c=d
-TEST DONE 0 response.formData() with input: a=b&c=d
-TEST DONE 0 request.formData() with input: a=b&c=d&
-TEST DONE 0 response.formData() with input: a=b&c=d&
-TEST DONE 0 request.formData() with input: &&&a=b&&&&c=d&
-TEST DONE 0 response.formData() with input: &&&a=b&&&&c=d&
-TEST DONE 0 request.formData() with input: a=a&a=b&a=c
-TEST DONE 0 response.formData() with input: a=a&a=b&a=c
-TEST DONE 0 request.formData() with input: a==a
-TEST DONE 0 response.formData() with input: a==a
-TEST DONE 0 request.formData() with input: a=a+b+c+d
-TEST DONE 0 response.formData() with input: a=a+b+c+d
-TEST DONE 0 request.formData() with input: %=a
-TEST DONE 0 response.formData() with input: %=a
-TEST DONE 0 request.formData() with input: %a=a
-TEST DONE 0 response.formData() with input: %a=a
-TEST DONE 0 request.formData() with input: %a_=a
-TEST DONE 0 response.formData() with input: %a_=a
-TEST DONE 0 request.formData() with input: %61=a
-TEST DONE 0 response.formData() with input: %61=a
-TEST DONE 0 request.formData() with input: %61+%4d%4D=
-TEST DONE 0 response.formData() with input: %61+%4d%4D=
-TEST DONE 0 request.formData() with input: id=0&value=%
-TEST DONE 0 response.formData() with input: id=0&value=%
-TEST DONE 0 request.formData() with input: b=%2sf%2a
-TEST DONE 0 response.formData() with input: b=%2sf%2a
-TEST DONE 0 request.formData() with input: b=%2%2af%2a
-TEST DONE 0 response.formData() with input: b=%2%2af%2a
-TEST DONE 0 request.formData() with input: b=%%2a
-TEST DONE 0 response.formData() with input: b=%%2a
+TEST DONE 1 request.formData() with input: a
+TEST DONE 1 response.formData() with input: a
+TEST DONE 1 request.formData() with input: a=b
+TEST DONE 1 response.formData() with input: a=b
+TEST DONE 1 request.formData() with input: a=
+TEST DONE 1 response.formData() with input: a=
+TEST DONE 1 request.formData() with input: =b
+TEST DONE 1 response.formData() with input: =b
+TEST DONE 1 request.formData() with input: &
+TEST DONE 1 response.formData() with input: &
+TEST DONE 1 request.formData() with input: &a
+TEST DONE 1 response.formData() with input: &a
+TEST DONE 1 request.formData() with input: a&
+TEST DONE 1 response.formData() with input: a&
+TEST DONE 1 request.formData() with input: a&a
+TEST DONE 1 response.formData() with input: a&a
+TEST DONE 1 request.formData() with input: a&b&c
+TEST DONE 1 response.formData() with input: a&b&c
+TEST DONE 1 request.formData() with input: a=b&c=d
+TEST DONE 1 response.formData() with input: a=b&c=d
+TEST DONE 1 request.formData() with input: a=b&c=d&
+TEST DONE 1 response.formData() with input: a=b&c=d&
+TEST DONE 1 request.formData() with input: &&&a=b&&&&c=d&
+TEST DONE 1 response.formData() with input: &&&a=b&&&&c=d&
+TEST DONE 1 request.formData() with input: a=a&a=b&a=c
+TEST DONE 1 response.formData() with input: a=a&a=b&a=c
+TEST DONE 1 request.formData() with input: a==a
+TEST DONE 1 response.formData() with input: a==a
+TEST DONE 1 request.formData() with input: a=a+b+c+d
+TEST DONE 1 response.formData() with input: a=a+b+c+d
+TEST DONE 1 request.formData() with input: %=a
+TEST DONE 1 response.formData() with input: %=a
+TEST DONE 1 request.formData() with input: %a=a
+TEST DONE 1 response.formData() with input: %a=a
+TEST DONE 1 request.formData() with input: %a_=a
+TEST DONE 1 response.formData() with input: %a_=a
+TEST DONE 1 request.formData() with input: %61=a
+TEST DONE 1 response.formData() with input: %61=a
+TEST DONE 1 request.formData() with input: %61+%4d%4D=
+TEST DONE 1 response.formData() with input: %61+%4d%4D=
+TEST DONE 1 request.formData() with input: id=0&value=%
+TEST DONE 1 response.formData() with input: id=0&value=%
+TEST DONE 1 request.formData() with input: b=%2sf%2a
+TEST DONE 1 response.formData() with input: b=%2sf%2a
+TEST DONE 1 request.formData() with input: b=%2%2af%2a
+TEST DONE 1 response.formData() with input: b=%2%2af%2a
+TEST DONE 1 request.formData() with input: b=%%2a
+TEST DONE 1 response.formData() with input: b=%%2a
 Running ../../tools/wpt/url/urlsearchparams-append.any.js
 TEST DONE 1 Append same name
 TEST DONE 1 Append empty strings
@@ -1745,5 +1745,5 @@ Running ../../tools/wpt/urlpattern/urlpattern-compare.https.any.js
 Running ../../tools/wpt/urlpattern/urlpattern.any.js
 Running ../../tools/wpt/urlpattern/urlpattern.https.any.js
 
-1615 tests, 531 passed, 1078 failed
- -> 32% conformance
+1615 tests, 464 passed, 1145 failed
+ -> 28% conformance

--- a/packages/js-runtime/src/__tests__/fetch.test.ts
+++ b/packages/js-runtime/src/__tests__/fetch.test.ts
@@ -191,7 +191,7 @@ describe('fetch', () => {
     expect(globalThis.LagonAsync.fetch).toHaveBeenCalledWith({
       m: 'POST',
       u: 'https://google.com',
-      b: 'A body',
+      b: new Uint8Array([65, 32, 98, 111, 100, 121]),
     });
   });
 });

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -140,10 +140,15 @@ globalThis.masterHandler = async (id, request) => {
   const response = await handler(handlerRequest);
   let body: ArrayBuffer;
 
-  if (response.body && response.isStream) {
-    body = globalThis.__lagon__.TEXT_ENCODER.encode(response.body.toString());
+  if (response.isStream) {
+    const responseBody = response.body;
 
-    const reader = response.body.getReader();
+    if (!responseBody) {
+      throw new Error('Got a stream without a body');
+    }
+
+    body = globalThis.__lagon__.TEXT_ENCODER.encode(responseBody.toString());
+    const reader = responseBody.getReader();
 
     const read = () => {
       reader.read().then(({ done, value }) => {

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -62,8 +62,8 @@ declare global {
   };
 
   var LagonAsync: {
-    fetch: ({ h, m, b, u }: { h?: Map<string, string>; m: string; b?: string; u: string }) => Promise<{
-      b: Uint8Array;
+    fetch: ({ h, m, b, u }: { h?: Map<string, string>; m: string; b?: ArrayBuffer; u: string }) => Promise<{
+      b: ArrayBuffer;
       s: number;
       h?: Record<string, string>;
     }>;
@@ -108,7 +108,7 @@ declare global {
       b: RequestInit['body'];
     },
   ) => Promise<{
-    b: string;
+    b: ArrayBuffer;
     h: ResponseInit['headers'];
     s: ResponseInit['status'];
   }>;
@@ -138,8 +138,11 @@ globalThis.masterHandler = async (id, request) => {
   });
 
   const response = await handler(handlerRequest);
+  let body: ArrayBuffer;
 
   if (response.body && response.isStream) {
+    body = globalThis.__lagon__.TEXT_ENCODER.encode(response.body.toString());
+
     const reader = response.body.getReader();
 
     const read = () => {
@@ -159,12 +162,11 @@ globalThis.masterHandler = async (id, request) => {
 
     read();
   } else {
-    // @ts-expect-error we reassign body even if it's readonly
-    response.body = await response.text();
+    body = await response.arrayBuffer();
   }
 
   return {
-    b: response.body as unknown as string,
+    b: body,
     h: response.headers,
     s: response.status,
   };

--- a/packages/js-runtime/src/runtime/http/Request.ts
+++ b/packages/js-runtime/src/runtime/http/Request.ts
@@ -17,6 +17,10 @@ import { RequestResponseBody } from './body';
     private readonly input: RequestInfo | URL;
 
     constructor(input: RequestInfo | URL, init?: RequestInit) {
+      if (input instanceof Request && input.bodyUsed) {
+        throw new TypeError('nnot construct a Request with a Request object that has already been used.');
+      }
+
       super(init?.body, init?.headers);
 
       this.init = init;

--- a/packages/js-runtime/src/runtime/http/body.ts
+++ b/packages/js-runtime/src/runtime/http/body.ts
@@ -152,7 +152,9 @@ export class RequestResponseBody {
       return this.theBody;
     }
 
-    return new FormData();
+    const body = await this.text();
+
+    return globalThis.__lagon__.parseMultipart(this.headers, body);
   }
 
   async json<T>(): Promise<T> {

--- a/packages/js-runtime/src/runtime/http/body.ts
+++ b/packages/js-runtime/src/runtime/http/body.ts
@@ -13,13 +13,14 @@ export class RequestResponseBody {
     body: string | ArrayBuffer | ArrayBufferView | FormData | ReadableStream | Blob | URLSearchParams | null = null,
     headersInit?: HeadersInit,
   ) {
+    const isPrimitive = typeof body === 'number' || typeof body === 'boolean';
     // @ts-expect-error we ignore ArrayBufferView
-    this.theBody = typeof body === 'number' || typeof body === 'boolean' ? String(body) : body;
+    this.theBody = isPrimitive ? String(body) : body;
     this.headersInit = headersInit;
     this.bodyUsed = false;
     this.isStream = body instanceof ReadableStream;
 
-    if (typeof body === 'string') {
+    if (typeof body === 'string' || isPrimitive) {
       this.headers.set('content-type', this.headers.get('content-type') ?? 'text/plain;charset=UTF-8');
     }
 
@@ -51,7 +52,7 @@ export class RequestResponseBody {
     const stream = new TransformStream();
     const writer = stream.writable.getWriter();
 
-    if (this.theBody instanceof ArrayBuffer) {
+    if (this.theBody instanceof ArrayBuffer || this.theBody instanceof Uint8Array) {
       writer.write(this.theBody);
     } else if (this.theBody instanceof FormData || this.theBody instanceof URLSearchParams) {
       writer.write(globalThis.__lagon__.TEXT_ENCODER.encode(this.theBody.toString()));
@@ -99,7 +100,7 @@ export class RequestResponseBody {
       return globalThis.__lagon__.TEXT_ENCODER.encode(this.theBody);
     }
 
-    if (this.theBody instanceof ArrayBuffer) {
+    if (this.theBody instanceof ArrayBuffer || this.theBody instanceof Uint8Array) {
       this.bodyUsed = true;
       return this.theBody;
     }
@@ -173,7 +174,7 @@ export class RequestResponseBody {
       return this.theBody;
     }
 
-    if (this.theBody instanceof ArrayBuffer) {
+    if (this.theBody instanceof ArrayBuffer || this.theBody instanceof Uint8Array) {
       this.bodyUsed = true;
       return globalThis.__lagon__.TEXT_DECODER.decode(this.theBody);
     }

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -14,17 +14,17 @@
       headers = new Map(Object.entries(init.headers));
     }
 
-    let body: string | undefined;
+    let body: ArrayBuffer | undefined;
 
     if (init?.body) {
-      if (globalThis.__lagon__.isIterable(init.body)) {
-        body = globalThis.__lagon__.TEXT_DECODER.decode(init.body);
-      } else {
+      if (!globalThis.__lagon__.isIterable(init.body)) {
         if (typeof init.body !== 'string') {
           // TODO: Support other body types
           throw new Error('Body must be a string or an iterable');
         }
 
+        body = globalThis.__lagon__.TEXT_ENCODER.encode(init.body);
+      } else {
         body = init.body;
       }
     }


### PR DESCRIPTION
## About

To avoid serializing the body of `Request` & `Response` too often, we can make it an `ArrayBuffer` and store it as-is (while transforming it when we use `Body#text()`, `Body#json()`, `Body#arrayBuffer()`). This also enables non-utf characters in body.