### PR TITLE
fix(js-runtime,cli,serverless): `SubtleCrypto#importKey` re-uses key data

### DIFF
--- a/.changeset/gold-falcons-tie.md
+++ b/.changeset/gold-falcons-tie.md
@@ -1,0 +1,7 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+'@lagon/js-runtime': patch
+---
+
+`SubtleCrypto#importKey` re-use key data

--- a/packages/js-runtime/src/runtime/global/crypto.ts
+++ b/packages/js-runtime/src/runtime/global/crypto.ts
@@ -1,5 +1,5 @@
 interface CryptoKey {
-  readonly keyValue: ArrayBuffer;
+  keyValue: ArrayBuffer;
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -132,7 +132,7 @@ interface CryptoKey {
     readonly usages: KeyUsage[];
 
     // Store the randomly generate key value here
-    readonly keyValue: ArrayBuffer;
+    keyValue: ArrayBuffer;
 
     // Trick to make TypeScript happy, CryptoKey constructor is normally empty
     // but we need to construct it at some point.
@@ -265,7 +265,14 @@ interface CryptoKey {
       keyUsages: ReadonlyArray<KeyUsage> | Iterable<KeyUsage>,
     ): Promise<CryptoKey> {
       // @ts-expect-error CryptoKey constructor is empty, but we know our implementation is not
-      return new CryptoKey(algorithm, extractable, 'secret', keyUsages);
+      const cryptoKey = new CryptoKey(algorithm, extractable, 'secret', keyUsages);
+
+      if (format === 'raw') {
+        // @ts-expect-error wrong format
+        cryptoKey.keyValue = keyData;
+      }
+
+      return cryptoKey;
     }
 
     async sign(


### PR DESCRIPTION
## About

`SubtleCrypto#importKey` re-uses key data when format is `raw`