### PR TITLE
fix(dashboard): restrict environment variable keys characters

### DIFF
--- a/.changeset/selfish-meals-joke.md
+++ b/.changeset/selfish-meals-joke.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Only allow alphanumeric characters, numbers and underscore as environment variable keys

--- a/packages/dashboard/lib/form/validators.ts
+++ b/packages/dashboard/lib/form/validators.ts
@@ -60,6 +60,16 @@ export const emailValidator: FieldValidator<string | number> = value => {
   return 'Field must be a string';
 };
 
+export const alphaNumUnderscoreValidator: FieldValidator<string | number> = value => {
+  if (typeof value === 'string') {
+    return /^[a-zA-Z0-9_]+$/.test(value)
+      ? undefined
+      : 'Field must only contain alphanumeric characters and underscores';
+  }
+
+  return undefined;
+};
+
 export const composeValidators =
   (...validators: FieldValidator<string | number>[]): FieldValidator<string | number> =>
   value => {

--- a/packages/dashboard/lib/pages/function/FunctionSettings.tsx
+++ b/packages/dashboard/lib/pages/function/FunctionSettings.tsx
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast';
 import { Button, Card, Form, Input, Text, Dialog, Menu, Divider, Dot } from '@lagon/ui';
 import { getCurrentDomain, getFullDomain } from 'lib/utils';
 import {
+  alphaNumUnderscoreValidator,
   composeValidators,
   cronValidator,
   domainNameValidator,
@@ -406,7 +407,10 @@ const FunctionSettings = ({ func, refetch }: FunctionSettingsProps) => {
                       event.preventDefault();
                     }
                   }}
-                  validator={maxLengthValidator(ENVIRONMENT_VARIABLE_KEY_MAX_LENGTH)}
+                  validator={composeValidators(
+                    maxLengthValidator(ENVIRONMENT_VARIABLE_KEY_MAX_LENGTH),
+                    alphaNumUnderscoreValidator,
+                  )}
                 />
                 <Input
                   name="envValue"


### PR DESCRIPTION
## About

Only allow alphanumeric characters, numbers, and underscore as environment variable keys.