### PR TITLE
fix(cli): assets path on Windows

### DIFF
--- a/.changeset/brown-pens-scream.md
+++ b/.changeset/brown-pens-scream.md
@@ -1,0 +1,5 @@
+---
+'@lagon/cli': patch
+---
+
+Fix assets path delimiter on Windows

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -306,6 +306,7 @@ pub fn bundle_function(
                 .unwrap()
                 .to_str()
                 .unwrap()
+                .replace("\\", "/")
                 .to_string()
                 + ".js",
             client_output,
@@ -338,6 +339,7 @@ pub fn bundle_function(
                     .unwrap()
                     .to_str()
                     .unwrap()
+                    .replace("\\", "/")
                     .to_string();
                 let file_content = fs::read(path)?;
 

--- a/crates/cli/src/utils/deployments.rs
+++ b/crates/cli/src/utils/deployments.rs
@@ -306,8 +306,7 @@ pub fn bundle_function(
                 .unwrap()
                 .to_str()
                 .unwrap()
-                .replace("\\", "/")
-                .to_string()
+                .replace('\\', "/")
                 + ".js",
             client_output,
         );
@@ -339,8 +338,7 @@ pub fn bundle_function(
                     .unwrap()
                     .to_str()
                     .unwrap()
-                    .replace("\\", "/")
-                    .to_string();
+                    .replace('\\', "/");
                 let file_content = fs::read(path)?;
 
                 final_assets.insert(diff, file_content);


### PR DESCRIPTION
## About

On Windows, the assets path includes a `\\` delimiter instead of the expected `/` that is used when deploying, and when running `lagon dev` to return the correct asset instead of calling the function.

Example debug before:
![Screenshot 2023-06-27 at 21 33 51](https://github.com/lagonapp/lagon/assets/43268759/0af66309-8095-4ccd-b1f3-664038e4efdc)

And after:
![Screenshot 2023-06-27 at 21 34 45](https://github.com/lagonapp/lagon/assets/43268759/4494e250-dffd-46ca-8c22-ffd50fab07a5)
