### PR TITLE
refactor(serverless,cli): redis pub/sub & rustls-tls

### DIFF
--- a/.changeset/nasty-weeks-lie.md
+++ b/.changeset/nasty-weeks-lie.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Fix redis pub/sub sometimes disconnecting

--- a/.changeset/rude-toys-wait.md
+++ b/.changeset/rude-toys-wait.md
@@ -1,0 +1,6 @@
+---
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Use rustls-ls instead of native-tls

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,11 +667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
- "futures-core",
  "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -1103,7 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -1786,7 +1803,6 @@ dependencies = [
  "envfile",
  "flume",
  "hyper",
- "hyper-tls",
  "indicatif",
  "lagon-runtime",
  "lagon-runtime-http",
@@ -1794,6 +1810,7 @@ dependencies = [
  "lagon-runtime-utils",
  "notify",
  "pathdiff",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -1948,7 +1965,7 @@ name = "lagon-serverless-pubsub"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "async-stream",
  "flume",
  "futures",
  "log",
@@ -2077,17 +2094,6 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -2317,15 +2323,18 @@ dependencies = [
  "lru",
  "mysql_common",
  "named_pipe",
- "native-tls",
  "once_cell",
  "pem",
  "percent-encoding",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "socket2 0.5.3",
  "twox-hash",
  "url",
+ "webpki",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -2624,15 +2633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.22.0+1.1.1q"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,7 +2641,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3012,19 +3011,12 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
 dependencies = [
- "async-trait",
- "bytes",
  "combine",
- "futures-util",
  "itoa",
- "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
  "ryu",
- "sha1_smol",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
  "url",
 ]
 
@@ -3130,7 +3122,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -3298,6 +3290,18 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3549,12 +3553,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -4363,6 +4361,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,12 +14,12 @@ indicatif = "0.17.5"
 dirs = "5.0.1"
 webbrowser = "0.8.10"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
-hyper = { version = "0.14.26", features = ["client", "server", "http1", "runtime", "stream"] }
+hyper = { version = "0.14.26", features = ["server", "http1", "runtime", "stream"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2.3.3"
 pathdiff = "0.2.1"
-hyper-tls = { version = "0.5.0", features = ["vendored"] }
 flume = "0.10.14"
 chrono = "0.4.26"
 notify = "6.0.0"

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -5,7 +5,6 @@ use crate::utils::{get_theme, print_progress, TrpcClient};
 use anyhow::{anyhow, Result};
 use dialoguer::console::style;
 use dialoguer::{Confirm, Input};
-use hyper::{Body, Method, Request};
 use pathdiff::diff_paths;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -428,12 +427,12 @@ pub async fn create_deployment(
 
     let end_progress = print_progress("Uploading files");
 
-    let request = Request::builder()
-        .method(Method::PUT)
-        .uri(code_url)
-        .body(Body::from(index))?;
-
-    trpc_client.client.request(request).await?;
+    trpc_client
+        .client
+        .request("PUT".parse()?, code_url)
+        .body(index)
+        .send()
+        .await?;
 
     let mut join_set = tokio::task::JoinSet::new();
     for (asset, url) in assets_urls {
@@ -484,11 +483,12 @@ pub async fn create_deployment(
 }
 
 async fn upload_asset(trpc_client: Arc<TrpcClient>, asset: Vec<u8>, url: String) -> Result<()> {
-    let request = Request::builder()
-        .method(Method::PUT)
-        .uri(url)
-        .body(Body::from(asset))?;
+    trpc_client
+        .client
+        .request("PUT".parse()?, url)
+        .body(asset)
+        .send()
+        .await?;
 
-    trpc_client.client.request(request).await?;
     Ok(())
 }

--- a/crates/runtime_isolate/Cargo.toml
+++ b/crates/runtime_isolate/Cargo.toml
@@ -15,7 +15,7 @@ linked-hash-map = "0.5.6"
 lagon-runtime-v8-utils = { path = "../runtime_v8_utils" }
 lagon-runtime-http = { path = "../runtime_http" }
 lagon-runtime-crypto = { path = "../runtime_crypto" }
-reqwest = { version = "0.11.18", features = ["rustls-tls"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 
 [features]
 default = []

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -15,7 +15,7 @@ lagon-serverless-logger = { path = "../serverless_logger" }
 lagon-serverless-downloader = { path = "../serverless_downloader" }
 lagon-serverless-pubsub = { path = "../serverless_pubsub" }
 flume = "0.10.14"
-mysql = "24.0.0"
+mysql = { version = "24.0.0", default-features = false, features = ["default-rustls"] }
 dotenv = "0.15.0"
 serde_json = "1.0"
 metrics = "0.21.0"
@@ -36,7 +36,7 @@ lagon-runtime-isolate = { path = "../runtime_isolate" }
 flume = "0.10.14"
 
 [dev-dependencies]
-reqwest = "0.11.18"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls-tls"] }
 serial_test = "2.0.0"
 clickhouse = { version = "0.11.4", features = ["test-util"] }
 

--- a/crates/serverless_logger/Cargo.toml
+++ b/crates/serverless_logger/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 flume = "0.10.14"
 chrono = "0.4.26"
 serde_json = "1.0"
-axiom-rs = { version = "0.8.0", default-features = false, features = ["tokio", "native-tls"] }
+axiom-rs = { version = "0.8.0", default-features = false, features = ["tokio", "rustls-tls"] }
 log = { version = "0.4.18", features = ["std", "kv_unstable", "kv_unstable_serde"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/crates/serverless_pubsub/Cargo.toml
+++ b/crates/serverless_pubsub/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.71"
-async-trait = "0.1.68"
+async-stream = "0.3.5"
 futures = "0.3.28"
-redis = { version = "0.23.0", features = ["tokio-native-tls-comp", "tokio-comp"] }
+redis = { version = "0.23.0", default-features = false, features = ["tls-rustls"] }
 log = { version = "0.4.18", features = ["std", "kv_unstable", "kv_unstable_serde"] }
 flume = "0.10.14"

--- a/crates/serverless_pubsub/src/lib.rs
+++ b/crates/serverless_pubsub/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::Stream;
+use std::pin::Pin;
 
 mod fake;
 mod redis;
@@ -38,9 +38,6 @@ impl From<String> for PubSubMessageKind {
     }
 }
 
-#[async_trait]
-pub trait PubSubListener: Send + Sized {
-    async fn connect(&mut self) -> Result<()>;
-
-    fn get_stream(&mut self) -> Box<dyn Stream<Item = PubSubMessage> + Unpin + Send + '_>;
+pub trait PubSubListener: Send {
+    fn get_stream(&mut self) -> Result<Pin<Box<dyn Stream<Item = Result<PubSubMessage>>>>>;
 }


### PR DESCRIPTION
## About

- Use rustls-tls instead of native-tls
- Try to fix redis pub/sub sometimes disconnecting and not pickup up new deployments by using the blocking version (it's in a separate thread so it's ok to block) and reconnecting on error.