### PR TITLE
feat(cli): automatically load `.env` from current dir

### DIFF
--- a/.changeset/itchy-chicken-count.md
+++ b/.changeset/itchy-chicken-count.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Automatically load .env file from current directory or specified path

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -32,7 +32,6 @@ fn parse_environment_variables(
     path: Option<PathBuf>,
     env: Option<PathBuf>,
 ) -> Result<HashMap<String, String>> {
-    let path = path.unwrap_or_else(|| PathBuf::from("."));
     let mut environment_variables = HashMap::new();
 
     if let Some(env) = env {
@@ -43,15 +42,28 @@ fn parse_environment_variables(
         }
 
         println!("{}", style("Loaded .env file...").black().bright());
-    } else if let Ok(envfile) = EnvFile::new(path.join(".env")) {
-        for (key, value) in envfile.store {
-            environment_variables.insert(key, value);
-        }
-
-        println!(
-            "{}",
-            style("Automatically loaded .env file...").black().bright()
+    } else {
+        let path = path.map_or_else(
+            || PathBuf::from("."),
+            |path| {
+                if path.is_file() {
+                    PathBuf::from(".")
+                } else {
+                    path
+                }
+            },
         );
+
+        if let Ok(envfile) = EnvFile::new(path.join(".env")) {
+            for (key, value) in envfile.store {
+                environment_variables.insert(key, value);
+            }
+
+            println!(
+                "{}",
+                style("Automatically loaded .env file...").black().bright()
+            );
+        }
     }
 
     Ok(environment_variables)


### PR DESCRIPTION
## About

Also automatically load `.env` from the current directory if we're specifying a path that is a file:

```bash
# Loads ./.env
lagon dev index.ts
# Loads ./.env
lagon dev src/index.ts
# Loads ./myproject/.env
lagon dev ./myproject
```