### PR TITLE
fix(dashboard): correctly get the organization id when using tokens

### DIFF
--- a/.changeset/great-teachers-draw.md
+++ b/.changeset/great-teachers-draw.md
@@ -1,0 +1,5 @@
+---
+'@lagon/dashboard': patch
+---
+
+Use the token's selected organization when the provided id is empty

--- a/packages/dashboard/pages/api/trpc/[trpc].ts
+++ b/packages/dashboard/pages/api/trpc/[trpc].ts
@@ -59,7 +59,7 @@ const createContext = async ({
 
     const organization = await prisma.organization.findFirst({
       where: {
-        id: organizationId ?? token.user.currentOrganizationId ?? '',
+        id: organizationId?.length ? organizationId : token.user.currentOrganizationId ?? '',
       },
       select: {
         id: true,


### PR DESCRIPTION
## About

Use the token's selected organization when the provided id is empty.