### PR TITLE
perf(runtime): improve Request/Response allocations

### DIFF
--- a/.changeset/friendly-doors-end.md
+++ b/.changeset/friendly-doors-end.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime': patch
+---
+
+Improve Request/Response allocations

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -1,7 +1,6 @@
 use httptest::bytes::Bytes;
 use lagon_runtime_http::{Method, Request, Response, RunResult, StreamResult};
 use lagon_runtime_isolate::options::IsolateOptions;
-use std::collections::HashMap;
 
 mod utils;
 
@@ -81,10 +80,10 @@ async fn get_body_streaming() {
     ));
     send(Request {
         body: Bytes::from("Hello world"),
-        headers: Some(HashMap::from([(
+        headers: Some(vec![(
             "content-type".into(),
-            Vec::from(["text/plain;charset=UTF-8".into()]),
-        )])),
+            vec!["text/plain;charset=UTF-8".into()],
+        )]),
         method: Method::GET,
         url: "".into(),
     });
@@ -117,10 +116,10 @@ async fn get_body() {
     ));
     send(Request {
         body: Bytes::from("Hello world"),
-        headers: Some(HashMap::from([(
+        headers: Some(vec![(
             "content-type".into(),
-            Vec::from(["text/plain;charset=UTF-8".into()]),
-        )])),
+            vec!["text/plain;charset=UTF-8".into()],
+        )]),
         method: Method::GET,
         url: "".into(),
     });
@@ -142,10 +141,10 @@ async fn get_input() {
     ));
     send(Request {
         body: Bytes::new(),
-        headers: Some(HashMap::from([(
+        headers: Some(vec![(
             "content-type".into(),
-            Vec::from(["text/plain;charset=UTF-8".into()]),
-        )])),
+            vec!["text/plain;charset=UTF-8".into()],
+        )]),
         method: Method::GET,
         url: "https://hello.world".into(),
     });
@@ -167,10 +166,10 @@ async fn get_method() {
     ));
     send(Request {
         body: Bytes::new(),
-        headers: Some(HashMap::from([(
+        headers: Some(vec![(
             "content-type".into(),
-            Vec::from(["text/plain;charset=UTF-8".into()]),
-        )])),
+            vec!["text/plain;charset=UTF-8".into()],
+        )]),
         method: Method::POST,
         url: "".into(),
     });
@@ -190,13 +189,9 @@ async fn get_headers() {
 }"
         .into(),
     ));
-
-    let mut headers = HashMap::new();
-    headers.insert("x-auth".into(), vec!["token".into()]);
-
     send(Request {
         body: Bytes::new(),
-        headers: Some(headers),
+        headers: Some(vec![("x-auth".into(), vec!["token".into()])]),
         method: Method::POST,
         url: "".into(),
     });
@@ -221,18 +216,16 @@ async fn return_headers() {
 }"
         .into(),
     ));
-
-    let mut headers = HashMap::new();
-    headers.insert("content-type".into(), vec!["text/html".into()]);
-    headers.insert("x-test".into(), vec!["test".into()]);
-
     send(Request::default());
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
         Response {
             body: "Hello world".into(),
-            headers: Some(headers),
+            headers: Some(vec![
+                ("content-type".into(), vec!["text/html".into()]),
+                ("x-test".into(), vec!["test".into()])
+            ]),
             status: 200,
         }
     );
@@ -252,18 +245,16 @@ async fn return_headers_from_headers_api() {
 }"
         .into(),
     ));
-
-    let mut headers = HashMap::new();
-    headers.insert("content-type".into(), vec!["text/html".into()]);
-    headers.insert("x-test".into(), vec!["test".into()]);
-
     send(Request::default());
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
         Response {
             body: "Hello world".into(),
-            headers: Some(headers),
+            headers: Some(vec![
+                ("content-type".into(), vec!["text/html".into()]),
+                ("x-test".into(), vec!["test".into()])
+            ]),
             status: 200,
         }
     );
