### PR TITLE
fix(js-runtime): set content-length header for POST/PUT with null body

### DIFF
--- a/.changeset/breezy-cycles-glow.md
+++ b/.changeset/breezy-cycles-glow.md
@@ -1,0 +1,7 @@
+---
+'@lagon/js-runtime': patch
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Set content-length header to 0 when body is null and method POST or PUT in `fetch()`

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -1,6 +1,8 @@
 (globalThis => {
   const isHeadersObject = (headers?: HeadersInit): headers is Headers => !!headers && 'entries' in headers;
 
+  const FORCE_0_CONTENT_LENGTH_METHODS = ['POST', 'PUT'];
+
   globalThis.fetch = async (input, init) => {
     let headers: Map<string, string> | undefined = undefined;
 
@@ -27,6 +29,14 @@
 
         body = init.body;
       }
+    }
+
+    if (body === undefined && init?.method && FORCE_0_CONTENT_LENGTH_METHODS.includes(init.method)) {
+      if (!headers) {
+        headers = new Map();
+      }
+
+      headers?.set('content-length', '0');
     }
 
     const checkAborted = () => {


### PR DESCRIPTION
## About

In `fetch()`, when the body is null and the method is POST or PUT, the `content-length` header should be set to 0:

![Screenshot 2023-06-05 at 07 21 36](https://github.com/lagonapp/lagon/assets/43268759/7741a1e2-38f8-4f00-b2b4-a038bee9f267)

Spec: https://fetch.spec.whatwg.org/#http-network-or-cache-fetch