### PR TITLE
fix(dashboard): don't crash when cron parsing fails

### DIFF
--- a/.changeset/proud-bears-sell.md
+++ b/.changeset/proud-bears-sell.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Do not crash when cron parsing fails

--- a/packages/dashboard/lib/pages/function/FunctionOverview.tsx
+++ b/packages/dashboard/lib/pages/function/FunctionOverview.tsx
@@ -92,11 +92,11 @@ const Usage = ({ func, timeframe }: UsageProps) => {
 
       return next
         ? t('usage.nextCron.label', {
-          time,
-        })
+            time,
+          })
         : t('usage.lastCron.label', {
-          time,
-        });
+            time,
+          });
     } catch (err) {
       Sentry.captureException(err, {
         tags: {

--- a/packages/dashboard/locales/en.ts
+++ b/packages/dashboard/locales/en.ts
@@ -170,6 +170,7 @@ export default {
   'functions.overview.usage.lastCron.label': '{time} ago',
   'functions.overview.usage.nextCron': 'Next Cron',
   'functions.overview.usage.nextCron.label': 'In {time}',
+  'functions.overview.usage.nextCron.label.invalid': 'Invalid',
   'functions.overview.usage.lastUpdate': 'Last update:',
   'functions.overview.usage.created': 'Created:',
   'functions.overview.requests': 'Requests',

--- a/packages/dashboard/locales/fr.ts
+++ b/packages/dashboard/locales/fr.ts
@@ -176,6 +176,7 @@ export default defineLocale({
   'functions.overview.usage.lastCron.label': 'Il y a {time}',
   'functions.overview.usage.nextCron': 'Prochain Cron',
   'functions.overview.usage.nextCron.label': 'Dans {time}',
+  'functions.overview.usage.nextCron.label.invalid': 'Invalide',
   'functions.overview.usage.lastUpdate': 'Dernière mise à jour :',
   'functions.overview.usage.created': 'Créé :',
   'functions.overview.requests': 'Requêtes',


### PR DESCRIPTION
## About

Do not crash when cron parsing fails. Send the error and the cron expression to Sentry.