### PR TITLE
feat(serverless): add `x-robots-tag: noindex` header to preview deployments

### DIFF
--- a/.changeset/modern-moose-reflect.md
+++ b/.changeset/modern-moose-reflect.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Add x-robots-tag: noindex header to preview deployments responses

--- a/crates/runtime_http/src/headers.rs
+++ b/crates/runtime_http/src/headers.rs
@@ -1,4 +1,6 @@
 pub const X_FORWARDED_FOR: &str = "x-forwarded-for";
+pub const X_FORWARDED_PROTO: &str = "x-forwarded-proto";
+pub const X_FORWARDED_HOST: &str = "x-forwarded-host";
 pub const X_REAL_IP: &str = "x-real-ip";
 
 pub const X_LAGON_REGION: &str = "x-lagon-region";

--- a/crates/runtime_utils/src/lib.rs
+++ b/crates/runtime_utils/src/lib.rs
@@ -17,7 +17,7 @@ pub const DEPLOYMENTS_DIR: &str = "deployments";
 #[cfg(feature = "test")]
 pub const DEPLOYMENTS_DIR: &str = "deployments_test";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Deployment {
     pub id: String,
     pub function_id: String,

--- a/crates/serverless/tests/requests.rs
+++ b/crates/serverless/tests/requests.rs
@@ -137,8 +137,9 @@ async fn forwards_headers() -> Result<()> {
 
     let response = reqwest::get("http://127.0.0.1:4000").await?;
     assert_eq!(response.status(), 200);
-    assert_eq!(response.headers()["x-lagon-region"], "local");
-    assert_eq!(response.headers()["x-forwarded-for"], "127.0.0.1");
+    assert_eq!(response.headers()["accept"], "*/*");
+    assert_eq!(response.headers()["accept-encoding"], "gzip");
+    assert_eq!(response.headers()["host"], "127.0.0.1:4000");
     assert_eq!(response.text().await?, "");
 
     Ok(())


### PR DESCRIPTION
## About

Add a new `x-robots-tag: noindex` header to responses from preview deployments, similar to what [Vercel](https://vercel.com/docs/concepts/edge-network/headers#x-robots-tag) and [Netlify](https://docs.netlify.com/site-deploys/overview/#search-engine-indexing) do. This prevents search engines from crawling preview deployments.
