### PR TITLE
fix(cli): load env file based on current directory

### DIFF
--- a/.changeset/metal-mangos-watch.md
+++ b/.changeset/metal-mangos-watch.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Load environment variable file based on current directory


### PR DESCRIPTION
## About

Small fix to load the given environment file based on the current (or specified) directory, instead of deriving it from the root. This will also better detect automatically `.env` files when using `lagon dev path/to/folder`