### PR TITLE
fix(dashboard): use correct monaco theme

### DIFF
--- a/.changeset/lazy-bears-tap.md
+++ b/.changeset/lazy-bears-tap.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Use correct theme for playground editor

--- a/packages/dashboard/lib/components/Playground.tsx
+++ b/packages/dashboard/lib/components/Playground.tsx
@@ -11,13 +11,18 @@ const Playground = ({ defaultValue, width, height }: PlaygroundProps) => {
   const monaco = useMonaco();
 
   useEffect(() => {
+    function setTheme(element = document.documentElement) {
+      const darkMode = element.classList.contains('dark');
+      monaco?.editor.setTheme(darkMode ? 'vs-dark' : 'vs-light');
+    }
+
     if (monaco) {
+      setTheme();
+
       const observer = new MutationObserver(mutations => {
         mutations.forEach(mutation => {
           if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-            const darkMode = (mutation.target as HTMLElement).classList.contains('dark');
-
-            monaco.editor.setTheme(darkMode ? 'vs-dark' : 'vs-light');
+            setTheme(mutation.target as HTMLElement);
           }
         });
       });

--- a/packages/dashboard/lib/components/Playground.tsx
+++ b/packages/dashboard/lib/components/Playground.tsx
@@ -1,5 +1,5 @@
 import Editor, { useMonaco } from '@monaco-editor/react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 type PlaygroundProps = {
   defaultValue: string;
@@ -8,33 +8,32 @@ type PlaygroundProps = {
 };
 
 const Playground = ({ defaultValue, width, height }: PlaygroundProps) => {
+  const [theme, setTheme] = useState('vs-light');
   const monaco = useMonaco();
 
+  const updateTheme = (element = document?.documentElement) => {
+    const darkMode = element?.classList.contains('dark');
+    setTheme(darkMode ? 'vs-dark' : 'vs-light');
+  };
+
   useEffect(() => {
-    function setTheme(element = document.documentElement) {
-      const darkMode = element.classList.contains('dark');
-      monaco?.editor.setTheme(darkMode ? 'vs-dark' : 'vs-light');
-    }
+    updateTheme();
 
-    if (monaco) {
-      setTheme();
-
-      const observer = new MutationObserver(mutations => {
-        mutations.forEach(mutation => {
-          if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-            setTheme(mutation.target as HTMLElement);
-          }
-        });
+    const observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          updateTheme(mutation.target as HTMLElement);
+        }
       });
+    });
 
-      observer.observe(document.documentElement, {
-        attributes: true,
-      });
+    observer.observe(document.documentElement, {
+      attributes: true,
+    });
 
-      return () => {
-        observer.disconnect();
-      };
-    }
+    return () => {
+      observer.disconnect();
+    };
   }, [monaco]);
 
   useEffect(() => {
@@ -55,6 +54,7 @@ const Playground = ({ defaultValue, width, height }: PlaygroundProps) => {
     <Editor
       width={width}
       height={height}
+      theme={theme}
       options={{
         minimap: {
           enabled: false,


### PR DESCRIPTION
## About

Fix setting correct monaco editor theme in playground. The editor theme was only set after changing the theme not on initial page load.

# TODO
- useEffect is not called again when going back to the page again