### PR TITLE
fix(js-runtime,cli,serverless): error when handler doesn't return a Response

### DIFF
--- a/.changeset/kind-doors-behave.md
+++ b/.changeset/kind-doors-behave.md
@@ -1,0 +1,7 @@
+---
+'@lagon/js-runtime': patch
+'@lagon/cli': patch
+'@lagon/serverless': patch
+---
+
+Throw an error if handler function do no return a Response

--- a/crates/runtime/tests/errors.rs
+++ b/crates/runtime/tests/errors.rs
@@ -74,6 +74,41 @@ async fn compilation_error() {
 }
 
 #[tokio::test]
+async fn return_nothing() {
+    utils::setup();
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
+        "export function handler() {
+}"
+        .into(),
+    ));
+    send(Request::default());
+
+    utils::assert_run_result(
+        &receiver,
+        RunResult::Error("Uncaught Error: Handler function should return a Response object".into()),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn do_not_return_response() {
+    utils::setup();
+    let (send, receiver) = utils::create_isolate(IsolateOptions::new(
+        "export function handler() {
+    return new Request('/')
+}"
+        .into(),
+    ));
+    send(Request::default());
+
+    utils::assert_run_result(
+        &receiver,
+        RunResult::Error("Uncaught Error: Handler function should return a Response object".into()),
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn import_errors() {
     utils::setup();
     let (send, receiver) = utils::create_isolate(IsolateOptions::new(

--- a/packages/js-runtime/src/index.ts
+++ b/packages/js-runtime/src/index.ts
@@ -159,6 +159,10 @@ globalThis.masterHandler = async (id, handler, request) => {
 
   const response = await handler(handlerRequest);
 
+  if (!(response instanceof Response)) {
+    throw new Error('Handler function should return a Response object');
+  }
+
   if (response.isStream) {
     const responseBody = response.body;
 


### PR DESCRIPTION
## About

Not returning a response would previously error with an error inside the js-runtime code, which wasn't ideal. This makes sure users get a proper error message if they forgot to return a `Response` from the `handler`