### PR TITLE
feat(runtime,docs): support HTTP/2 in `fetch()`

### DIFF
--- a/.changeset/new-insects-retire.md
+++ b/.changeset/new-insects-retire.md
@@ -1,0 +1,8 @@
+---
+'@lagon/runtime': patch
+'@lagon/docs': patch
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Support HTTP/2 (along with HTTP/1.1) in `fetch()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,17 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.16",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1561,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,16 +1855,15 @@ name = "lagon-runtime-isolate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion",
  "flume",
  "futures",
  "hyper",
- "hyper-tls",
  "lagon-runtime-crypto",
  "lagon-runtime-http",
  "lagon-runtime-v8-utils",
  "linked-hash-map",
  "log",
+ "reqwest",
  "tokio",
  "v8",
 ]
@@ -3104,6 +3105,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3113,11 +3115,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -3125,6 +3130,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3283,6 +3289,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rxml"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,6 +3374,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -3906,6 +3953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,6 +4344,25 @@ dependencies = [
  "raw-window-handle",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/crates/runtime_isolate/Cargo.toml
+++ b/crates/runtime_isolate/Cargo.toml
@@ -8,15 +8,14 @@ v8 = "0.73.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 futures = "0.3.28"
 hyper = { version = "0.14.26", features = ["client"] }
-hyper-tls = { version = "0.5.0", features = ["vendored"] }
 flume = "0.10.14"
 anyhow = "1.0.71"
 log = { version = "0.4.18", features = ["std", "kv_unstable"] }
-async-recursion = "1.0.4"
 linked-hash-map = "0.5.6"
 lagon-runtime-v8-utils = { path = "../runtime_v8_utils" }
 lagon-runtime-http = { path = "../runtime_http" }
 lagon-runtime-crypto = { path = "../runtime_crypto" }
+reqwest = { version = "0.11.18", features = ["rustls-tls"] }
 
 [features]
 default = []

--- a/crates/runtime_isolate/src/bindings/mod.rs
+++ b/crates/runtime_isolate/src/bindings/mod.rs
@@ -5,7 +5,7 @@ use crypto::{
     verify_binding, verify_init,
 };
 use fetch::{fetch_binding, fetch_init};
-use hyper::{body::Bytes, http::response::Parts};
+use hyper::{body::Bytes, HeaderMap};
 use lagon_runtime_http::response_to_v8;
 use lagon_runtime_v8_utils::{v8_boolean, v8_string, v8_uint8array};
 use pull_stream::pull_stream_binding;
@@ -32,7 +32,7 @@ pub struct BindingResult {
 }
 
 pub enum PromiseResult {
-    Response((Parts, Bytes)),
+    Response((u16, HeaderMap, Bytes)),
     ArrayBuffer(Vec<u8>),
     Boolean(bool),
     Error(String),

--- a/packages/docs/pages/runtime-apis.mdx
+++ b/packages/docs/pages/runtime-apis.mdx
@@ -238,6 +238,10 @@ The standard `clearTimeout` method. [See the documentation on MDN](https://devel
 
 The standard `fetch` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/fetch).
 
+<Callout type="info">
+  `fetch()` supports both HTTP/1.1 and HTTP/2. Additionally, there are [some limits](/cloud/limits#functions) in place to prevent abuses.
+</Callout>
+
 ### `queueMicrotask()`
 
 The standard `queueMicrotask` method. [See the documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask).


### PR DESCRIPTION
## About

Replace Hyper by reqwest for `fetch()`, allowing us to remove a bunch of crappy code and easily support HTTP/2, while keeping the limits of `fetch()` calls per request and fetch recursion limit.