### PR TITLE
perf(serverless): download deployments assets in parallel

### DIFF
--- a/.changeset/smooth-walls-float.md
+++ b/.changeset/smooth-walls-float.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Download deployments assets in parallel


### PR DESCRIPTION
## About

Closes #762 

Download deployments assets in parallel instead of sequentially. From ~5s to ~3s on Lagon Cloud deployments. 
