### PR TITLE
perf(cli,serverless): tweak release build flags

### DIFF
--- a/.changeset/eleven-plants-flow.md
+++ b/.changeset/eleven-plants-flow.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Tweak release build flags to improve performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,9 +1262,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3220,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,8 @@ members = [
   "crates/cli",
   "crates/wpt-runner",
 ]
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+panic = "abort"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ colored = "2.0.0"
 dirs = "5.0.1"
 webbrowser = "0.8.9"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
-hyper = { version = "0.14", features = ["client", "server", "http1", "runtime", "stream"] }
+hyper = { version = "0.14.26", features = ["client", "server", "http1", "runtime", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2.3.3"

--- a/crates/runtime_http/Cargo.toml
+++ b/crates/runtime_http/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 v8 = "0.70.0"
-hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
+hyper = { version = "0.14.26", features = ["client", "http1", "http2", "tcp"] }
 anyhow = "1.0.71"
 lagon-runtime-v8-utils = { path = "../runtime_v8_utils" }

--- a/crates/runtime_isolate/Cargo.toml
+++ b/crates/runtime_isolate/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 v8 = "0.70.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 futures = "0.3.28"
-hyper = { version = "0.14", features = ["client"] }
+hyper = { version = "0.14.26", features = ["client"] }
 hyper-tls = { version = "0.5.0", features = ["vendored"] }
 flume = "0.10.14"
 anyhow = "1.0.71"

--- a/crates/runtime_utils/Cargo.toml
+++ b/crates/runtime_utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.71"
 lagon-runtime-http = { path = "../runtime_http" }
-hyper = { version = "0.14", features = ["stream"] }
+hyper = { version = "0.14.26", features = ["stream"] }
 flume = "0.10.14"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-hyper = { version = "0.14", features = ["server", "http1", "runtime", "stream"] }
+hyper = { version = "0.14.26", features = ["server", "http1", "runtime", "stream"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "signal"] }
 tokio-util = { version = "0.7.8", features = ["rt"] }
 lagon-runtime = { path = "../runtime" }


### PR DESCRIPTION
## About

Tweak release build flags to improve performance (but increases build time (for release only)).
Also upgrade hyper to latest patch.
