### PR TITLE
perf(runtime,js-runtime): revert body as ArrayBuffer

### DIFF
--- a/.changeset/stupid-spies-jog.md
+++ b/.changeset/stupid-spies-jog.md
@@ -1,6 +1,7 @@
 ---
 '@lagon/runtime': patch
+'@lagon/cli': patch
 '@lagon/js-runtime': patch
 ---
 
-Use ArrayBuffer for Request/response body
+Improve Request/Response default headers

--- a/crates/runtime/tests/fetch.rs
+++ b/crates/runtime/tests/fetch.rs
@@ -206,7 +206,7 @@ async fn response_headers() {
 
     assert_eq!(
         receiver.recv_async().await.unwrap().as_response(),
-        Response::from("content-length: 0 x-token: hello")
+        Response::from("content-length: 0 content-type: text/plain;charset=UTF-8 x-token: hello")
     );
 }
 

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -55,7 +55,9 @@ impl IntoV8 for Request {
 
         if body_exists {
             names.push(v8_string(scope, "b").into());
-            values.push(v8_string(scope, std::str::from_utf8(&self.body).unwrap()).into());
+            values.push(
+                v8_string(scope, unsafe { std::str::from_utf8_unchecked(&self.body) }).into(),
+            );
         }
 
         if let Some(headers) = self.headers {

--- a/crates/runtime_http/src/request.rs
+++ b/crates/runtime_http/src/request.rs
@@ -6,8 +6,7 @@ use hyper::{
     Body, Request as HyperRequest,
 };
 use lagon_runtime_v8_utils::{
-    extract_v8_headers_object, extract_v8_string, extract_v8_uint8array, v8_headers_object,
-    v8_string, v8_uint8array,
+    extract_v8_headers_object, extract_v8_string, v8_headers_object, v8_string,
 };
 use std::str::FromStr;
 
@@ -56,7 +55,7 @@ impl IntoV8 for Request {
 
         if body_exists {
             names.push(v8_string(scope, "b").into());
-            values.push(v8_uint8array(scope, self.body.to_vec()).into());
+            values.push(v8_string(scope, std::str::from_utf8(&self.body).unwrap()).into());
         }
 
         if let Some(headers) = self.headers {
@@ -84,7 +83,7 @@ impl FromV8 for Request {
 
         if let Some(body_value) = request.get(scope, body_key.into()) {
             if !body_value.is_null_or_undefined() {
-                body = Bytes::from(extract_v8_uint8array(body_value)?);
+                body = Bytes::from(extract_v8_string(body_value, scope)?);
             }
         }
 

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -55,7 +55,7 @@ impl IntoV8 for Response {
         let mut values = Vec::with_capacity(len);
 
         names.push(v8_string(scope, "b").into());
-        values.push(v8_string(scope, std::str::from_utf8(&self.body).unwrap()).into());
+        values.push(v8_string(scope, unsafe { std::str::from_utf8_unchecked(&self.body) }).into());
 
         names.push(v8_string(scope, "s").into());
         values.push(v8_integer(scope, self.status.into()).into());

--- a/crates/runtime_http/src/response.rs
+++ b/crates/runtime_http/src/response.rs
@@ -6,8 +6,8 @@ use hyper::{
     Body, Response as HyperResponse,
 };
 use lagon_runtime_v8_utils::{
-    extract_v8_headers_object, extract_v8_integer, extract_v8_uint8array, v8_headers_object,
-    v8_integer, v8_string, v8_uint8array,
+    extract_v8_headers_object, extract_v8_integer, extract_v8_string, v8_headers_object,
+    v8_integer, v8_string,
 };
 use std::str::FromStr;
 
@@ -55,7 +55,7 @@ impl IntoV8 for Response {
         let mut values = Vec::with_capacity(len);
 
         names.push(v8_string(scope, "b").into());
-        values.push(v8_uint8array(scope, self.body.to_vec()).into());
+        values.push(v8_string(scope, std::str::from_utf8(&self.body).unwrap()).into());
 
         names.push(v8_string(scope, "s").into());
         values.push(v8_integer(scope, self.status.into()).into());
@@ -84,7 +84,7 @@ impl FromV8 for Response {
         let body_key = v8_string(scope, "b");
 
         if let Some(body_value) = response.get(scope, body_key.into()) {
-            body = extract_v8_uint8array(body_value)?;
+            body = extract_v8_string(body_value, scope)?;
         } else {
             return Err(anyhow!("Could not find body"));
         }

--- a/crates/wpt-runner/current-results.md
+++ b/crates/wpt-runner/current-results.md
@@ -1586,55 +1586,10 @@ TEST DONE 0 Unusual but valid property bag: function() {}
 TEST DONE 1 Property bag propagates exceptions
 Running ../../tools/wpt/FileAPI/file/send-file-formdata-controls.any.js
 TEST DONE 1 Upload file-for-upload-in-form-NUL-[ ].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-BS-[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-VT-[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-LF-[
-].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-LF-CR-[
-].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-CR-[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-CR-LF-[
-].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-HT-[	].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-FF-[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-DEL-[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-ESC-[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-SPACE-[ ].txt (ASCII) in fetch with FormData
 Running ../../tools/wpt/FileAPI/file/send-file-formdata-punctuation.any.js
 TEST DONE 1 Upload file-for-upload-in-form-QUOTATION-MARK-["].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload "file-for-upload-in-form-double-quoted.txt" (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-REVERSE-SOLIDUS-[\].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-EXCLAMATION-MARK-[!].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-DOLLAR-SIGN-[$].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-PERCENT-SIGN-[%].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-AMPERSAND-[&].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-APOSTROPHE-['].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-LEFT-PARENTHESIS-[(].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-RIGHT-PARENTHESIS-[)].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-ASTERISK-[*].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-PLUS-SIGN-[+].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-COMMA-[,].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-FULL-STOP-[.].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-SOLIDUS-[/].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-COLON-[:].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-SEMICOLON-[;].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-EQUALS-SIGN-[=].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-QUESTION-MARK-[?].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-CIRCUMFLEX-ACCENT-[^].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-LEFT-SQUARE-BRACKET-[[].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-RIGHT-SQUARE-BRACKET-[]].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-LEFT-CURLY-BRACKET-[{].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-VERTICAL-LINE-[|].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-RIGHT-CURLY-BRACKET-[}].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-TILDE-[~].txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload 'file-for-upload-in-form-single-quoted.txt' (ASCII) in fetch with FormData
 Running ../../tools/wpt/FileAPI/file/send-file-formdata-utf-8.any.js
 TEST DONE 1 Upload file-for-upload-in-form.txt (ASCII) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-.txt (x-user-defined) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-â˜ºðŸ˜‚.txt (windows-1252) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-★星★.txt (JIS X 0201 and JIS X 0208) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-☺😂.txt (Unicode) in fetch with FormData
-TEST DONE 1 Upload file-for-upload-in-form-ABC~‾¥≈¤･・•∙·☼★星🌟星★☼·∙•・･¤≈¥‾~XYZ.txt (Unicode) in fetch with FormData
 Running ../../tools/wpt/FileAPI/file/send-file-formdata.any.js
 TEST DONE 1 Upload file-for-upload-in-form.txt (ASCII) in fetch with FormData
 Running ../../tools/wpt/FileAPI/reading-data-section/Determining-Encoding.any.js
@@ -1745,5 +1700,5 @@ Running ../../tools/wpt/urlpattern/urlpattern-compare.https.any.js
 Running ../../tools/wpt/urlpattern/urlpattern.any.js
 Running ../../tools/wpt/urlpattern/urlpattern.https.any.js
 
-1615 tests, 464 passed, 1145 failed
- -> 28% conformance
+1576 tests, 464 passed, 1103 failed
+ -> 29% conformance

--- a/packages/js-runtime/src/__tests__/fetch.test.ts
+++ b/packages/js-runtime/src/__tests__/fetch.test.ts
@@ -191,7 +191,7 @@ describe('fetch', () => {
     expect(globalThis.LagonAsync.fetch).toHaveBeenCalledWith({
       m: 'POST',
       u: 'https://google.com',
-      b: new Uint8Array([65, 32, 98, 111, 100, 121]),
+      b: 'A body',
     });
   });
 });

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -62,8 +62,8 @@ declare global {
   };
 
   var LagonAsync: {
-    fetch: ({ h, m, b, u }: { h?: Map<string, string>; m: string; b?: ArrayBuffer; u: string }) => Promise<{
-      b: ArrayBuffer;
+    fetch: ({ h, m, b, u }: { h?: Map<string, string>; m: string; b?: string; u: string }) => Promise<{
+      b: Uint8Array;
       s: number;
       h?: Record<string, string>;
     }>;
@@ -108,7 +108,7 @@ declare global {
       b: RequestInit['body'];
     },
   ) => Promise<{
-    b: ArrayBuffer;
+    b: string;
     h: ResponseInit['headers'];
     s: ResponseInit['status'];
   }>;
@@ -138,7 +138,7 @@ globalThis.masterHandler = async (id, request) => {
   });
 
   const response = await handler(handlerRequest);
-  let body: ArrayBuffer;
+  let body: string;
 
   if (response.isStream) {
     const responseBody = response.body;
@@ -147,7 +147,7 @@ globalThis.masterHandler = async (id, request) => {
       throw new Error('Got a stream without a body');
     }
 
-    body = globalThis.__lagon__.TEXT_ENCODER.encode(responseBody.toString());
+    body = responseBody.toString();
     const reader = responseBody.getReader();
 
     const read = () => {
@@ -167,7 +167,7 @@ globalThis.masterHandler = async (id, request) => {
 
     read();
   } else {
-    body = await response.arrayBuffer();
+    body = await response.text();
   }
 
   return {

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -14,17 +14,17 @@
       headers = new Map(Object.entries(init.headers));
     }
 
-    let body: ArrayBuffer | undefined;
+    let body: string | undefined;
 
     if (init?.body) {
-      if (!globalThis.__lagon__.isIterable(init.body)) {
+      if (globalThis.__lagon__.isIterable(init.body)) {
+        body = globalThis.__lagon__.TEXT_DECODER.decode(init.body);
+      } else {
         if (typeof init.body !== 'string') {
           // TODO: Support other body types
           throw new Error('Body must be a string or an iterable');
         }
 
-        body = globalThis.__lagon__.TEXT_ENCODER.encode(init.body);
-      } else {
         body = init.body;
       }
     }


### PR DESCRIPTION
## About

Partially revert https://github.com/lagonapp/lagon/pull/807: use a string for Request/Response body as it's faster than encoding/decoding a lot inside JS-land, but keep the implementation improvements (default headers & other perf improvements)

Before:

![image](https://user-images.githubusercontent.com/43268759/235439235-0f464fcd-6e8c-4aa3-bbfb-d61edbe082cc.png)



After:

![image](https://user-images.githubusercontent.com/43268759/235439225-925d43be-1086-4e04-afc7-556fdc3bc2a5.png)

