### PR TITLE
perf(serverless): reduce `clone()`ing

### DIFF
--- a/.changeset/perfect-boats-divide.md
+++ b/.changeset/perfect-boats-divide.md
@@ -1,0 +1,5 @@
+---
+'@lagon/serverless': patch
+---
+
+Reduce `clone()`ing

--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -94,14 +94,15 @@ async fn handle_request(
         );
 
         let run_result = match handle_asset(public_dir.unwrap(), asset) {
-            Ok(response) => RunResult::Response(response, None),
+            Ok((response_builder, body)) => RunResult::Response(response_builder, body, None),
             Err(error) => RunResult::Error(format!("Could not retrieve asset ({asset}): {error}")),
         };
 
         tx.send_async(run_result).await.unwrap_or(());
     } else if url == FAVICON_URL {
         tx.send_async(RunResult::Response(
-            Response::builder().status(404).body(Body::empty())?,
+            Response::builder().status(404),
+            Body::empty(),
             None,
         ))
         .await
@@ -143,12 +144,6 @@ async fn handle_request(
 
     handle_response(rx, deployment, |event| async move {
         match event {
-            ResponseEvent::StreamDoneNoDataError => {
-                println!(
-                    "{} The stream was done before sending a response/data",
-                    style("✕").red()
-                );
-            }
             ResponseEvent::UnexpectedStreamResult(result) => {
                 println!(
                     "{} Unexpected stream result: {:?}",

--- a/crates/runtime/tests/allow_codegen.rs
+++ b/crates/runtime/tests/allow_codegen.rs
@@ -1,4 +1,4 @@
-use hyper::{header::CONTENT_TYPE, Request, Response};
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lagon_runtime_isolate::options::IsolateOptions;
 
 mod utils;
@@ -17,10 +17,8 @@ return new Response(result)
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("2".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("2"),
     )
     .await;
 }
@@ -39,10 +37,8 @@ async fn allow_function() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("2".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("2"),
     )
     .await;
 }

--- a/crates/runtime/tests/async_context.rs
+++ b/crates/runtime/tests/async_context.rs
@@ -1,4 +1,4 @@
-use hyper::{header::CONTENT_TYPE, Request, Response};
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lagon_runtime_isolate::options::IsolateOptions;
 
 mod utils;
@@ -24,10 +24,8 @@ export function handler() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true"),
     )
     .await;
 }
@@ -51,7 +49,7 @@ export function handler() {
     ));
     send(Request::default());
 
-    utils::assert_response(&receiver, Response::default()).await;
+    utils::assert_response(&receiver, Response::builder(), Body::empty()).await;
 }
 
 #[tokio::test]
@@ -74,7 +72,7 @@ export function handler() {
     ));
     send(Request::default());
 
-    utils::assert_response(&receiver, Response::default()).await;
+    utils::assert_response(&receiver, Response::builder(), Body::empty()).await;
 }
 
 #[tokio::test]
@@ -111,7 +109,7 @@ export function handler() {
     ));
     send(Request::default());
 
-    utils::assert_response(&receiver, Response::default()).await;
+    utils::assert_response(&receiver, Response::builder(), Body::empty()).await;
 }
 
 #[tokio::test]
@@ -160,7 +158,7 @@ export function handler() {
     ));
     send(Request::default());
 
-    utils::assert_response(&receiver, Response::default()).await;
+    utils::assert_response(&receiver, Response::builder(), Body::empty()).await;
 }
 
 #[tokio::test]
@@ -193,10 +191,8 @@ export async function handler() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("2".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("2"),
     )
     .await;
 
@@ -204,10 +200,8 @@ export async function handler() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("4".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("4"),
     )
     .await;
 

--- a/crates/runtime/tests/crypto.rs
+++ b/crates/runtime/tests/crypto.rs
@@ -1,4 +1,4 @@
-use hyper::{header::CONTENT_TYPE, Request, Response};
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lagon_runtime_http::RunResult;
 use lagon_runtime_isolate::options::IsolateOptions;
 use std::time::Duration;
@@ -20,10 +20,8 @@ async fn crypto_random_uuid() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("string 36 false".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("string 36 false"),
     )
     .await;
 }
@@ -43,10 +41,8 @@ async fn crypto_get_random_values() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true 3 3 false false".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true 3 3 false false"),
     )
     .await;
 }
@@ -66,10 +62,8 @@ async fn crypto_get_random_values_update_in_place() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("3 false".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("3 false"),
     )
     .await;
 }
@@ -117,10 +111,8 @@ async fn crypto_key_value() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("object 6".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("object 6"),
     )
     .await;
 }
