### PR TITLE
fix(dashboard,serverless): typo, playground types & result errors logs

### DIFF
--- a/.changeset/fair-pandas-swim.md
+++ b/.changeset/fair-pandas-swim.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Fix "Londo" -> "London" typo

--- a/.changeset/nine-ghosts-shop.md
+++ b/.changeset/nine-ghosts-shop.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Set playground TS to ESNext & add dom.iterable

--- a/.changeset/real-flowers-peel.md
+++ b/.changeset/real-flowers-peel.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Ingest results error to the logs

--- a/packages/dashboard/lib/components/Playground.tsx
+++ b/packages/dashboard/lib/components/Playground.tsx
@@ -1,5 +1,4 @@
 import Editor, { useMonaco } from '@monaco-editor/react';
-import useTheme from 'lib/hooks/useTheme';
 import { useEffect } from 'react';
 
 type PlaygroundProps = {
@@ -41,7 +40,7 @@ const Playground = ({ defaultValue, width, height }: PlaygroundProps) => {
       });
 
       monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-        lib: ['es2015', 'dom'],
+        lib: ['esnext', 'dom', 'dom.iterable'],
         allowNonTsExtensions: true,
       });
     }

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -27,7 +27,7 @@ export const REGIONS = {
   'hillsboro-us-west': 'Hillsboro (us-west)',
   'san-francisco-us-west': 'San Francisco (us-west)',
   'beauharnois-ca-east': 'Beauharnois (ca-east)',
-  'london-eu-west': 'Londo (eu-west)',
+  'london-eu-west': 'London (eu-west)',
   'paris-eu-west': 'Paris (eu-west)',
   'nuremberg-eu-central': 'Nuremberg (eu-central)',
   'helsinki-eu-north': 'Helsinki (eu-north)',


### PR DESCRIPTION
## About

- Fix "Londo" -> "London" typo
- Set playground TS to ESNext & add dom.iterable
- Ingest results error to the logs