### PR TITLE
feat(cli): add link to authorization code on `lagon login`

### DIFF
--- a/.changeset/odd-shoes-unite.md
+++ b/.changeset/odd-shoes-unite.md
@@ -2,4 +2,4 @@
 '@lagon/cli': patch
 ---
 
-Add info message with link to get authorization code when using `lagon dev`
+Add info message with link to get authorization code when using `lagon login`

--- a/.changeset/odd-shoes-unite.md
+++ b/.changeset/odd-shoes-unite.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Add info message with link to get authorization code when using `lagon dev`

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use dialoguer::{Confirm, Password};
 use serde::{Deserialize, Serialize};
 
-use crate::utils::{debug, info, input, print_progress, success, Config, TrpcClient};
+use crate::utils::{debug, error, info, input, print_progress, success, Config, TrpcClient};
 
 #[derive(Deserialize, Debug)]
 struct CliResponse {
@@ -31,7 +31,11 @@ pub async fn login() -> Result<()> {
 
     let end_progress = print_progress("Opening browser...");
     let url = config.site_url.clone() + "/cli";
-    webbrowser::open(&url)?;
+
+    if let Err(_) = webbrowser::open(&url) {
+        println!("{}", error("Couldn't open browser."));
+    }
+
     end_progress();
 
     println!();

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -37,7 +37,7 @@ pub async fn login() -> Result<()> {
     println!();
     println!(
         "{}",
-        info("Please copy and paste the verification from your browser.")
+        info(&format!("Please copy and paste the verification from your browser. You can also manually visit {}", url))
     );
 
     let code = Password::new()

--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -32,7 +32,7 @@ pub async fn login() -> Result<()> {
     let end_progress = print_progress("Opening browser...");
     let url = config.site_url.clone() + "/cli";
 
-    if let Err(_) = webbrowser::open(&url) {
+    if webbrowser::open(&url).is_err() {
         println!("{}", error("Couldn't open browser."));
     }
 


### PR DESCRIPTION
## About

Add a link to get the authorization code when using `lagon login`, in case the browser wasn't opened.