### PR TITLE
fix(dashboard,docs): bangalore region is ap-west and not ap-south

### DIFF
--- a/.changeset/lazy-walls-impress.md
+++ b/.changeset/lazy-walls-impress.md
@@ -1,0 +1,6 @@
+---
+'@lagon/dashboard': patch
+'@lagon/docs': patch
+---
+
+Fix Bangalore region to be ap-west instead of ap-south

--- a/packages/dashboard/lib/constants.ts
+++ b/packages/dashboard/lib/constants.ts
@@ -32,7 +32,7 @@ export const REGIONS = {
   'nuremberg-eu-central': 'Nuremberg (eu-central)',
   'helsinki-eu-north': 'Helsinki (eu-north)',
   'warsaw-eu-east': 'Warsaw (eu-east)',
-  'bangalore-ap-south': 'Bangalore (ap-south)',
+  'bangalore-ap-west': 'Bangalore (ap-west)',
   'singapore-ap-south': 'Singapore (ap-south)',
   'sydney-ap-south': 'Sydney (ap-south)',
   'tokyo-ap-east': 'Tokyo (ap-east)',

--- a/packages/docs/pages/cloud/regions.mdx
+++ b/packages/docs/pages/cloud/regions.mdx
@@ -15,7 +15,7 @@ You can access the Region that is responding to the current requests using the [
 - Nuremberg, Germany (`nuremberg-eu-central`)
 - Helsinki, Finland (`helsinki-eu-north`)
 - Warsaw, Poland (`warsaw-eu-east`)
-- Bangalore, India (`bangalore-ap-south`)
+- Bangalore, India (`bangalore-ap-west`)
 - Singapore (`singapore-ap-south`)
 - Sydney, Australia (`sydney-ap-south`)
 - Tokio, Japan (`tokio-ap-east`)


### PR DESCRIPTION
## About

Fix Bangalore region to be ap-west instead of ap-south