@@ -153,10 +145,8 @@ async fn crypto_unique_key_value() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("false".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("false"),
     )
     .await;
 }
@@ -186,10 +176,8 @@ async fn crypto_sign() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true 32".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true 32"),
     )
     .await;
 }
@@ -223,10 +211,8 @@ async fn crypto_verify() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true"),
     )
     .await;
 }
@@ -246,12 +232,8 @@ async fn crypto_digest_sha1() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body(
-                "20 183,226,62,194,154,242,43,11,78,65,218,49,232,104,213,114,38,18,28,132".into(),
-            )
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("20 183,226,62,194,154,242,43,11,78,65,218,49,232,104,213,114,38,18,28,132"),
     )
     .await;
 }
@@ -272,11 +254,10 @@ async fn crypto_digest_string() {
     utils::assert_response(
         &receiver,
         Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body(
-                "32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91".into(),
+            .header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+            Body::from(
+                "32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91"
             )
-            .unwrap(),
     )
     .await;
 }
@@ -297,11 +278,10 @@ async fn crypto_digest_object() {
     utils::assert_response(
         &receiver,
         Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body(
-                "32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91".into(),
+            .header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+            Body::from(
+                "32 9,202,126,78,170,110,138,233,199,210,97,22,113,41,24,72,131,100,77,7,223,186,124,191,188,76,138,46,8,54,13,91"
             )
-            .unwrap(),
     )
     .await;
 }
@@ -335,10 +315,8 @@ async fn crypto_encrypt_aes_gcm() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true 28".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true 28"),
     )
     .await;
 }
@@ -378,10 +356,8 @@ async fn crypto_decrypt_aes_gcm() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("hello, world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("hello, world"),
     )
     .await;
 }
@@ -415,10 +391,8 @@ async fn crypto_encrypt_aes_cbc() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true 16".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true 16"),
     )
     .await;
 }
@@ -458,10 +432,8 @@ async fn crypto_decrypt_aes_cbc() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("hello, world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("hello, world"),
     )
     .await;
 }
@@ -495,10 +467,8 @@ async fn crypto_encrypt_aes_ctr() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true 12".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true 12"),
     )
     .await;
 }
@@ -538,10 +508,8 @@ async fn crypto_decrypt_aes_ctr() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("hello, world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("hello, world"),
     )
     .await;
 }
@@ -578,10 +546,8 @@ async fn crypto_encrypt_rsa_oaep() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true 128".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true 128"),
     )
     .await;
 }
@@ -626,10 +592,8 @@ async fn crypto_decrypt_rsa_oaep() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("hello, world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("hello, world"),
     )
     .await;
 }
@@ -666,10 +630,8 @@ async fn crypto_hkdf_derive_bits() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("16".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("16"),
     )
     .await;
 }
@@ -706,10 +668,8 @@ async fn crypto_pbkdf2_derive_bits() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("16".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("16"),
     )
     .await;
 }
@@ -766,10 +726,8 @@ async fn crypto_ecdh_derive_bits() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("256 384".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("256 384"),
     )
     .await;
 }
@@ -812,10 +770,8 @@ async fn crypto_derive_key() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true true true true true".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true true true true true"),
     )
     .await;
 }
@@ -856,10 +812,8 @@ async fn crypto_ecdsa_sign_verify() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true"),
     )
     .await;
 }
@@ -905,10 +859,8 @@ async fn crypto_rsa_pss_sign_verify() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true"),
     )
     .await;
 }
@@ -954,10 +906,8 @@ async fn crypto_rsa_ssa_sign_verify() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("true".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("true"),
     )
     .await;
 }

--- a/crates/runtime/tests/fetch.rs
+++ b/crates/runtime/tests/fetch.rs
@@ -1,5 +1,5 @@
 use httptest::{matchers::*, responders::*, Expectation, Server};
-use hyper::{header::CONTENT_TYPE, Request, Response};
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lagon_runtime_http::RunResult;
 use lagon_runtime_isolate::options::IsolateOptions;
 
@@ -25,10 +25,8 @@ async fn basic_fetch() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -56,10 +54,8 @@ async fn request_method() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -87,10 +83,8 @@ async fn request_method_fallback() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -123,10 +117,8 @@ async fn request_headers() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -159,10 +151,8 @@ async fn request_headers_class() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -194,10 +184,8 @@ async fn request_body() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -231,10 +219,8 @@ async fn response_headers() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("content-length: 0 content-type: text/plain;charset=UTF-8 x-token: hello".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("content-length: 0 content-type: text/plain;charset=UTF-8 x-token: hello"),
     )
     .await;
 }
@@ -265,10 +251,8 @@ async fn response_status() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Moved: 200".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Moved: 200"),
     )
     .await;
 }
