### PR TITLE
fix(runtime): out bytes for sync responses

### DIFF
--- a/.changeset/pretty-socks-grab.md
+++ b/.changeset/pretty-socks-grab.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime-utils': patch
+'@lagon/serverless': patch
+---
+
+Fix sync responses bytes length


### PR DESCRIPTION
## About

Fix a regression in #883 were the out bytes were always 0 for sync responses. Also improve tests to prevent future regressions.