### PR TITLE
fix(dashboard): set full session with token auth

### DIFF
--- a/.changeset/poor-ants-lay.md
+++ b/.changeset/poor-ants-lay.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Properly set session information when authenticating via a token


### PR DESCRIPTION
## About

Properly set session information when authenticating via a token (when using the CLI). This notably fixes the assets limit when creating a deployment from the CLI.