@@ -286,10 +277,10 @@ async fn return_status() {
         receiver.recv_async().await.unwrap().as_response(),
         Response {
             body: "Moved permanently".into(),
-            headers: Some(HashMap::from([(
+            headers: Some(vec![(
                 "content-type".into(),
-                Vec::from(["text/plain;charset=UTF-8".into()]),
-            )])),
+                vec!["text/plain;charset=UTF-8".into()],
+            )]),
             status: 302,
         }
     );

--- a/crates/runtime/tests/streams.rs
+++ b/crates/runtime/tests/streams.rs
@@ -1,7 +1,6 @@
 use httptest::bytes::Bytes;
 use lagon_runtime_http::{Request, Response, RunResult, StreamResult};
 use lagon_runtime_isolate::options::IsolateOptions;
-use std::collections::HashMap;
 
 mod utils;
 
@@ -105,8 +104,6 @@ async fn custom_response() {
         .into(),
     ));
     send(Request::default());
-    let mut headers = HashMap::new();
-    headers.insert("x-lagon".into(), vec!["test".into()]);
 
     assert_eq!(
         receiver.recv_async().await.unwrap(),
@@ -120,7 +117,7 @@ async fn custom_response() {
         RunResult::Stream(StreamResult::Start(Response {
             body: Bytes::from("[object ReadableStream]"),
             status: 201,
-            headers: Some(headers),
+            headers: Some(vec![("x-lagon".into(), vec!["test".into()])]),
         }))
     );
 }

--- a/crates/runtime_http/src/headers.rs
+++ b/crates/runtime_http/src/headers.rs
@@ -1,3 +1,5 @@
+pub type Headers = Vec<(String, Vec<String>)>;
+
 pub const X_FORWARDED_FOR: &str = "x-forwarded-for";
 pub const X_REAL_IP: &str = "x-real-ip";
 

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -9,15 +9,15 @@ use lagon_runtime_v8_utils::{
     extract_v8_headers_object, extract_v8_string, extract_v8_uint8array, v8_headers_object,
     v8_string, v8_uint8array,
 };
-use std::{collections::HashMap, str::FromStr};
+use std::str::FromStr;
 
