### PR TITLE
perf(runtime): calculate statistics at every second at most

### DIFF
--- a/.changeset/early-ants-smile.md
+++ b/.changeset/early-ants-smile.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Calculate isolate statistics at every seconds instead of every request

--- a/crates/runtime_isolate/src/options.rs
+++ b/crates/runtime_isolate/src/options.rs
@@ -13,6 +13,7 @@ pub struct IsolateOptions {
     pub memory: usize, // in MB (MegaBytes)
     pub tick_timeout: Duration,
     pub total_timeout: Duration,
+    pub statistics_interval: Duration,
     pub metadata: Rc<Metadata>,
     pub on_drop: Option<OnIsolateDropCallback>,
     pub on_statistics: Option<OnIsolateStatisticsCallback>,
@@ -30,6 +31,7 @@ impl IsolateOptions {
             environment_variables: None,
             tick_timeout: Duration::from_millis(200),
             total_timeout: Duration::from_secs(1),
+            statistics_interval: Duration::from_secs(1),
             memory: 128,
             metadata: Rc::new(None),
             on_drop: None,


### PR DESCRIPTION
## About

`v8::GetHeapStatistics` is very expensive and we don't need to run it after each request. Instead, we calculate it at most one time per second, if a request has been made.

Take a look at `HashMap::retain` on the left:

Before:

![image](https://user-images.githubusercontent.com/43268759/235341855-5596f560-78f9-4dd1-b46f-396184a63f28.png)



After:

![image](https://user-images.githubusercontent.com/43268759/235341905-eaaabb54-d0a8-4b9b-a5cf-bdee5669ad7a.png)


