### PR TITLE
feat(dashboard): only allow lowercase alphanumeric chars and dashes for functions names

### DIFF
--- a/.changeset/honest-bears-relate.md
+++ b/.changeset/honest-bears-relate.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Only allow lowercase alphanumeric characters and dashes for Functions names

--- a/packages/dashboard/lib/api/functions.ts
+++ b/packages/dashboard/lib/api/functions.ts
@@ -2,6 +2,7 @@ import prisma from 'lib/prisma';
 import { randomName } from '@scaleway/use-random-name';
 import { TRPCError } from '@trpc/server';
 import type { Plan } from 'lib/plans';
+import { FUNCTION_NAME_REGEX } from 'lib/constants';
 
 const LAGON_BLACKLISTED_FUNCTIONS_NAMES = process.env.LAGON_BLACKLISTED_NAMES?.split(',') ?? [];
 
@@ -24,6 +25,10 @@ export async function findUniqueFunctionName(): Promise<string> {
   }
 
   return name;
+}
+
+export function isFunctionNameAllowed(name: string): boolean {
+  return FUNCTION_NAME_REGEX.test(name);
 }
 
 export function isFunctionNameBlacklisted(name: string): boolean {

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -21,6 +21,8 @@ export const CUSTOM_DOMAINS_PER_FUNCTION = 10;
 
 export const PRESIGNED_URL_EXPIRES_SECONDS = 60 * 60; // 1 hour
 
+export const FUNCTION_NAME_REGEX = /^[a-z0-9-]+$/;
+
 export const REGIONS = {
   'ashburn-us-east': 'Ashburn (us-east)',
   'hillsboro-us-west': 'Hillsboro (us-west)',

--- a/packages/dashboard/lib/form/validators.ts
+++ b/packages/dashboard/lib/form/validators.ts
@@ -1,4 +1,5 @@
 import { FieldValidator } from 'final-form';
+import { FUNCTION_NAME_REGEX } from 'lib/constants';
 
 export const requiredValidator: FieldValidator<string | number> = value => {
   return value ? undefined : 'Field is required';
@@ -22,9 +23,9 @@ export const maxLengthValidator =
 
 export const functionNameValidator: FieldValidator<string | number> = value => {
   if (typeof value === 'string') {
-    return /^[a-zA-Z0-9-]*$/.test(value)
+    return FUNCTION_NAME_REGEX.test(value)
       ? undefined
-      : 'Field must only contains alphanumerics characters, numbers and dashes';
+      : 'Function name must only contain lowercase alphanumeric characters and dashes';
   }
 
   return 'Field must be a string';

--- a/packages/dashboard/lib/trpc/functionsRouter.ts
+++ b/packages/dashboard/lib/trpc/functionsRouter.ts
@@ -18,6 +18,7 @@ import {
   checkCanCreateFunction,
   checkCanQueryFunction,
   findUniqueFunctionName,
+  isFunctionNameAllowed,
   isFunctionNameBlacklisted,
   isFunctionNameUnique,
 } from 'lib/api/functions';
@@ -219,6 +220,13 @@ LIMIT 100`,
           });
         }
 
+        if (!isFunctionNameAllowed(name)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'Function name must only contain lowercase alphanumeric characters and dashes',
+          });
+        }
+
         if (isFunctionNameBlacklisted(name)) {
           throw new TRPCError({
             code: 'FORBIDDEN',
@@ -362,6 +370,13 @@ LIMIT 100`,
             throw new TRPCError({
               code: 'CONFLICT',
               message: 'A Function with the same name already exists',
+            });
+          }
+
+          if (!isFunctionNameAllowed(input.name)) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'Function name must only contain lowercase alphanumeric characters and dashes',
             });
           }
 


### PR DESCRIPTION
## About

Closes #805

Only allow lowercase alphanumeric characters and dashes for Functions names, both when creating or when updating a Function.