### PR TITLE
refactor(serverless,runtime-utils): avoid allocating `String`s

### DIFF
--- a/.changeset/slimy-moles-jump.md
+++ b/.changeset/slimy-moles-jump.md
@@ -1,0 +1,6 @@
+---
+'@lagon/runtime-utils': patch
+'@lagon/serverless': patch
+---
+
+Avoid allocating `String` where possible and use `&str` instead

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -23,7 +23,7 @@ pub fn find_asset<'a>(url: &'a str, assets: &'a HashSet<String>) -> Option<&'a S
     })
 }
 
-pub fn handle_asset(root: PathBuf, asset: &String) -> Result<(Builder, Body)> {
+pub fn handle_asset(root: PathBuf, asset: &str) -> Result<(Builder, Body)> {
     let path = root.join(asset);
     let body = fs::read(path)?;
 

--- a/crates/runtime_utils/src/assets.rs
+++ b/crates/runtime_utils/src/assets.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub fn find_asset<'a>(url: &'a str, assets: &'a HashSet<String>) -> Option<&'a String> {
+pub fn find_asset<'a>(url: &'a str, assets: &'a HashSet<String>) -> Option<&'a str> {
     // Fast path to return early if there are no assets
     if assets.len() == 0 {
         return None;
@@ -15,12 +15,15 @@ pub fn find_asset<'a>(url: &'a str, assets: &'a HashSet<String>) -> Option<&'a S
     // Remove the leading '/' from the url
     let url = &url[1..];
 
-    assets.iter().find(|asset| {
-        **asset == url
-            || asset.replace(".html", "") == url
-            || asset.replace("/index.html", "") == url
-            || asset.replace("index.html", "") == url
-    })
+    assets
+        .iter()
+        .find(|asset| {
+            **asset == url
+                || asset.replace(".html", "") == url
+                || asset.replace("/index.html", "") == url
+                || asset.replace("index.html", "") == url
+        })
+        .map(|asset| asset.as_str())
 }
 
 pub fn handle_asset(root: PathBuf, asset: &str) -> Result<(Builder, Body)> {
@@ -64,15 +67,12 @@ mod tests {
         .into_iter()
         .collect::<HashSet<String>>();
 
-        assert_eq!(find_asset("/", &assets), Some(&"index.html".into()));
-        assert_eq!(find_asset("/about", &assets), Some(&"about.html".into()));
-        assert_eq!(
-            find_asset("/hello", &assets),
-            Some(&"hello/index.html".into())
-        );
+        assert_eq!(find_asset("/", &assets), Some("index.html"));
+        assert_eq!(find_asset("/about", &assets), Some("about.html"));
+        assert_eq!(find_asset("/hello", &assets), Some("hello/index.html"));
         assert_eq!(
             find_asset("/hello/world", &assets),
-            Some(&"hello/world.html".into())
+            Some("hello/world.html")
         );
     }
 
@@ -87,21 +87,15 @@ mod tests {
         .into_iter()
         .collect::<HashSet<String>>();
 
-        assert_eq!(
-            find_asset("/index.html", &assets),
-            Some(&"index.html".into())
-        );
-        assert_eq!(
-            find_asset("/about.html", &assets),
-            Some(&"about.html".into())
-        );
+        assert_eq!(find_asset("/index.html", &assets), Some("index.html"));
+        assert_eq!(find_asset("/about.html", &assets), Some("about.html"));
         assert_eq!(
             find_asset("/hello/index.html", &assets),
-            Some(&"hello/index.html".into())
+            Some("hello/index.html")
         );
         assert_eq!(
             find_asset("/hello/world.html", &assets),
-            Some(&"hello/world.html".into())
+            Some("hello/world.html")
         );
     }
 

--- a/crates/serverless/src/deployments/mod.rs
+++ b/crates/serverless/src/deployments/mod.rs
@@ -26,7 +26,9 @@ pub async fn download_deployment<D>(deployment: &Deployment, downloader: Arc<D>)
 where
     D: Downloader,
 {
-    match downloader.download(deployment.id.clone() + ".js").await {
+    let path = format!("{}.js", deployment.id);
+
+    match downloader.download(&path).await {
         Ok(object) => {
             deployment.write_code(&object)?;
             info!(deployment = deployment.id; "Wrote deployment");
@@ -36,8 +38,9 @@ where
 
                 for asset in &deployment.assets {
                     futures.push(async {
-                        let future =
-                            downloader.download(deployment.id.clone() + "/" + asset.as_str());
+                        let path = format!("{}/{}", deployment.id, asset.clone());
+                        let future = downloader.download(&path);
+
                         (future.await, asset.clone())
                     });
                 }

--- a/crates/serverless/src/serverless.rs
+++ b/crates/serverless/src/serverless.rs
@@ -46,7 +46,7 @@ async fn handle_error(
     result: RunResult,
     function_id: String,
     deployment_id: String,
-    request_id: &String,
+    request_id: &str,
     inserters: Arc<Mutex<(Inserter<RequestRow>, Inserter<LogRow>)>>,
 ) {
     let (level, message) = match result {

--- a/crates/serverless_downloader/src/fake.rs
+++ b/crates/serverless_downloader/src/fake.rs
@@ -9,7 +9,7 @@ pub struct FakeDownloader;
 
 #[async_trait]
 impl Downloader for FakeDownloader {
-    async fn download(&self, path: String) -> Result<Vec<u8>> {
+    async fn download(&self, path: &str) -> Result<Vec<u8>> {
         let path = Path::new(DEPLOYMENTS_DIR).join(path);
         let bytes = fs::read(path)?;
         Ok(bytes)

--- a/crates/serverless_downloader/src/lib.rs
+++ b/crates/serverless_downloader/src/lib.rs
@@ -36,5 +36,5 @@ pub fn get_bucket() -> Result<Bucket> {
 
 #[async_trait]
 pub trait Downloader {
-    async fn download(&self, path: String) -> Result<Vec<u8>>;
+    async fn download(&self, path: &str) -> Result<Vec<u8>>;
 }

--- a/crates/serverless_downloader/src/s3_bucket.rs
+++ b/crates/serverless_downloader/src/s3_bucket.rs
@@ -16,7 +16,7 @@ impl S3BucketDownloader {
 
 #[async_trait]
 impl Downloader for S3BucketDownloader {
-    async fn download(&self, path: String) -> Result<Vec<u8>> {
+    async fn download(&self, path: &str) -> Result<Vec<u8>> {
         let object = self.bucket.get_object(path).await?;
         Ok(object.bytes().to_vec())
     }

--- a/crates/serverless_pubsub/src/lib.rs
+++ b/crates/serverless_pubsub/src/lib.rs
@@ -27,9 +27,9 @@ impl PubSubMessage {
     }
 }
 
-impl From<String> for PubSubMessageKind {
-    fn from(value: String) -> Self {
-        match value.as_str() {
+impl From<&str> for PubSubMessageKind {
+    fn from(value: &str) -> Self {
+        match value {
             "deploy" => Self::Deploy,
             "undeploy" => Self::Undeploy,
             "promote" => Self::Promote,

--- a/crates/serverless_pubsub/src/redis.rs
+++ b/crates/serverless_pubsub/src/redis.rs
@@ -1,4 +1,4 @@
-use super::{PubSubListener, PubSubMessage};
+use super::{PubSubListener, PubSubMessage, PubSubMessageKind};
 use anyhow::Result;
 use futures::Stream;
 use log::info;
@@ -33,7 +33,7 @@ impl PubSubListener for RedisPubSub {
 
             loop {
                 let msg = pubsub.get_message()?;
-                let kind = msg.get_channel_name().to_string().into();
+                let kind = PubSubMessageKind::from(msg.get_channel_name());
                 let payload = msg.get_payload::<String>()?;
 
                 yield Ok(PubSubMessage { kind, payload });


### PR DESCRIPTION
## About

Avoid allocating `String` where possible and use `&str` instead

