### PR TITLE
feat(astro): write config if not present when building

### DIFF
--- a/.changeset/thin-lies-warn.md
+++ b/.changeset/thin-lies-warn.md
@@ -1,0 +1,5 @@
+---
+'@lagon/astro': minor
+---
+
+Write Lagon config if not present when building


### PR DESCRIPTION
## About

Write Lagon's configuration file if not present when building using the Astro integration, similar to what we did on Nitro: https://github.com/unjs/nitro/pull/996

![Screenshot 2023-05-10 at 19 37 44](https://github.com/lagonapp/lagon/assets/43268759/289e5a77-7caa-4ce2-92e2-a262f052ea8f)