@@ -295,10 +279,8 @@ async fn response_json() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body(r#"object {"hello":"world"}"#.into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from(r#"object {"hello":"world"}"#),
     )
     .await;
 }
@@ -323,7 +305,7 @@ async fn response_array_buffer() {
     )));
     send(Request::default());
 
-    utils::assert_response(&receiver, Response::new("Hello, World".into())).await;
+    utils::assert_response(&receiver, Response::builder(), Body::from("Hello, World")).await;
 }
 
 #[tokio::test]
@@ -401,10 +383,8 @@ async fn abort_signal() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Aborted".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Aborted"),
     )
     .await;
 }
@@ -429,10 +409,8 @@ async fn redirect() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("200".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("200"),
     )
     .await;
 }
@@ -461,10 +439,8 @@ async fn redirect_relative_url() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("200".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("200"),
     )
     .await;
 }
@@ -554,10 +530,8 @@ export async function handler() {{
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("ok".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("ok"),
     )
     .await;
 }
@@ -576,10 +550,8 @@ async fn fetch_https() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("200".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("200"),
     )
     .await;
 
@@ -620,10 +592,8 @@ async fn fetch_set_content_length() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Ok".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Ok"),
     )
     .await;
 }
@@ -658,10 +628,8 @@ async fn fetch_input_request() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }
@@ -702,10 +670,8 @@ async fn fetch_input_request_init() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }

--- a/crates/runtime/tests/promises.rs
+++ b/crates/runtime/tests/promises.rs
@@ -1,5 +1,5 @@
 use httptest::{matchers::*, responders::*, Expectation, Server};
-use hyper::{header::CONTENT_TYPE, Request, Response};
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lagon_runtime_isolate::options::IsolateOptions;
 
 mod utils;
@@ -17,10 +17,8 @@ async fn execute_async_handler() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Async handler".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Async handler"),
     )
     .await;
 }
@@ -45,10 +43,8 @@ async fn execute_promise() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello, World".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello, World"),
     )
     .await;
 }

--- a/crates/runtime/tests/runtime.rs
+++ b/crates/runtime/tests/runtime.rs
@@ -20,10 +20,8 @@ async fn execute_function() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -43,10 +41,8 @@ export { hello as handler }"
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -64,10 +60,8 @@ async fn execute_function_twice() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 
@@ -75,10 +69,8 @@ async fn execute_function_twice() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -103,10 +95,8 @@ async fn environment_variables() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -162,10 +152,8 @@ async fn get_body() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -190,10 +178,8 @@ async fn get_input() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("https://hello.world/hello".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("https://hello.world/hello"),
     )
     .await;
 }
@@ -217,10 +203,8 @@ async fn get_method() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("POST".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("POST"),
     )
     .await;
 }
@@ -243,10 +227,8 @@ async fn get_headers() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("token".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("token"),
     )
     .await;
 }
@@ -271,9 +253,8 @@ async fn return_headers() {
         &receiver,
         Response::builder()
             .header(CONTENT_TYPE, "text/html")
-            .header("x-test", "test")
-            .body("Hello world".into())
-            .unwrap(),
+            .header("x-test", "test"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -298,9 +279,8 @@ async fn return_headers_from_headers_api() {
         &receiver,
         Response::builder()
             .header(CONTENT_TYPE, "text/html")
-            .header("x-test", "test")
-            .body("Hello world".into())
-            .unwrap(),
+            .header("x-test", "test"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -322,9 +302,8 @@ async fn return_status() {
         &receiver,
         Response::builder()
             .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .status(302)
-            .body("Moved permanently".into())
-            .unwrap(),
+            .status(302),
+        Body::from("Moved permanently"),
     )
     .await;
 }
@@ -342,11 +321,7 @@ async fn return_uint8array() {
     ));
     send(Request::default());
 
-    utils::assert_response(
-        &receiver,
-        Response::builder().body("Hello world".into()).unwrap(),
-    )
-    .await;
+    utils::assert_response(&receiver, Response::builder(), Body::from("Hello world")).await;
 }
 
 #[tokio::test]
@@ -368,10 +343,8 @@ async fn console_log() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from(""),
     )
     .await;
 }
@@ -389,10 +362,8 @@ async fn atob() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello"),
     )
     .await;
 }
@@ -410,10 +381,8 @@ async fn btoa() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("SGVsbG8=".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("SGVsbG8="),
     )
     .await;
 }

--- a/crates/runtime/tests/timers.rs
+++ b/crates/runtime/tests/timers.rs
@@ -1,4 +1,4 @@
-use hyper::{header::CONTENT_TYPE, Request, Response};
+use hyper::{header::CONTENT_TYPE, Body, Request, Response};
 use lagon_runtime_isolate::options::IsolateOptions;
 use serial_test::serial;
 