-use crate::X_LAGON_ID;
+use crate::{Headers, X_LAGON_ID};
 
 use super::{FromV8, IntoV8, Method};
 
 #[derive(Debug)]
 pub struct Request {
-    pub headers: Option<HashMap<String, Vec<String>>>,
+    pub headers: Option<Headers>,
     pub method: Method,
     pub body: Bytes,
     pub url: String,
@@ -166,23 +166,29 @@ impl Request {
         request: HyperRequest<Body>,
         capacity: usize,
     ) -> Result<Self> {
-        let mut headers =
-            HashMap::<String, Vec<String>>::with_capacity(request.headers().keys_len() + capacity);
+        let host = request
+            .headers()
+            .get("host")
+            .map_or_else(String::new, |host| {
+                host.to_str()
+                    .map_or_else(|_| String::new(), |value| value.to_string())
+            });
 
-        for (key, value) in request.headers().iter() {
+        let mut headers = Vec::with_capacity(request.headers().keys_len() + capacity);
+
+        for key in request.headers().keys() {
             if key != X_LAGON_ID {
-                headers
-                    .entry(key.to_string())
-                    .or_default()
-                    .push(value.to_str()?.to_string());
+                let mut values = Vec::new();
+
+                for value in request.headers().get_all(key) {
+                    values.push(value.to_str()?.to_string());
+                }
+
+                headers.push((key.to_string(), values));
             }
         }
 
         let method = Method::from(request.method());
-        let host = headers.get("host").map_or_else(String::new, |host| {
-            host.get(0)
-                .map_or_else(String::new, |value| value.to_string())
-        });
         let url = format!("http://{}{}", host, request.uri().to_string().as_str());
 
         let body = body::to_bytes(request.into_body()).await?;
@@ -201,7 +207,7 @@ impl Request {
 
     pub fn set_header(&mut self, key: String, value: String) {
         if let Some(ref mut headers) = self.headers {
-            headers.insert(key, vec![value]);
+            headers.push((key, vec![value]));
         }
     }
 }

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -178,7 +178,8 @@ impl Request {
 
         for key in request.headers().keys() {
             if key != X_LAGON_ID {
-                let mut values = Vec::new();
+                // We guess that most of the time there will be only one header value
+                let mut values = Vec::with_capacity(1);
 
                 for value in request.headers().get_all(key) {
                     values.push(value.to_str()?.to_string());

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -35,10 +35,10 @@ impl Default for Response {
 impl From<&str> for Response {
     fn from(body: &str) -> Self {
         Response {
-            headers: Some(Vec::from([(
+            headers: Some(vec![(
                 "content-type".into(),
-                Vec::from(["text/plain;charset=UTF-8".into()]),
-            )])),
+                vec!["text/plain;charset=UTF-8".into()],
+            )]),
             body: Bytes::from(body.to_string()),
             status: 200,
         }

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -165,7 +165,8 @@ impl Response {
         let mut headers = Vec::with_capacity(response.headers().keys_len());
 
         for key in response.headers().keys() {
-            let mut values = Vec::new();
+            // We guess that most of the time there will be only one header value
+            let mut values = Vec::with_capacity(1);
 
             for value in response.headers().get_all(key) {
                 values.push(value.to_str()?.to_string());

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use hyper::body::Bytes;
 use lagon_runtime_http::Response;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     fs,
     path::{Path, PathBuf},
 };
@@ -39,8 +39,7 @@ pub fn handle_asset(root: PathBuf, asset: &String) -> Result<Response> {
         },
     );
 
-    let mut headers = HashMap::with_capacity(1);
-    headers.insert("content-type".into(), vec![content_type.into()]);
+    let headers = Vec::from([("content-type".into(), vec![content_type.into()])]);
 
     Ok(Response {
         status: 200,

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -39,7 +39,7 @@ pub fn handle_asset(root: PathBuf, asset: &String) -> Result<Response> {
         },
     );
 
-    let headers = Vec::from([("content-type".into(), vec![content_type.into()])]);
+    let headers = vec![("content-type".into(), vec![content_type.into()])];
 
     Ok(Response {
         status: 200,

--- a/crates/runtime_v8_utils/src/lib.rs
+++ b/crates/runtime_v8_utils/src/lib.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use anyhow::{anyhow, Result};
 
 pub fn extract_v8_string(
@@ -24,7 +22,7 @@ pub fn extract_v8_integer(value: v8::Local<v8::Value>, scope: &mut v8::HandleSco
 pub fn extract_v8_headers_object(
     value: v8::Local<v8::Value>,
     scope: &mut v8::HandleScope,
-) -> Result<Option<HashMap<String, Vec<String>>>> {
+) -> Result<Option<Vec<(String, Vec<String>)>>> {
     if !value.is_map() {
         return Err(anyhow!("Value is not of type 'Map'"));
     }
@@ -34,7 +32,7 @@ pub fn extract_v8_headers_object(
     if map.size() > 0 {
         let headers_keys = map.as_array(scope);
         let length = headers_keys.length();
-        let mut headers = HashMap::with_capacity((length / 2) as usize);
+        let mut headers = Vec::with_capacity((length / 2) as usize);
 
         for mut index in 0..length {
             if index % 2 != 0 {
@@ -73,7 +71,7 @@ pub fn extract_v8_headers_object(
                     result
                 });
 
-            headers.insert(key, values);
+            headers.push((key, values));
         }
 
         return Ok(Some(headers));
@@ -120,7 +118,7 @@ pub fn v8_uint8array<'a>(
 
 pub fn v8_headers_object<'a>(
     scope: &mut v8::HandleScope<'a>,
-    value: HashMap<String, Vec<String>>,
+    value: Vec<(String, Vec<String>)>,
 ) -> v8::Local<'a, v8::Object> {
     let len = value.len();
 


### PR DESCRIPTION
## About

Reduce memory allocations of `Request` / `Response` by representing the headers using a `Vec<(String, Vec<String>)>` instead of a `HashMap<String, String>`

Looking at the difference between `Response::from_v8` & `Request::into_v8`:

Before:

![image](https://user-images.githubusercontent.com/43268759/235418204-aa95f6e9-7c4c-4841-ab9c-507039179b98.png)


After:

![image](https://user-images.githubusercontent.com/43268759/235418220-f6f39423-06a1-4d5b-84e9-b4249becaadc.png)

