### PR TITLE
feat(js-runtime,serverless,cli): allow `fetch()` with a `Request`

### DIFF
--- a/.changeset/pretty-jeans-develop.md
+++ b/.changeset/pretty-jeans-develop.md
@@ -1,0 +1,7 @@
+---
+'@lagon/js-runtime': patch
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Allow `fetch()` with a `Request`

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -5,7 +5,7 @@
     const headers = new Headers(init?.headers);
     let body: string | undefined;
 
-    const isInputRequest = input instanceof Request
+    const isInputRequest = input instanceof Request;
 
     if (init?.body || (isInputRequest && (input as Request).body)) {
       const paramBody = init?.body || (input as Request).body;
@@ -15,16 +15,9 @@
       } else if (paramBody instanceof ReadableStream) {
         body = '';
 
-        const reader = paramBody.getReader();
-
-        while (true) {
-          const { done, value } = await reader.read();
-
-          if (done) {
-            break;
-          }
-
-          body += globalThis.__lagon__.TEXT_DECODER.decode(value);
+        // @ts-expect-error iterate over the stream
+        for await (const chunk of paramBody) {
+          body += globalThis.__lagon__.TEXT_DECODER.decode(chunk);
         }
       } else {
         if (typeof paramBody !== 'string') {
@@ -32,7 +25,7 @@
           throw new Error('Body must be a string or an iterable');
         }
 
-        body = paramBody
+        body = paramBody;
       }
     }
 

--- a/packages/js-runtime/src/runtime/http/fetch.ts
+++ b/packages/js-runtime/src/runtime/http/fetch.ts
@@ -5,17 +5,47 @@
     const headers = new Headers(init?.headers);
     let body: string | undefined;
 
-    if (init?.body) {
-      if (globalThis.__lagon__.isIterable(init.body)) {
-        body = globalThis.__lagon__.TEXT_DECODER.decode(init.body);
+    const isInputRequest = input instanceof Request
+
+    if (init?.body || (isInputRequest && (input as Request).body)) {
+      const paramBody = init?.body || (input as Request).body;
+
+      if (globalThis.__lagon__.isIterable(paramBody)) {
+        body = globalThis.__lagon__.TEXT_DECODER.decode(paramBody);
+      } else if (paramBody instanceof ReadableStream) {
+        body = '';
+
+        const reader = paramBody.getReader();
+
+        while (true) {
+          const { done, value } = await reader.read();
+
+          if (done) {
+            break;
+          }
+
+          body += globalThis.__lagon__.TEXT_DECODER.decode(value);
+        }
       } else {
-        if (typeof init.body !== 'string') {
+        if (typeof paramBody !== 'string') {
           // TODO: Support other body types
           throw new Error('Body must be a string or an iterable');
         }
 
-        body = init.body;
+        body = paramBody
       }
+    }
+
+    let method = init?.method || 'GET';
+    let url = input.toString();
+
+    if (isInputRequest) {
+      for (const [key, value] of (input as Request).headers.entries()) {
+        headers.set(key, value);
+      }
+
+      method = init?.method || (input as Request).method;
+      url = (input as Request).url.toString();
     }
 
     if (body === undefined && init?.method && FORCE_0_CONTENT_LENGTH_METHODS.includes(init.method)) {
@@ -32,8 +62,8 @@
       checkAborted();
 
       const response = await LagonAsync.fetch({
-        m: init?.method || 'GET',
-        u: input.toString(),
+        m: method,
+        u: url,
         b: body,
         // @ts-expect-error private property
         h: headers.h,


### PR DESCRIPTION
## About

Allow using `fetch()` with a `Request` and an optional `init` (that will take priority). We can still use `fetch()` using a string or `URL` and an optional `init`.

MDN: https://developer.mozilla.org/en-US/docs/Web/API/fetch