### PR TITLE
fix: create s3 bucket for minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,8 @@ services:
     environment:
       MINIO_ROOT_USER: ${S3_ACCESS_KEY:-root}
       MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-supersecret}
-    command: server /data --console-address ":9001" --address ":9002"
+    entrypoint: sh
+    command: -c 'mkdir -p /data/lagon && minio server /data --console-address ":9001" --address ":9002"'
 
 volumes:
   redis:


### PR DESCRIPTION
## About

- creates the `lagon` s3 bucket on start when using minio
