### PR TITLE
refactor(serverless): revert cache eviction using ClickHouse selects

### DIFF
--- a/.changeset/good-meals-grow.md
+++ b/.changeset/good-meals-grow.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Revert isolates cache eviction using ClickHouse to use local cache instead

--- a/crates/serverless/src/deployments/cache.rs
+++ b/crates/serverless/src/deployments/cache.rs
@@ -1,53 +1,54 @@
-use super::{pubsub::clear_deployment_cache, Deployments};
-use crate::{serverless::Workers, REGION};
-use clickhouse::{Client, Row};
-use serde::Deserialize;
-use std::{collections::HashSet, env, sync::Arc, time::Duration};
+use super::pubsub::clear_deployment_cache;
+use crate::serverless::Workers;
+use dashmap::DashMap;
+use std::{
+    env,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 const CACHE_TASK_INTERVAL: Duration = Duration::from_secs(5);
 
-#[derive(Debug, Row, Deserialize)]
-struct MyRow {
-    count: usize,
-}
-
-pub fn run_cache_clear_task(client: &Client, deployments: Deployments, workers: Workers) {
+pub fn run_cache_clear_task(last_requests: Arc<DashMap<String, Instant>>, workers: Workers) {
     let isolates_cache_seconds = Duration::from_secs(
         env::var("LAGON_ISOLATES_CACHE_SECONDS")
             .expect("LAGON_ISOLATES_CACHE_SECONDS is not set")
             .parse()
             .expect("LAGON_ISOLATES_CACHE_SECONDS is not a valid number"),
     );
-    let client = Arc::new(client.clone());
 
     tokio::spawn(async move {
+        let mut deployments_to_clear = Vec::new();
+
         loop {
             tokio::time::sleep(CACHE_TASK_INTERVAL).await;
 
-            let deployments_id = deployments
-                .iter()
-                .map(|deployment| deployment.id.clone())
-                .collect::<HashSet<_>>();
+            let now = Instant::now();
 
-            for deployment_id in deployments_id {
-                let query = client
-                    .query("SELECT count(*) as count FROM serverless.requests WHERE timestamp >= subtractSeconds(now(), ?) AND region = ? AND deployment_id = ?")
-                    .bind(isolates_cache_seconds.as_secs())
-                    .bind(REGION.clone())
-                    .bind(deployment_id.clone())
-                    .fetch_one::<MyRow>().await;
+            for last_request in last_requests.iter() {
+                let (deployment_id, last_request) = last_request.pair();
 
-                if let Ok(row) = query {
-                    if row.count == 0 {
-                        clear_deployment_cache(
-                            deployment_id,
-                            Arc::clone(&workers),
-                            String::from("expiration"),
-                        )
-                        .await;
-                    }
+                if now.duration_since(*last_request) > isolates_cache_seconds {
+                    deployments_to_clear.push(deployment_id.clone());
                 }
             }
+
+            if deployments_to_clear.is_empty() {
+                continue;
+            }
+
+            for deployment_id in &deployments_to_clear {
+                last_requests.remove(deployment_id);
+
+                clear_deployment_cache(
+                    deployment_id.clone(),
+                    Arc::clone(&workers),
+                    String::from("expiration"),
+                )
+                .await;
+            }
+
+            deployments_to_clear.clear();
         }
     });
 }


### PR DESCRIPTION
## About

Partially revert https://github.com/lagonapp/lagon/pull/883 to use a hashmap for the last requests cache instead of making expensive ClickHouse queries.
