### PR TITLE
perf(serverless): use Jemalloc instead of the default allocator

### DIFF
--- a/.changeset/lucky-mails-admire.md
+++ b/.changeset/lucky-mails-admire.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Use Jemalloc instead of the default allocator

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tikv-jemallocator",
  "tokio",
  "tokio-cron-scheduler",
  "tokio-util",
@@ -3860,6 +3861,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/serverless/Cargo.toml
+++ b/crates/serverless/Cargo.toml
@@ -31,6 +31,10 @@ bytes = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 uuid = "1.3.4"
 
+# Jemalloc does not work on Windows
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 [build-dependencies]
 lagon-runtime = { path = "../runtime" }
 lagon-runtime-isolate = { path = "../runtime_isolate" }

--- a/crates/serverless/src/main.rs
+++ b/crates/serverless/src/main.rs
@@ -20,6 +20,11 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 
+// Jemalloc does not work on Windows
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Only load a .env file on development


### PR DESCRIPTION
## About

Use Jemalloc instead of the default allocator for the serverless binary. This brings the performance to +100k req/s, but we might revert it later (Deno reverted it: https://github.com/denoland/deno/pull/19187)
