### PR TITLE
feat(runtime_utils): add dark-mode for error pages

### DIFF
--- a/.changeset/nervous-books-fetch.md
+++ b/.changeset/nervous-books-fetch.md
@@ -1,0 +1,5 @@
+---
+'@lagon/runtime-utils': minor
+---
+
+Add dark-mode for error pages

--- a/crates/runtime_utils/public/403.html
+++ b/crates/runtime_utils/public/403.html
@@ -9,15 +9,16 @@
 </head>
 
 <body>
-  <section class="w-screen h-screen flex items-center justify-center flex-col">
-    <h1 class="font-semibold text-3xl text-gray-900 mb-1">Forbidden</h1>
+  <section class="w-screen h-screen flex items-center justify-center flex-col dark:bg-stone-800">
+    <h1 class="font-semibold text-3xl text-gray-900 dark:text-gray-200 mb-1">Forbidden</h1>
     <span class="uppercase text-lg text-blue-500 mb-6">403</span>
-    <p class="text-base text-gray-800 text-center">You can't access this deployment.</p>
+    <p class="text-base text-gray-800 dark:text-gray-300 text-center">You can't access this deployment.</p>
   </section>
 
   <footer class="absolute bottom-4 left-[50%] transform -translate-x-[50%]">
     <a href="https://lagon.app" target="_blank">
-      <img class="h-6" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 dark:hidden" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 hidden dark:block" alt="Lagon logo for dark mode" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-white.png?raw=true" />
     </a>
   </footer>
 </body>

--- a/crates/runtime_utils/public/404.html
+++ b/crates/runtime_utils/public/404.html
@@ -9,15 +9,16 @@
 </head>
 
 <body>
-  <section class="w-screen h-screen flex items-center justify-center flex-col">
-    <h1 class="font-semibold text-3xl text-gray-900 mb-1">Deployment not found</h1>
+  <section class="w-screen h-screen flex items-center justify-center flex-col dark:bg-stone-800">
+    <h1 class="font-semibold text-3xl text-gray-900 dark:text-gray-200 mb-1">Deployment not found</h1>
     <span class="uppercase text-lg text-blue-500 mb-6">404</span>
-    <p class="text-base text-gray-800 text-center">This Deployment does not exist.</p>
+    <p class="text-base text-gray-800 dark:text-gray-300 text-center">This Deployment does not exist.</p>
   </section>
 
   <footer class="absolute bottom-4 left-[50%] transform -translate-x-[50%]">
     <a href="https://lagon.app" target="_blank">
-      <img class="h-6" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 dark:hidden" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 hidden dark:block" alt="Lagon logo for dark mode" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-white.png?raw=true" />
     </a>
   </footer>
 </body>

--- a/crates/runtime_utils/public/500.html
+++ b/crates/runtime_utils/public/500.html
@@ -9,10 +9,10 @@
 </head>
 
 <body>
-  <section class="w-screen h-screen flex items-center justify-center flex-col">
-    <h1 class="font-semibold text-3xl text-gray-900 mb-1">Function errored</h1>
+  <section class="w-screen h-screen flex items-center justify-center flex-col dark:bg-stone-800">
+    <h1 class="font-semibold text-3xl text-gray-900 dark:text-gray-200 mb-1">Function errored</h1>
     <span class="uppercase text-lg text-blue-500 mb-6">500</span>
-    <p class="text-base text-gray-800 text-center">
+    <p class="text-base text-gray-800 dark:text-gray-300 text-center">
       An error occurred while running this Function.
       <br />
       If you are the owner, check the logs.
@@ -21,7 +21,8 @@
 
   <footer class="absolute bottom-4 left-[50%] transform -translate-x-[50%]">
     <a href="https://lagon.app" target="_blank">
-      <img class="h-6" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 dark:hidden" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 hidden dark:block" alt="Lagon logo for dark mode" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-white.png?raw=true" />
     </a>
   </footer>
 </body>

--- a/crates/runtime_utils/public/502.html
+++ b/crates/runtime_utils/public/502.html
@@ -9,10 +9,10 @@
 </head>
 
 <body>
-  <section class="w-screen h-screen flex items-center justify-center flex-col">
-    <h1 class="font-semibold text-3xl text-gray-900 mb-1">Function resources reached</h1>
+  <section class="w-screen h-screen flex items-center justify-center flex-col dark:bg-stone-800">
+    <h1 class="font-semibold text-3xl text-gray-900 dark:text-gray-200 mb-1">Function resources reached</h1>
     <span class="uppercase text-lg text-blue-500 mb-6">502</span>
-    <p class="text-base text-gray-800 text-center">
+    <p class="text-base text-gray-800 dark:text-gray-300 text-center">
       Resources have been reached for this
       <br />
       Function. Please try again.
@@ -21,7 +21,8 @@
 
   <footer class="absolute bottom-4 left-[50%] transform -translate-x-[50%]">
     <a href="https://lagon.app" target="_blank">
-      <img class="h-6" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 dark:hidden" alt="Lagon logo" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-black.png?raw=true" />
+      <img class="h-6 hidden dark:block" alt="Lagon logo for dark mode" src="https://github.com/lagonapp/lagon/blob/main/assets/logo-white.png?raw=true" />
     </a>
   </footer>
 </body>


### PR DESCRIPTION
## About

This PR adds dark-mode support for error pages. This especially fixes the readability of the error pages when shown in the playground. Previously it looked like:

![Screenshot from 2023-05-15 11-15-25](https://github.com/lagonapp/lagon/assets/6918444/789776c8-ed38-4d28-8ba6-8efa80fb7a39)

