### PR TITLE
chore(www,docs,dashboard): disable ESLint + TypeScript when building …

### DIFF
--- a/.changeset/tidy-cheetahs-cross.md
+++ b/.changeset/tidy-cheetahs-cross.md
@@ -1,0 +1,7 @@
+---
+'@lagon/dashboard': patch
+'@lagon/docs': patch
+'@lagon/www': patch
+---
+
+Disable ESLint + TypeScript when building Next.js website

--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -9,11 +9,18 @@ const { withSentryConfig } = require('@sentry/nextjs');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  swcMinify: true,
   i18n: {
     locales: ['en', 'fr'],
     defaultLocale: 'en',
   },
   transpilePackages: ['@lagon/ui'],
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 const sentryWebpackPluginOptions = {

--- a/packages/docs/next.config.js
+++ b/packages/docs/next.config.js
@@ -9,6 +9,12 @@ const nextConfig = {
       permanent: true,
     },
   ],
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 const withNextra = require('nextra')({

--- a/www/next.config.js
+++ b/www/next.config.js
@@ -10,12 +10,19 @@ const withMDX = require('@next/mdx')({
 const nextConfig = {
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
   reactStrictMode: true,
+  swcMinify: true,
   experimental: {
     appDir: true,
   },
   output: 'export',
   images: {
     unoptimized: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
   },
 };
 


### PR DESCRIPTION
…Next.js website

## About

ESLint & TypeScript already runs on the CI, so it's useless to run them when building our Next.js websites.
