### PR TITLE
feat(runtime): allow `export as` for handler function

### DIFF
--- a/.changeset/nasty-ads-buy.md
+++ b/.changeset/nasty-ads-buy.md
@@ -1,0 +1,8 @@
+---
+'@lagon/cli': patch
+'@lagon/runtime': patch
+'@lagon/serverless': patch
+'@lagon/js-runtime': patch
+---
+
+Allow `export as` for handler function

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -22,6 +22,25 @@ async fn execute_function() {
 }
 
 #[tokio::test]
+async fn execute_function_export_as() {
+    utils::setup();
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
+        "function hello() {
+    return new Response('Hello world');
+}
+
+export { hello as handler }"
+            .into(),
+    ));
+    send(Request::default());
+
+    assert_eq!(
+        receiver.recv_async().await.unwrap().as_response(),
+        Response::from("Hello world")
+    );
+}
+
+#[tokio::test]
 async fn execute_function_twice() {
     utils::setup();
     let (send, receiver) = utils::create_isolate(IsolateOptions::new(

--- a/crates/runtime_isolate/src/options.rs
+++ b/crates/runtime_isolate/src/options.rs
@@ -127,8 +127,7 @@ impl IsolateOptions {
                     scope,
                     &format!(
                         r"{environment_variables}
-{code}
-globalThis.handler = handler;"
+{code}"
                     ),
                 ),
                 environment_variables.lines().count() + 1,
@@ -146,8 +145,7 @@ globalThis.handler = handler;"
                     &format!(
                         r"{JS_RUNTIME}
 {environment_variables}
-{code}
-globalThis.handler = handler;"
+{code}"
                     ),
                 ),
                 JS_RUNTIME.lines().count() + environment_variables.lines().count() + 2,

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -113,9 +113,9 @@ declare global {
     TEXT_DECODER: TextDecoder;
   };
   var __storage__: Map<AsyncContext, unknown>;
-  var handler: (request: Request) => Promise<Response>;
   var masterHandler: (
     id: number,
+    handler: (request: Request) => Promise<Response>,
     request: {
       i: string;
       m: RequestInit['method'];
@@ -141,7 +141,7 @@ declare global {
   }
 }
 
-globalThis.masterHandler = async (id, request) => {
+globalThis.masterHandler = async (id, handler, request) => {
   if (typeof handler !== 'function') {
     throw new Error('Handler function is not defined or is not a function');
   }


### PR DESCRIPTION
## About

Allow using `export as` for the handler function, which is often generated by bundlers.

Instead of relying on setting `globalThis.handler`, the handler function is grabbed from the module's exports and passed as an argument to the `masterHandler`