@@ -22,10 +22,8 @@ async fn set_timeout() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("test".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("test"),
     )
     .await;
 }
@@ -58,10 +56,8 @@ async fn set_timeout_not_blocking_response() {
     );
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello!".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello!"),
     )
     .await;
     assert_eq!(
@@ -93,10 +89,8 @@ async fn set_timeout_clear() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("second".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("second"),
     )
     .await;
 }
@@ -123,10 +117,8 @@ async fn set_timeout_clear_correct() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("first".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("first"),
     )
     .await;
 }
@@ -180,10 +172,8 @@ async fn set_interval() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -221,10 +211,8 @@ async fn queue_microtask() {
 
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }
@@ -284,10 +272,8 @@ async fn timers_order() {
     );
     utils::assert_response(
         &receiver,
-        Response::builder()
-            .header(CONTENT_TYPE, "text/plain;charset=UTF-8")
-            .body("Hello world".into())
-            .unwrap(),
+        Response::builder().header(CONTENT_TYPE, "text/plain;charset=UTF-8"),
+        Body::from("Hello world"),
     )
     .await;
 }

--- a/crates/runtime_http/src/lib.rs
+++ b/crates/runtime_http/src/lib.rs
@@ -1,4 +1,4 @@
-use hyper::{http::response::Builder, Body, Response};
+use hyper::{http::response::Builder, Body};
 use std::time::Duration;
 
 mod headers;
@@ -22,7 +22,7 @@ pub enum StreamResult {
 pub enum RunResult {
     // Isolate responses have a duration (cpu time)
     // Assets responses don't
-    Response(Response<Body>, Option<Duration>),
+    Response(Builder, Body, Option<Duration>),
     Stream(StreamResult),
     Timeout,
     MemoryLimit,
@@ -46,9 +46,9 @@ impl RunResult {
         panic!("RunResult is not an Error: {:?}", self);
     }
 
-    pub fn as_response(self) -> Response<Body> {
-        if let RunResult::Response(response, _) = self {
-            return response;
+    pub fn as_response(self) -> (Builder, Body) {
+        if let RunResult::Response(response_builder, body, _) = self {
+            return (response_builder, body);
         }
 
         panic!("RunResult is not a Response: {:?}", self);

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use hyper::{body::Bytes, header::CONTENT_TYPE, Body, Response};
+use hyper::{body::Bytes, header::CONTENT_TYPE, http::response::Builder, Body, Response};
 use std::{
     collections::HashSet,
     fs,
@@ -23,7 +23,7 @@ pub fn find_asset<'a>(url: &'a str, assets: &'a HashSet<String>) -> Option<&'a S
     })
 }
 
-pub fn handle_asset(root: PathBuf, asset: &String) -> Result<Response<Body>> {
+pub fn handle_asset(root: PathBuf, asset: &String) -> Result<(Builder, Body)> {
     let path = root.join(asset);
     let body = fs::read(path)?;
 
@@ -43,9 +43,10 @@ pub fn handle_asset(root: PathBuf, asset: &String) -> Result<Response<Body>> {
         },
     );
 
-    Ok(Response::builder()
-        .header(CONTENT_TYPE, content_type)
-        .body(Body::from(Bytes::from(body)))?)
+    Ok((
+        Response::builder().header(CONTENT_TYPE, content_type),
+        Body::from(Bytes::from(body)),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/serverless/src/clickhouse.rs
+++ b/crates/serverless/src/clickhouse.rs
@@ -1,8 +1,7 @@
-use std::env;
-
 use anyhow::Result;
 use clickhouse::{Client, Row};
 use serde::{Deserialize, Serialize};
+use std::env;
 
 #[derive(Row, Serialize, Deserialize)]
 pub struct LogRow {

--- a/crates/serverless/src/cronjob.rs
+++ b/crates/serverless/src/cronjob.rs
@@ -157,7 +157,8 @@ impl Cronjob {
 
                                 (String::from("warn"), String::from("Cron Functions can't return a stream"))
                             }
-                            RunResult::Response(response, elapsed) => {
+                            RunResult::Response(response_builder, body, elapsed) => {
+                                let response = response_builder.body(body).unwrap();
                                 let status = response.status();
                                 let body = body::to_bytes(response.into_body()).await.unwrap_or_else(|error| {
                                     error!(


### PR DESCRIPTION
## About

Reduce `clone()`ing inside serverless' request handler and replace the `handle_response` signature with a `FnOnce` (instead of `Fn`)
