### PR TITLE
perf(serverless): small perf wins

### DIFF
--- a/.changeset/wicked-pears-battle.md
+++ b/.changeset/wicked-pears-battle.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Add a fast path when handling assets, inline dashmap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "git+https://github.com/xacrimon/dashmap.git?rev=7f9522c5286cfbbb78df15f00f87b8331cb875d6#7f9522c5286cfbbb78df15f00f87b8331cb875d6"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,7 +1924,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clickhouse",
- "dashmap",
+ "dashmap 5.4.0 (git+https://github.com/xacrimon/dashmap.git?rev=7f9522c5286cfbbb78df15f00f87b8331cb875d6)",
  "dotenv",
  "flume",
  "futures",
@@ -3524,7 +3536,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
 dependencies = [
- "dashmap",
+ "dashmap 5.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "lazy_static",
  "log",

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -7,6 +7,11 @@ use std::{
 };
 
 pub fn find_asset<'a>(url: &'a str, assets: &'a HashSet<String>) -> Option<&'a String> {
+    // Fast path to return early if there are no assets
+    if assets.len() == 0 {
+        return None;
+    }
+
     // Remove the leading '/' from the url
     let url = &url[1..];
 

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -23,7 +23,8 @@ metrics-exporter-prometheus = { version = "0.12.1", default-features = false, fe
 log = { version = "0.4.19", features = ["std", "kv_unstable", "kv_unstable_serde"] }
 anyhow = "1.0.71"
 tokio-cron-scheduler = "0.9.4"
-dashmap = "5.4.0"
+# TODO: use a specific version of dashmap when the inline feature is released
+dashmap = { git = "https://github.com/xacrimon/dashmap.git", rev = "7f9522c5286cfbbb78df15f00f87b8331cb875d6", features = ["inline"] }
 futures = "0.3.28"
 clickhouse = "0.11.5"
 bytes = "1.4.0"


### PR DESCRIPTION
## About

- Use the `inline` feature of `dashmap` that enables `inline-more` in hashbrown
- Add a fast path in `find_assets`
- Remove the connection IP handling
